### PR TITLE
Let the network barclamp create OVS bridges

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -648,17 +648,18 @@ class ::Nic
     end
 
     def add_slave(slave)
-      slave = self.class.coerce(slave)
       unless ::Nic.exists?(slave)
         raise ::ArgumentError.new("#{slave} does not exist, cannot add to bridge#{@nic}")
       end
-      return if slaves.member?(slave)
+      slave = self.class.coerce(slave)
+      return slave if slaves.member?(slave)
       if current_master = slave.master
         current_master.remove_slave(slave)
       end
       slave.up
       usurp(slave)
       ::Kernel.system("brctl addif #{@nic} #{slave}")
+      slave
     end
 
     def remove_slave(slave)
@@ -668,6 +669,7 @@ class ::Nic
       end
       ::Kernel.system("brctl delif #{@nic} #{slave}")
       slave.down
+      slave
     end
 
     def stp
@@ -745,17 +747,18 @@ class ::Nic
     end
 
     def add_slave(slave)
-      slave = self.class.coerce(slave)
       unless ::Nic.exists?(slave)
         raise ::ArgumentError.new("#{slave} does not exist, cannot add to bridge#{@nic}")
       end
-      return if slaves.member?(slave)
+      slave = self.class.coerce(slave)
+      return slave if slaves.member?(slave)
       if current_master = slave.master
         current_master.remove_slave(slave)
       end
       slave.up
       usurp(slave)
       ::Kernel.system("ovs-vsctl add-port #{@nic} #{slave}")
+      slave
     end
 
     def remove_slave(slave)
@@ -765,6 +768,7 @@ class ::Nic
       end
       ::Kernel.system("ovs-vsctl del-port #{@nic} #{slave}")
       slave.down
+      slave
     end
 
     def up

--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -374,7 +374,9 @@ class ::Nic
   # Return the bond we are enslaved to, or nil if we are not in a bond.
   def bond_master
     return nil unless File.exists?("#{@nicdir}/master")
-    Nic.new(File.readlink("#{@nicdir}/master").split("/")[-1])
+    master = File.readlink("#{@nicdir}/master").split("/")[-1]
+    return nil unless Nic.bond?(master)
+    Nic.new(master)
   end
 
   # Return the bridge we are enslaved to, or nil if we are not in a bridge.

--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -650,8 +650,8 @@ class ::Nic
       unless ::Nic.exists?(slave)
         raise ::ArgumentError.new("#{slave} does not exist, cannot add to bridge#{@nic}")
       end
-      return if self.slaves.member?(slave)
-      if current_master = slave.master()
+      return if slaves.member?(slave)
+      if current_master = slave.master
         current_master.remove_slave(slave)
       end
       slave.up
@@ -692,7 +692,7 @@ class ::Nic
     end
 
     def up
-      slaves.each{ |s|s.up }
+      slaves.each(&:up)
       super
     end
 
@@ -705,7 +705,7 @@ class ::Nic
       nil
     end
 
-    def self.create(nic,slaves=[])
+    def self.create(nic, slaves = [])
       Chef::Log.info("Creating new bridge #{nic}")
       if self.exists?(nic)
         raise ::ArgumentError.new("#{nic} already exists.")
@@ -747,8 +747,8 @@ class ::Nic
       unless ::Nic.exists?(slave)
         raise ::ArgumentError.new("#{slave} does not exist, cannot add to bridge#{@nic}")
       end
-      return if self.slaves.member?(slave)
-      if current_master = slave.master()
+      return if slaves.member?(slave)
+      if current_master = slave.master
         current_master.remove_slave(slave)
       end
       slave.up
@@ -766,7 +766,7 @@ class ::Nic
     end
 
     def up
-      slaves.each{ |s|s.up }
+      slaves.each(&:up)
       super
     end
 

--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -729,8 +729,7 @@ class ::Nic
     end
   end
 
