### PR TITLE
fix error responses from REST API

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/apache.conf.erb
+++ b/chef/cookbooks/crowbar/templates/default/apache.conf.erb
@@ -11,7 +11,6 @@
 
     ProxyPass / http://127.0.0.1:<%= @port %>/ timeout=600 Keepalive=On
     ProxyPassReverse / http://127.0.0.1:<%= @port %>/
-    ProxyErrorOverride On
 
     <Location />
         <%- unless @realm.nil? %>


### PR DESCRIPTION
[N.B. There could well be a good reason why `ProxyErrorOverride On` was included.  I can't think of any, but if there is, this PR will need some more discussion.]

Sometimes Crowbar returns JSON-formatted errors from the REST API.  One easily reproducible example is to attempt to allocate a node which is already allocated.  This is what should happen:

    root@crowbar:~ # crowbar machines -d allocate d52-54-01-77-77-01.c19.cloud.suse.de

    [... snipped authentication stuff ...]

    DEBUG: (post) hostname: 127.0.0.1:80
    DEBUG: (post) request: /crowbar/machines/1.0/allocate/d52-54-01-77-77-01.c19.cloud.suse.de
    DEBUG: (post) data: {}
    DEBUG: (post) return code: 422
    DEBUG: (post) return body: {"error":"Node already allocated"}
    Failed to talk to service allocate: Node already allocated (422)

However https://github.com/crowbar/crowbar-core/pull/20 put Crowbar behind an Apache proxy, and one of the directives introduced was `ProxyErrorOverride On` which intercepts all errors and replaces the response body with its own documents as directed by ErrorDocument directives.  This caused the responses to be a) HTML, which confused the client-side JSON parser, and b) uninformative, because the original error (`Node already allocated`) never reaches the user.

Removing the `ProxyErrorOverride On` directive fixes this.