### PR TITLE
For large disks, we're gonna need to create BIOS boot partition

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -108,6 +108,11 @@
           <initialize config:type="boolean">true</initialize>
           <partitions config:type="list">
             <partition>
+              <create config:type="boolean">true</create>
+              <partition_id config:type="integer">263</partition_id>
+              <size>10M</size>
+            </partition>
+            <partition>
               <mount>swap</mount>
               <size>auto</size>
             </partition>


### PR DESCRIPTION
Just testing first solution. What is missing:

- partition_nr ? [EDIT: not needed]
- more details about swap (likely not needed) [EDIT: true, not needed]
- size is just a guess EDIT: 1MB should be enough based on https://en.wikipedia.org/wiki/BIOS_boot_partition
- limit this for big disks only (maybe not needed)

Based on real example: https://bugzilla.suse.com/attachment.cgi?id=646431 . Should fix https://bugzilla.suse.com/show_bug.cgi?id=944467