### PR TITLE
[WIP] batch build: fix merging of Array attributes

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -41,7 +41,6 @@ require "open3"
 require "tempfile"
 
 require "easy_diff"
-require "chef/mixin/deep_merge"
 require "pp"
 
 ALIAS_REGEXP = /"(@@[^ @]+@@)"/
@@ -331,11 +330,7 @@ def merge_attributes(new_json, barclamp, proposal)
 
   prevent_password_lockout(attrs) if barclamp == 'crowbar'
 
-  # easy_merge! seems to have problems with Arrays of Hashes :-/
-  #new_json.easy_merge! to_merge
-
-  #new_json.extend Chef::Mixin::DeepMerge
-  Chef::Mixin::DeepMerge.deep_merge!(to_merge, new_json)
+  new_json.easy_merge! to_merge
 end
 
 def prevent_password_lockout(attrs)


### PR DESCRIPTION
[Port of https://github.com/crowbar/barclamp-crowbar/pull/1337 to this new merged repo]

Switch from `Chef::Mixin::DeepMerge.deep_merge!` to `#easy_merge!`

## TODO

- [ ] Fix [cinder-related breakage](https://github.com/crowbar/barclamp-crowbar/pull/1337#issuecomment-128041993)

## Background

In easy_diff 0.0.4, `#easy_merge!` fails to handle merging of Arrays of Hashes, so we used `Chef::Mixin::DeepMerge.deep_merge!` instead. A solution for this issue has since been provided:

  https://github.com/Blargel/easy_diff/pull/5

and subsequently merged and published as 0.0.5, which is now packaged in our repos, so this reason for avoiding `#easy_merge!` has now gone.

Additionally `#deep_merge!` didn't correctly merge Arrays at all.  One example is with the neutron.ml2_type_drivers attribute, which defaults to `["gre"]` whereas mkcloud often sets it to `["gre", "vlan"]`. easy_diff's comparison correctly reports no removals and "vlan" as the only addition, but when this addition is fed to `#deep_merge!`, it resulted in the array being overwritten, so it would end up as `["vlan"]`, not `["gre", "vlan"]`.

Since `#easy_merge!` comes from the same easy_diff gem as `#easy_diff, in theory they should work nicely together (and the above is one concrete example of that), so it's better to stick with that.