### PR TITLE
adjust to new sntp (bnc#949513)

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -134,8 +134,10 @@ sync_time() {
 
 <% if @target_platform_version.to_f < 12.0 %>
     SNTP_OPTS="-P no -r"
-<% else %>
+<% elsif @target_platform_version.to_f < 12.09 %>
     SNTP_OPTS="-s"
+<% else %>
+    SNTP_OPTS="-S"
 <% end %>
     while [[ $tries_left > 0 ]] ; do
         for ntpserver in $VALID_NTP_SERVERS ; do


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=949513
we need to set the system time when we start booting.
But according to man sntp it changed meaning of params

```
12-GA:
       -s, --settod
              Set (step) the time with settimeofday().  This option  must  not
              appear  in  combination  with any of the following options: adj-
              time.

12-SP1:
       -S, --step
              OK to 'step' the time with settimeofday(2).

       -s, --slew
              OK to 'slew' the time with adjtime(2).
```