### PR TITLE
Fix crowbar production.log ownership

### DIFF
--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -226,6 +226,13 @@ directory logdir do
   action :create
 end
 
+file "#{logdir}/production.log" do
+  owner "crowbar"
+  group "crowbar"
+  mode "0644"
+  action :create
+end
+
 directory "#{logdir}/chef-client" do
   owner "crowbar"
   group "crowbar"


### PR DESCRIPTION
When install-chef-suse.sh fails for some reason and the script
is reexecuted, /var/log/crowbar/production.log can be owned by
root:root which prevents crowbar from executing the db:migrate rake
task:

rake aborted!
Permission denied @ rb_sysopen - /var/log/crowbar/production.log
[snipped backtrace]
Tasks: TOP => db:migrate => environment

chef-client runs before the rake task execution so setting the owner
in the crowbar recipe fixes the problem.