### PR TITLE
Revert "batch build: abort on unknown aliases" (bsc#944404)

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -97,11 +97,6 @@ def build(input_file)
     input_data.gsub!(ALIAS_TEMPLATE % aliaz, hostname)
   end
 
-  unknown_aliases = input_data.to_enum(:scan, ALIAS_REGEXP).map { Regexp.last_match.to_s }
-  unless unknown_aliases.empty?
-    abort "Some of the aliases in the YAML file are not known to Crowbar:\n- #{unknown_aliases.uniq.join("\n- ")}"
-  end
-
   data = YAML.load(input_data)
   abort "#{input_file} is empty" unless data
 


### PR DESCRIPTION
This reverts commit 2b351ca757aac468497198baf97f98d5138bd8cb.