### PR TITLE
provisioner: Rework dependencies of crowbar_join/crowbar_notify_shutdown

### DIFF
--- a/chef/cookbooks/provisioner/files/default/crowbar_join.service
+++ b/chef/cookbooks/provisioner/files/default/crowbar_join.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Synchronize with Crowbar administration server
-After=crowbar_notify_shutdown.service
+After=network.target syslog.target remote-fs.target sshd.service neutron-ovs-cleanup.service xend.service libvirtd.service crowbar_notify_shutdown.service
 Before=chef-client.service
 
 [Service]

--- a/chef/cookbooks/provisioner/files/default/crowbar_notify_shutdown.service
+++ b/chef/cookbooks/provisioner/files/default/crowbar_notify_shutdown.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Synchronize with Crowbar administration server (shutdown/reboot notify)
-After=network.target syslog.target remote-fs.target sshd.service neutron-ovs-cleanup.service xend.service libvirtd.service
+After=network.target syslog.target remote-fs.target sshd.service
 Before=crowbar_join.service
 
 [Service]


### PR DESCRIPTION
I assume the After dependencies were moved to crowbar_notify_shutdown
to avoid duplication, but it's actually a bit confusing. And
crowbar_notify_shutdown doesn't actually depend on services like
libvirtd or xend.