### PR TITLE
Fix/workaround node-role revision races

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1044,6 +1044,10 @@ class ServiceObject
 
     applying_nodes = run_order.flatten.uniq.sort
 
+    # Mark nodes as applying; beware that all_nodes do not contain nodes that
+    # are actually removed.
+    set_to_applying(applying_nodes, inst, pre_cached_nodes)
+
     # Prevent any intervallic runs from running whilst we apply the
     # proposal, in order to avoid the orchestration problems described
     # in https://bugzilla.suse.com/show_bug.cgi?id=857375
@@ -1079,10 +1083,6 @@ class ServiceObject
     # By this point, no intervallic runs should be running, and no
     # more will be able to start running until we release the locks
     # after the proposal has finished applying.
-
-    # Mark nodes as applying; beware that all_nodes do not contain nodes that
-    # are actually removed.
-    set_to_applying(applying_nodes, inst, pre_cached_nodes)
 
     # Part III: Update run lists of nodes to reflect new deployment. I.e. write
     # through the deployment schedule in pending node actions into run lists.

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -160,10 +160,13 @@ class ServiceObject
 # Helper routines for queuing
 #
 
-  def set_to_applying(nodes, inst)
+  def set_to_applying(nodes, inst, pre_cached_nodes)
     with_lock "BA-LOCK" do
       nodes.each do |node_name|
-        node = NodeObject.find_node_by_name(node_name)
+        node = pre_cached_nodes[node_name]
+        if node.nil?
+          node = NodeObject.find_node_by_name(node_name)
+        end
         next if node.nil?
 
         node.crowbar["state"] = "applying"
@@ -1079,7 +1082,7 @@ class ServiceObject
 
     # Mark nodes as applying; beware that all_nodes do not contain nodes that
     # are actually removed.
-    set_to_applying(applying_nodes, inst)
+    set_to_applying(applying_nodes, inst, pre_cached_nodes)
 
     # Part III: Update run lists of nodes to reflect new deployment. I.e. write
     # through the deployment schedule in pending node actions into run lists.


### PR DESCRIPTION
This will reduce the race window that exists when multiple nodes transition to
"ready" at the same time and trigger the processing for the proposal queue.
This will NOT really fix the underlying issue for the race.

The following actions lead to the possible race:

Preconditions:
 - 2 Nodes are allocated at roughly the same time (e.g. using bulk edit)
 - While the nodes are being installed proposal for some barclamps are created
   and at least two independent are assigned to one of the above nodes. (e.g
   database and rabbitmq). The proposals are queued for deployment.

Now:
 - Node1 transitions to "ready"
 - that triggers processing of the proposal queue
 - one of the queued proposals is unqueued
 - that causes apply_role to be called
 - apply_role tries to lock the node (which takes some time), the node state is
   not yet updated to "applying"
 - during that Node2 transitions to "ready"
 - that triggers processing of the proposal queue again
 - the queued proposals is unqueued (for Node1(!) because it's state is still
   "ready"
 - apply_role is called again (in a different crowbar process). <- this should
   NEVER happen, even while it won't cause chef-client to be started twice on
   the same node it will lead to various kinds for revisions races on the node
   role.
