### PR TITLE
add netwait=60 (bsc#927997)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -44,6 +44,8 @@ end
 if crowbar_key != ""
   append_line += " crowbar.install.key=#{crowbar_key}"
 end
+# workaround broken IPMI/BMC firmwares not transmitting traffic for 35s (bsc#927997)
+append_line += " netwait=60"
 append_line = append_line.split.join(" ")
 node.set[:provisioner][:sledgehammer_append_line] = append_line
 


### PR DESCRIPTION
this is now also needed for SLES12-based sleshammer images
https://bugzilla.suse.com/show_bug.cgi?id=927997

(and maybe it can help avoid an observed race where node1 comes up without network and thus cannot be discovered)