### PR TITLE
Start crowbar_notify_shutdown service after register

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -283,7 +283,7 @@ if node["platform"] == "suse" && !node.roles.include?("provisioner-server")
     end
 
     service "crowbar_notify_shutdown" do
-      action :enable
+      action [:enable, :start]
     end
   end
 


### PR DESCRIPTION
At the first shutdown or reboot systemd assumes that the crowbar_join
service and the coherently crowbar_notify_shutdown service was never
started. Due to this assumption the service will not stopped at the
first shutdown or reboot.