### PR TITLE
Change global link color

### DIFF
--- a/crowbar_framework/app/assets/stylesheets/variables.css.scss
+++ b/crowbar_framework/app/assets/stylesheets/variables.css.scss
@@ -9,7 +9,7 @@ $gray-lighter: lighten(#000, 93.5%);
 
 // Brand colors
 // -------------------------
-$brand-primary: #428bca;
+$brand-primary: #4a90e2;
 $brand-success: #5cb85c;
 $brand-warning: #f0ad4e;
 $brand-danger: #d9534f;


### PR DESCRIPTION
This change is based on the SUSE branding branch where we changed the
link color to blue. The blue is nearly the same as the default crowbar
blue and the changes also matches the default crowbar design.