### PR TITLE
Add dual-team network mode for 4 NIC ceph nodes

### DIFF
--- a/chef/data_bags/crowbar/template-network.json
+++ b/chef/data_bags/crowbar/template-network.json
@@ -68,6 +68,14 @@
       ],
       "conduit_map": [
         {
+          "pattern" : "team/4/ceph.*",
+          "conduit_list" : {
+            "intf2" : { "if_list" : [ "?1g1", "?1g3" ] },
+            "intf1" : { "if_list" : [ "?1g2", "?1g4" ] },
+            "intf0" : { "if_list" : [ "?1g1", "?1g3" ] }
+          }
+        },
+        {
           "pattern": "team/.*/.*",
           "conduit_list": {
             "intf0": {


### PR DESCRIPTION
For any node with 4 NICs and a ceph role, this provides a bond of
eth0+eth2 for the admin/client network and a bond of eth1+eth3 for the
storage network.  This should possibly be considered an example, because
I suspect specific sites will want to tweak it, or have 6- or 8-NIC
variants.  If it should only ever be an example, then this by rights
belongs in the docs, not in the stock network.json.  Also, it may need
tweaking once a dedicated ceph-client network is added (see
https://github.com/crowbar/barclamp-ceph/pull/166)

Signed-off-by: Tim Serong <tserong@suse.com>