### PR TITLE
Sync config/boot.rb version specifications with Gemfile requirements

### DIFF
--- a/crowbar_framework/config/boot.rb
+++ b/crowbar_framework/config/boot.rb
@@ -27,62 +27,62 @@ if File.exists? ENV["BUNDLE_GEMFILE"]
   Bundler.require(:default, Rails.env)
 else
   # rails related
-  gem "rails", version: "~> 4.2"
+  gem "rails", version: "~> 4.2.2"
   require "rails/all"
 
-  gem "haml-rails", version: "~> 0.9"
+  gem "haml-rails", version: "~> 0.9.0"
   require "haml-rails"
 
-  gem "sass-rails", version: "~> 5.0"
+  gem "sass-rails", version: "~> 5.0.3"
   require "sass-rails"
 
   gem "puma", version: "~> 2.11.3"
   require "puma"
 
   # general stuff
-  gem "activerecord-session_store", version: "~> 0.1"
+  gem "activerecord-session_store", version: "~> 0.1.0"
   require "activerecord/session_store"
 
-  gem "active_model_serializers", version: "~> 0.9"
+  gem "active_model_serializers", version: "~> 0.9.0"
   require "active_model_serializers"
 
-  gem "activeresource", version: "~> 4.0"
+  gem "activeresource", version: "~> 4.0.0"
   require "active_resource"
 
-  gem "closure-compiler", version: "~> 1.1"
+  gem "closure-compiler", version: "~> 1.1.10"
   require "closure-compiler"
 
-  gem "dotenv", version: "~> 1.0"
+  gem "dotenv", version: "~> 1.0.2"
   require "dotenv"
 
-  gem "hashie", version: "~> 3.4"
+  gem "hashie", version: "~> 3.4.1"
   require "hashie"
 
-  gem "i18n-js", version: "~> 2.1"
+  gem "i18n-js", version: "~> 2.1.2"
   require "i18n-js"
 
-  gem "js-routes", version: "~> 1.0"
+  gem "js-routes", version: "~> 1.0.1"
   require "js-routes"
 
-  gem "kwalify", version: "~> 0.7"
+  gem "kwalify", version: "~> 0.7.2"
   require "kwalify"
 
-  gem "mime-types", version: "~> 1.25"
+  gem "mime-types", version: "~> 1.25.0"
   require "mime/types"
 
-  gem "redcarpet", version: "~> 3.2"
+  gem "redcarpet", version: "~> 3.2.0"
   require "redcarpet"
 
-  gem "simple-navigation", version: "~> 3.12"
+  gem "simple-navigation", version: "~> 3.12.2"
   require "simple-navigation"
 
-  gem "simple_navigation_renderers", version: "~> 1.0"
+  gem "simple_navigation_renderers", version: "~> 1.0.2"
   require "simple_navigation_renderers"
 
-  gem "sqlite3", version: "~> 1.3"
+  gem "sqlite3", version: "~> 1.3.9"
   require "sqlite3"
 
-  gem "syslogger", version: "~> 1.6"
+  gem "syslogger", version: "~> 1.6.0"
   require "syslogger"
 
   gem "yaml_db", version: "~> 0.3.0"
@@ -92,12 +92,12 @@ else
   require "easy_diff"
 
   # chef related
-  gem "mixlib-shellout", version: "~> 1.3"
+  gem "mixlib-shellout", version: "~> 1.3.0"
   require "mixlib/shellout"
 
-  gem "ohai", version: "~> 6.24"
+  gem "ohai", version: "~> 6.24.2"
   require "ohai"
 
-  gem "chef", version: "~> 10.32"
+  gem "chef", version: "~> 10.32.2"
   require "chef"
 end


### PR DESCRIPTION
Assuming that rubygems follow semantic versioning guidelines,
we want to lock on patch level releases. It seems useful to me
to be consistent with the versioning in the Gemfile and this
part of crowbar to ensure that production and dev environments
always have exactly the same rubygem dependency restrictions.

Rebase of https://github.com/crowbar/barclamp-crowbar/pull/1324