### PR TITLE
Clean MD Raid markers from partitions when wiping disks (bsc#939684)

### DIFF
--- a/updates/control.sh
+++ b/updates/control.sh
@@ -179,6 +179,8 @@ nuke_everything() {
         [[ -b /dev/$name && -w /dev/$name && $name != name ]] || continue
         [[ $name = loop* ]] && continue
         [[ $name = dm* ]] && continue
+        # Remove Software RAID markers from the disk
+        wipefs -a /dev/$name
         if (( blocks >= 2048)); then
             dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=2048"
             dd "if=/dev/zero" "of=/dev/$name" "bs=512" "count=2048" "seek=$(($blocks - 2048))"


### PR DESCRIPTION
Those are hard to get rid of otherwise, and they will
screw up a following autoyast install.