### PR TITLE
Only install suse-openstack-cloud-release package on SLES 12.1

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -278,10 +278,10 @@ sync
 <% else -%>
   <% if @target_platform_version == "11.3" -%>
       <package>suse-sle11-openstack-cloud-release</package>
-  <% else -%>
+  <% elsif @target_platform_version == "12.1" -%>
       <package>suse-openstack-cloud-release</package>
-  <% end -%>
       <package>supportutils-plugin-suse-openstack-cloud</package>
+  <% end -%>
 <% end -%>
 <% @packages.each do |package| -%>
       <package><%= package %></package>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -299,7 +299,7 @@ PACKAGES_INSTALL="$PACKAGES_INSTALL openssh"
 
 # From autoyast profile
 PATTERNS_INSTALL="$PATTERNS_INSTALL Minimal base"
-PACKAGES_INSTALL="$PACKAGES_INSTALL netcat ruby2.1-rubygem-chef supportutils-plugin-suse-openstack-cloud"
+PACKAGES_INSTALL="$PACKAGES_INSTALL netcat ruby2.1-rubygem-chef"
 
 case $ARCH in
     x86_64) PACKAGES_INSTALL+=" biosdevname";;
@@ -309,8 +309,8 @@ zypper --non-interactive install -t pattern $PATTERNS_INSTALL
 # Auto-agree with the license since it was already agreed on for the admin server
 <% if @target_platform_version.to_f < 12.0 -%>
 zypper --non-interactive install --auto-agree-with-licenses suse-sle11-openstack-cloud-release
-<% else -%>
-zypper --non-interactive install --auto-agree-with-licenses suse-openstack-cloud-release
+<% elsif @target_platform_version == "12.1" -%>
+zypper --non-interactive install --auto-agree-with-licenses suse-openstack-cloud-release supportutils-plugin-suse-openstack-cloud
 <% end -%>
 zypper --non-interactive install $PACKAGES_INSTALL<%= " '#{@packages.join("' '")}'" unless @packages.empty? %>
 
@@ -368,7 +368,7 @@ export HOSTNAME
 <% if @target_platform_version.to_f < 12.0 -%>
 ntp="sntp -P no -r $NTP_SERVERS"
 <% else -%>
-ntp="sntp -s $NTP_SERVERS"
+ntp="/usr/sbin/ntpdate $NTP_SERVERS"
 <% end -%>
 # Make sure date is up-to-date
 until $ntp; do

--- a/updates/control.sh
+++ b/updates/control.sh
@@ -45,20 +45,6 @@ function is_suse() {
     return 1
 }
 
-function suse_ver() {
-    local ver=$1
-    local suse_ver=0
-
-    if [ -f /etc/os-release ]; then
-        . /etc/os-release
-        [ "$NAME" == "SLES" ] && suse_ver=$VERSION
-    elif [ -f /etc/SuSE-release ]; then
-        suse_ver=`cat /etc/SuSE-release  | awk '/VERSION/ {print $3}'`
-    fi
-
-    [ "$suse_ver" -eq "$ver" ]
-}
-
 #
 # Override HOSTNAME if it is specified.  In kernel,
 # This handles changing boot IFs in the middle of
@@ -126,14 +112,8 @@ ALLOCATED=false
 export DHCP_STATE MYINDEX ADMIN_ADDRESS BMC_ADDRESS BMC_NETMASK BMC_ROUTER ADMIN_IP
 export ALLOCATED HOSTNAME CROWBAR_KEY CROWBAR_STATE
 
-if suse_ver 11; then
-    ntp="sntp -P no -r $ADMIN_IP"
-else
-    ntp="/usr/sbin/ntpdate $ADMIN_IP"
-fi
-
 # Make sure date is up-to-date
-until $ntp || [[ $DHCP_STATE = 'debug' ]]; do
+until /usr/sbin/ntpdate $ADMIN_IP || [[ $DHCP_STATE = 'debug' ]]; do
   echo "Waiting for NTP server"
   sleep 1
 done


### PR DESCRIPTION
In case we need to install a SLES 12.0 node (for SES2 :-(), don't
try to install additional software on it.