### PR TITLE
[UNTESTED] only run ovs-vsctl if openvswitch service is running

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -91,7 +91,8 @@ class ::Nic
   def self.ovs_bridge?(nic)
     nic.kind_of?(::Nic::OvsBridge) or
       # If no ovs tools are installed there's no ovs switch
-      if ::Kernel.system("which ovs-vsctl > /dev/null 2>&1")
+      if ::Kernel.system("which ovs-vsctl > /dev/null 2>&1 && " \
+                         "systemctl -q is-active openvswitch.service")
         ::Kernel.system("ovs-vsctl br-exists #{nic}")
       end
   end


### PR DESCRIPTION
(N.B. Here's a real world example of [a PR which needs an `untested` label but not `wip`](https://github.com/SUSE/cloud/pull/87#issuecomment-142867716).  This is a consequence of a debugging session with a real customer this morning, and I'm submitting this now before I forget it, before I have time to test it, and before the gate has had time to run.  It's cosmetic only so I can't prioritise testing it for quite a while.  But it's simple enough that I'm pretty sure it's finished.)

If openvswitch is installed, running `ovs-vsctl` when the openvswitch service is not running will result in an ugly error in syslog about not being able to connect to a socket in `/var/run`.  This can be misleading
and cause confusion during debugging, so let's avoid it.