### PR TITLE
fix windows install by using IPv4 tftp symlinks

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/tftp.erb
+++ b/chef/cookbooks/provisioner/templates/default/tftp.erb
@@ -8,7 +8,7 @@ service tftp
        socket_type             = dgram
        protocol                = udp
        wait                    = yes
-       flags                   = IPv6 IPv4
+       flags                   = IPv4
        user                    = root
        server                  = /usr/sbin/in.tftpd
        server_args             = -m /etc/tftpd.conf -s <%=@tftproot%>


### PR DESCRIPTION
    In the Hyper-V case we use name-remapping for the bootmgr.exe
    using the \x expanding to the hexadecimal version of the IP-address.
    With IPv6 now being used (even when connecting from a IPv4 addr),
    this address and thus the remapped name is different than in Cloud5
    and thus did not find our symlinks.
