### PR TITLE
crowbar: Fix issues with some HTTP requests being broken due to proxy

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/apache.conf.erb
+++ b/chef/cookbooks/crowbar/templates/default/apache.conf.erb
@@ -11,6 +11,8 @@
 
     ProxyPass / http://127.0.0.1:<%= @port %>/ timeout=600 Keepalive=On
     ProxyPassReverse / http://127.0.0.1:<%= @port %>/
+    SetEnv proxy-nokeepalive 1
+    SetEnv proxy-initial-not-pooled 1
 
     <Location />
         <%- unless @realm.nil? %>


### PR DESCRIPTION
When this happens, we have this in the logs:

[proxy_http:error] [pid 2580] (104)Connection reset by peer: [client 127.0.0.1:27917] AH01102: error reading status line from remote server 127.0.0.1:3000
[proxy:error] [pid 2580] [client 127.0.0.1:27917] AH00898: Error reading from remote server returned by /crowbar/glance/1.0/proposals/default

It seems to happen due to a timeout for a connection. In theory, we
could increase the timeout, but it's unclear which value would be
correct. The issue actually probably comes from the fact that mod_proxy
tries to re-use connections for performance reasons. Since the
performance of the crowbar rails app should not be much of an issue,
just disable that.

See also
http://stackoverflow.com/questions/169453/bad-gateway-502-error-with-apache-mod-proxy-and-tomcat