### PR TITLE
crowbar_batch: build input from stdin and files

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -80,17 +80,15 @@ INDENT = "   "
 
 @commands = {
   "help" => ["help", "help - This page for further help"],
-  "build" => ["build ARGV.shift", "build <YAML spec> - Create/edit/commit proposals defined via YAML"],
+  "build" => ["build", "build - Create/edit/commit proposals defined in a YAML file or from stdin"],
   "export" => ["export ARGV", "export <barclamp> [<barclamp> ...] - export barclamps as YAML"]
 }
 
-def build(input_file)
-  usage(-1) if input_file.nil? or input_file == ""
+def build()
+  # read from stdin or from file(s)
+  input_data = ARGF.read
 
   host_by_alias = get_aliases[0]
-
-  abort "#{input_file} does not exist" unless File.file?(input_file)
-  input_data = IO.read(input_file)
 
   # Translate @@alias@@ to Chef node name
   host_by_alias.each do |aliaz, hostname|


### PR DESCRIPTION
When using "crowbar_batch build" to apply proposals, allow in
addition to a single yaml file multiple yaml files and input
from stdin. So you can now do things like:

- crowbar_batch export nova|crowbar_batch (stupid but an example)
- crowbar_batch build nova.yaml
- crowbar_batch build snippet1.yaml snippet2.yaml

When providing multiple files, the concatenated text
must still be valid yaml syntax.