### PR TITLE
batch: reintroduce ALIAS_REGEXP

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -44,6 +44,7 @@ require "easy_diff"
 require "chef/mixin/deep_merge"
 require "pp"
 
+ALIAS_REGEXP = /"(@@[^ @]+@@)"/
 ALIAS_TEMPLATE = "@@%s@@"
 
 INDENT = "   "


### PR DESCRIPTION
2b351ca introduced a nice new sanity check for invalid aliases, but it relies on `ALIAS_REGEXP` and was written before 5849ca5 which dropped the definition of `ALIAS_REGEXP`.  So we need to bring back `ALIAS_REGEXP` to make this check work again.

Supercedes https://github.com/crowbar/crowbar-core/pull/23