-  # Base class for an ovs-bridge. This is just enough to be able to
-  # implement the remove_slave call
+  # Base class for an ovs-bridge.
   class ::Nic::OvsBridge < ::Nic
     def slaves
       ports = []
@@ -743,6 +742,20 @@ class ::Nic
       ports.map{ |i| ::Nic.new(i) }
     end
 
+    def add_slave(slave)
+      slave = self.class.coerce(slave)
+      unless ::Nic.exists?(slave)
+        raise ::ArgumentError.new("#{slave} does not exist, cannot add to bridge#{@nic}")
+      end
+      return if self.slaves.member?(slave)
+      if current_master = slave.master()
+        current_master.remove_slave(slave)
+      end
+      slave.up
+      usurp(slave)
+      ::Kernel.system("ovs-vsctl add-port #{@nic} #{slave}")
+    end
+
     def remove_slave(slave)
       slave = self.class.coerce(slave)
       unless self.slaves.member?(slave)
@@ -750,6 +763,41 @@ class ::Nic
       end
       ::Kernel.system("ovs-vsctl del-port #{@nic} #{slave}")
       slave.down
+    end
+
+    def up
+      slaves.each{ |s|s.up }
+      super
+    end
+
+    def destroy
+      slaves.each do |slave|
+        remove_slave(slave)
+      end
+      super
+      ::Kernel.system("ovs-vsctl del-br #{@nic}")
+      nil
+    end
+
+    def self.create(nic, slaves = [])
+      Chef::Log.info("Creating new OVS bridge #{nic}")
+      if self.exists?(nic)
+        raise ::ArgumentError.new("#{nic} already exists.")
+      end
+      ::Kernel.system("ovs-vsctl add-br #{nic}")
+      5.times do
+        if self.exists?(nic) && self.ovs_bridge?(nic)
+          iface = ::Nic.new(nic)
+          slaves.each do |slave|
+            iface.add_slave slave
+          end
+          iface.up
+          return iface
+        end
+        sleep(0.1)
+      end
+
+      raise ::ArgumentError.new("Unable to create new ovs-bridge #{nic}")
     end
   end
 

--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -718,6 +718,8 @@ class ::Nic
         ::Kernel.system("modprobe bridge")
       end
       ::Kernel.system("brctl addbr #{nic}")
+      # It might take a little until the sysfs files for the bridge appear
+      # so let's wait for that
       5.times do
         if self.exists?(nic) && self.bridge?(nic)
           iface = ::Nic.new(nic)
@@ -800,6 +802,8 @@ class ::Nic
         raise ::ArgumentError.new("#{nic} already exists.")
       end
       ::Kernel.system("ovs-vsctl add-br #{nic}")
+      # It might take a little until the sysfs files for the bridge appear
+      # so let's wait for that
       5.times do
         if self.exists?(nic) && self.ovs_bridge?(nic)
           iface = ::Nic.new(nic)

--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -781,6 +781,15 @@ class ::Nic
       nil
     end
 
+    def replug(slave)
+      slave = self.class.coerce(slave)
+      unless self.slaves.member?(slave)
+        raise ::ArgumentError.new("#{slave} is not a member of bridge #{@nic}")
+      end
+      ::Kernel.system("ovs-vsctl del-port #{@nic} #{slave}")
+      ::Kernel.system("ovs-vsctl add-port #{@nic} #{slave}")
+    end
+
     def self.create(nic, slaves = [])
       Chef::Log.info("Creating new OVS bridge #{nic}")
       if self.exists?(nic)

--- a/chef/cookbooks/network/attributes/default.rb
+++ b/chef/cookbooks/network/attributes/default.rb
@@ -1,0 +1,26 @@
+# Copyright 2015, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+case node["platform"]
+when "suse"
+  default[:network][:base_pkgs] = ["bridge-utils",
+                                   "vlan"]
+when "centos", "redhat"
+  default[:network][:base_pkgs] = ["bridge-utils",
+                                   "vconfig"]
+else
+  default[:network][:base_pkgs] = ["bridge-utils",
+                                   "vlan"]
+end

