### PR TITLE
Preparation for SLES12 SP1 support

### DIFF
--- a/chef/cookbooks/provisioner/libraries/repositories.rb
+++ b/chef/cookbooks/provisioner/libraries/repositories.rb
@@ -29,7 +29,7 @@ class Provisioner
               SUSE-OpenStack-Cloud-SLE11-6-Pool
               SUSE-OpenStack-Cloud-SLE11-6-Updates
             )
-          when "12.0"
+          when "12.0", "12.1"
             %w(
               Cloud
               SUSE-OpenStack-Cloud-6-Pool
@@ -46,6 +46,8 @@ class Provisioner
             %w(SLE11-HAE-SP4-Pool SLE11-HAE-SP4-Updates)
           when "12.0"
             %w(SLE12-HA-Pool SLE12-HA-Updates)
+          when "12.1"
+            %w(SLE12-SP1-HA-Pool SLE12-SP1-HA-Updates)
           else
             []
           end
@@ -88,7 +90,7 @@ class Provisioner
           hae_available = false
           storage_available = false
 
-          %w(11.3 11.4 12.0).each do |version|
+          %w(11.3 11.4 12.0 12.1).each do |version|
             repos.merge! suse_get_repos_from_attributes(node,"suse",version)
 
             # Common optional repos (regardless of cloud vs. storage)
@@ -180,6 +182,11 @@ class Provisioner
             repo_names = %w(
               SLES12-Pool
               SLES12-Updates
+            )
+          when "12.1"
+            repo_names = %w(
+              SLES12-SP1-Pool
+              SLES12-SP1-Updates
             )
           else
             raise "Unsupported version of SLE/openSUSE!"

--- a/chef/cookbooks/provisioner/libraries/repositories.rb
+++ b/chef/cookbooks/provisioner/libraries/repositories.rb
@@ -23,7 +23,7 @@ class Provisioner
           %w(PTF)
         when :cloud
           case version
-          when /^11\.[34]$/
+          when "11.3", "11.4"
             %w(
               Cloud
               SUSE-OpenStack-Cloud-SLE11-6-Pool

--- a/chef/data_bags/crowbar/bc-template-provisioner.json
+++ b/chef/data_bags/crowbar/bc-template-provisioner.json
@@ -49,6 +49,11 @@
           "kernel": "boot/x86_64/loader/linux",
           "append": " "
         },
+        "suse-12.1": {
+          "initrd": "boot/x86_64/loader/initrd",
+          "kernel": "boot/x86_64/loader/linux",
+          "append": " "
+        },
         "windows-6.2": {
           "initrd": " ",
           "kernel": "boot/pxeboot.0",
@@ -112,7 +117,7 @@
     "provisioner": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 24,
+      "schema-revision": 30,
       "element_states": {
         "provisioner-bootdisk-finder": [ "hardware-installing" ],
         "provisioner-server": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/migrate/provisioner/030_add_sle12sp1.rb
+++ b/chef/data_bags/crowbar/migrate/provisioner/030_add_sle12sp1.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["supported_oses"]["suse-12.1"] = ta["supported_oses"]["suse-12.1"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["supported_oses"].delete("suse-12.1")
+  return a, d
+end

--- a/crowbar_framework/app/helpers/form_helper.rb
+++ b/crowbar_framework/app/helpers/form_helper.rb
@@ -19,8 +19,8 @@ module FormHelper
   def platforms_for_select(selected)
     options_for_select(
       available_platforms.select { |p|
-        # Only allow SLES 12 for SUSE Enterprise Storage
-        Crowbar::Product::is_ses? ? p == "suse-12.0" : true
+        # Only allow one platform for SUSE Enterprise Storage
+        Crowbar::Product::is_ses? ? p == Crowbar::Product::ses_platform : true
       }.map { |p| [crowbar_service.pretty_target_platform(p), p] },
       selected: selected.to_s,
       disabled: disabled_platforms

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -101,9 +101,9 @@ class CrowbarService < ServiceObject
       end
 
       if Crowbar::Product::is_ses?
-        # For SUSE Enterprise Storage, default all non-admin nodes to SLES 12
+        # For SUSE Enterprise Storage, default all non-admin nodes to the right platform
         if state == "discovering" and !node.admin?
-          node["target_platform"] = "suse-12.0"
+          node["target_platform"] = Crowbar::Product::ses_platform
           node.save
         end
       end

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -289,7 +289,9 @@ class CrowbarService < ServiceObject
   end
 
   def self.pretty_target_platform(target_platform)
+    return "SLES 12 SP1" if target_platform == "suse-12.1"
     return "SLES 12" if target_platform == "suse-12.0"
+    return "SLES 11 SP4" if target_platform == "suse-11.4"
     return "SLES 11 SP3" if target_platform == "suse-11.3"
     return "Windows Server 2012 R2" if target_platform == "windows-6.3"
     return "Windows Server 2012" if target_platform == "windows-6.2"
@@ -311,7 +313,9 @@ class CrowbarService < ServiceObject
 
   def self.support_software_raid
     [
+      "suse-12.1",
       "suse-12.0",
+      "suse-11.4",
       "suse-11.3"
     ]
   end

--- a/crowbar_framework/lib/crowbar/product.rb
+++ b/crowbar_framework/lib/crowbar/product.rb
@@ -26,6 +26,11 @@ module Crowbar
       BarclampCatalog.barclamps.key?("suse_enterprise_storage") &&
         BarclampCatalog.members("suse_enterprise_storage").key?("suse_enterprise_storage")
     end
+
+    def self.ses_platform
+      # Returns the platform used for SES
+      "suse-12.0"
+    end
   end
 end
 


### PR DESCRIPTION
Right now, the code change should have no effect, but as soon as the repos for SLES 12 SP1 are available on the admin server, it should enable using it.

Note that this conflicts with https://github.com/crowbar/crowbar-core/pull/18. I'll rebase when that other PR will be merged.