### PR TITLE
Fix apache syntax error for crowbar vhost (bsc#948717)

### DIFF
--- a/chef/cookbooks/apache2/recipes/default.rb
+++ b/chef/cookbooks/apache2/recipes/default.rb
@@ -222,8 +222,3 @@ end
 
 # We don't need this.
 #apache_site "default" if platform?("centos", "redhat", "fedora")
-
-service "apache2" do
-  action :start
-  ignore_failure true
-end

--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -393,6 +393,10 @@ template "#{node[:apache][:dir]}/vhosts.d/crowbar.conf" do
   notifies :reload, resources(service: "apache2")
 end
 
+service "apache2" do
+  action [:enable, :start]
+end
+
 # The below code swiped from:
 # https://github.com/opscode-cookbooks/chef-server/blob/chef10/recipes/default.rb
 # It will automaticaly compact the couchdb database when it gets too large.


### PR DESCRIPTION
Crowbar needs now mod_proxy (and some other related modules) but
using these modules via the chef cookbook only triggers a a2enmod
which writes the module to /etc/sysconfig/apache2.
A reload is not enough because the listed modules from the sysconfig
file are added as parameters to the command line when starting apache.

https://bugzilla.suse.com/show_bug.cgi?id=948717