--- a/chef/cookbooks/network/attributes/default.rb
+++ b/chef/cookbooks/network/attributes/default.rb
@@ -17,10 +17,24 @@ case node["platform"]
 when "suse"
   default[:network][:base_pkgs] = ["bridge-utils",
                                    "vlan"]
+  default[:network][:ovs_pkgs] =  ["openvswitch",
+                                   "openvswitch-switch",
+                                   "openvswitch-kmp-default"]
+  default[:network][:ovs_service] = "openvswitch-switch"
 when "centos", "redhat"
   default[:network][:base_pkgs] = ["bridge-utils",
                                    "vconfig"]
+  default[:network][:ovs_pkgs] = ["openvswitch",
+                                  "openstack-neutron-openvswitch"]
+  default[:network][:ovs_service] = "openvswitch"
+
 else
   default[:network][:base_pkgs] = ["bridge-utils",
                                    "vlan"]
+  default[:network][:ovs_pkgs] = ["linux-headers-#{`uname -r`.strip}",
+                                  "openvswitch-datapath-dkms",
+                                  "openvswitch-switch"]
+  default[:network][:ovs_service] = "openvswitch-service"
 end
+
+default[:network][:ovs_module] = "openvswitch"

--- a/chef/cookbooks/network/attributes/default.rb
+++ b/chef/cookbooks/network/attributes/default.rb
@@ -17,9 +17,9 @@ case node["platform"]
 when "suse"
   default[:network][:base_pkgs] = ["bridge-utils",
                                    "vlan"]
-  default[:network][:ovs_pkgs] =  ["openvswitch",
-                                   "openvswitch-switch",
-                                   "openvswitch-kmp-default"]
+  default[:network][:ovs_pkgs] = ["openvswitch",
+                                  "openvswitch-switch",
+                                  "openvswitch-kmp-default"]
   default[:network][:ovs_service] = "openvswitch-switch"
 when "centos", "redhat"
   default[:network][:base_pkgs] = ["bridge-utils",

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -262,12 +262,12 @@ node["crowbar"]["network"].keys.sort{|a,b|
     s.run_action :start
 
     br = if Nic.exists?(bridge) && Nic.ovs_bridge?(bridge)
-           Chef::Log.info("Using OVS bridge #{bridge} for network #{name}")
-           Nic.new bridge
-         else
-           Chef::Log.info("Creating OVS bridge #{bridge} for network #{name}")
-           Nic::OvsBridge.create(bridge)
-         end
+      Chef::Log.info("Using OVS bridge #{bridge} for network #{name}")
+      Nic.new bridge
+    else
+      Chef::Log.info("Creating OVS bridge #{bridge} for network #{name}")
+      Nic::OvsBridge.create(bridge)
+    end
     unless ifs.has_key? "ovs-system"
       ifs["ovs-system"] ||= Hash.new
       ifs["ovs-system"]["addresses"] ||= Array.new

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -279,6 +279,18 @@ node["crowbar"]["network"].keys.sort{|a,b|
     ifs[our_iface.name]["ovs_slave"] = true
     ifs[our_iface.name]["master"] = br.name
     br.add_slave our_iface
+    # FIXME: Workaround for https://bugzilla.suse.com/show_bug.cgi?id=945219
+    # Find vlan interface on top of 'our_iface' that are plugged into other
+    # ovs bridges. Replug them.
+    our_kids = our_iface.children
+    our_kids.each do |k|
+      next unless Nic.vlan?(k)
+      ovs_master = k.ovs_master
+      unless ovs_master.nil?
+        Chef::Log.warn("Replugging #{k.name} to #{ovs_master.name} (workaround bnc#945219)")
+        ovs_master.replug(k.name)
+      end
+    end
     ifs[br.name]["slaves"] = [our_iface.name]
     ifs[br.name]["type"] = "ovs_bridge"
     our_iface = br

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -17,21 +17,11 @@
 return if node[:platform] == "windows"
 
 # Make sure packages we need will be present
-case node[:platform]
-when "ubuntu","debian","suse"
-  %w{bridge-utils vlan}.each do |pkg|
-    p = package pkg do
-      action :nothing
-    end
-    p.run_action :install
+node[:network][:base_pkgs].each do |pkg|
+  p = package pkg do
+    action :nothing
   end
-when "centos","redhat"
-  %w{bridge-utils vconfig}.each do |pkg|
-    p = package pkg do
-      action :nothing
-    end
-    p.run_action :install
-  end
+  p.run_action :install
 end
 
 require "fileutils"

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -77,6 +77,9 @@ old_ifs = node["crowbar_wall"]["network"]["interfaces"] || Mash.new rescue Mash.
 if_mapping = Mash.new
 addr_mapping = Mash.new
 default_route = {}
+# flag to avoid creating the chef (service and package) resources for ovs more
+# than once
+ovs_setup_once = false
 
 # dhclient running?  Not for long.
 ::Kernel.system("killall -w -q -r '^dhclient'")
@@ -242,24 +245,29 @@ node["crowbar"]["network"].keys.sort{|a,b|
   if network["add_ovs_bridge"]
     bridge = node[:network][:networks][name][:bridge_name] || "br-#{name}"
 
-    node[:network][:ovs_pkgs].each do |pkg|
-      p = package pkg do
-        action :nothing
+    # There might be more than one network that needs an ovs-bridge. Make
+    # sure these resources are only created once during the chef-client run.
+    unless ovs_setup_once
+      ovs_setup_once = true
+      node[:network][:ovs_pkgs].each do |pkg|
+        p = package pkg do
+          action :nothing
+        end
+        p.run_action :install
       end
-      p.run_action :install
-    end
 
-    unless ::File.exists?("/sys/module/#{node[:network][:ovs_module]}")
-      ::Kernel.system("modprobe #{node[:network][:ovs_module]}")
-    end
+      unless ::File.exists?("/sys/module/#{node[:network][:ovs_module]}")
+        ::Kernel.system("modprobe #{node[:network][:ovs_module]}")
+      end
 
-    s = service node[:network][:ovs_service] do
-      service_name node[:network][:ovs_service]
-      supports status: true, restart: true
-      action [:nothing]
+      s = service node[:network][:ovs_service] do
+        service_name node[:network][:ovs_service]
+        supports status: true, restart: true
+        action [:nothing]
+      end
+      s.run_action :enable
+      s.run_action :start
     end
-    s.run_action :enable
-    s.run_action :start
 
     br = if Nic.exists?(bridge) && Nic.ovs_bridge?(bridge)
       Chef::Log.info("Using OVS bridge #{bridge} for network #{name}")

--- a/chef/cookbooks/network/templates/default/suse-cfg.erb
+++ b/chef/cookbooks/network/templates/default/suse-cfg.erb
@@ -20,17 +20,18 @@ NAME=<%=quote(@nic.name)%>
 <% if iface["ovs_slave"] -%>
 STARTMODE=hotplug
 MASTER_DEVICE=ovs-system
-<% elsif @nic.kind_of?(Nic::OvsBridge) -%>
+<% elsif @nic.kind_of?(Nic::OvsBridge) || iface["ovs_master"] -%>
 STARTMODE=hotplug
 <% else -%>
 STARTMODE=auto
 <% end -%>
-<% if iface["slave"] -%>
+<% if iface["slave"] || iface["ovs_master"] -%>
 BOOTPROTO=none
 <% else -%>
 BOOTPROTO=static
 <% end -%>
-<% unless @nic.kind_of?(Nic::Vlan) or @nic.kind_of?(Nic::Bond) or @nic.kind_of?(Nic::OvsBridge) -%>
+<% unless @nic.kind_of?(Nic::Vlan) or @nic.kind_of?(Nic::Bond) or
+       @nic.kind_of?(Nic::OvsBridge)  or iface["ovs_master"] -%>
   <% unless @ethtool_options.empty? -%>
 ETHTOOL_OPTIONS="-K iface <%= @ethtool_options -%>"
   <% end -%>

--- a/chef/data_bags/crowbar/bc-template-network.json
+++ b/chef/data_bags/crowbar/bc-template-network.json
@@ -171,6 +171,8 @@
           "vlan": 500,
           "use_vlan": true,
           "add_bridge": false,
+          "add_ovs_bridge": false,
+          "bridge_name": "br-fixed",
           "subnet": "192.168.123.0",
           "netmask": "255.255.255.0",
           "broadcast": "192.168.123.255",
@@ -185,6 +187,8 @@
           "vlan": 300,
           "use_vlan": true,
           "add_bridge": false,
+          "add_ovs_bridge": false,
+          "bridge_name": "br-public",
           "subnet": "192.168.126.128",
           "netmask": "255.255.255.128",
           "broadcast": "192.168.126.255",
@@ -253,7 +257,7 @@
     "network": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 10,
+      "schema-revision": 11,
       "element_states": {
         "network": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/bc-template-network.schema
+++ b/chef/data_bags/crowbar/bc-template-network.schema
@@ -82,6 +82,8 @@
                     "vlan": { "type": "int", "required": true },
                     "use_vlan": { "type": "bool", "required": true },
                     "add_bridge": { "type": "bool", "required": true },
+                    "add_ovs_bridge": { "type": "bool", "required": false },
+                    "bridge_name": { "type": "str", "required": false },
                     "subnet": { "type": "str", "required": true, "name": "IpAddress" },
                     "netmask": { "type": "str", "required": true, "name": "IpAddress" },
                     "broadcast": { "type": "str", "required": true, "name": "IpAddress" },

--- a/chef/data_bags/crowbar/migrate/network/011_add_ovs_attributes.rb
+++ b/chef/data_bags/crowbar/migrate/network/011_add_ovs_attributes.rb
@@ -1,0 +1,17 @@
+def upgrade(ta, td, a, d)
+  a["networks"]["nova_floating"]["add_ovs_bridge"] = ta["networks"]["nova_floating"]["add_ovs_bridge"]
+  a["networks"]["nova_floating"]["bridge_name"] = ta["networks"]["nova_floating"]["bridge_name"]
+  a["networks"]["nova_fixed"]["add_ovs_bridge"] = ta["networks"]["nova_fixed"]["add_ovs_bridge"]
+  a["networks"]["nova_fixed"]["bridge_name"] = ta["networks"]["nova_fixed"]["bridge_name"]
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["networks"]["nova_floating"].delete "add_ovs_bridge"
+  a["networks"]["nova_floating"].delete "bridge_name"
+  a["networks"]["nova_fixed"].delete "add_ovs_bridge"
+  a["networks"]["nova_fixed"].delete "bridge_name"
+
+  return a, d
+end


### PR DESCRIPTION
Initial work for moving the ovs creation for neutron to the network barclamp as an alternative approach to https://github.com/crowbar/crowbar-openstack/pull/3

It's not quite ready yet (but it works already on my test system), but I'd like to get some feedback.

This should allow to make the neutron::common_agent recipe a lot simpler. I am still somewhat undecided on the new proposal attributes. An alternative approach to the new ```add_ovs_brigde``` attribute would be to use the existing ```add_bridge``` flag and add an (optional?) ```bridge_type``` attribute. I am open to suggestion. 

Also it might make sense to create a common base class for ```Nic::OvsBridge``` and ```Nic::Bridge``` in barclamp/libraries/nic.rb since they share some code. 

The related change to the neutron barclamp will follow soon.