### PR TITLE
provisioner: Fix SLE12 nodes requiring Cloud repositories

### DIFF
--- a/chef/cookbooks/provisioner/libraries/repositories.rb
+++ b/chef/cookbooks/provisioner/libraries/repositories.rb
@@ -29,7 +29,9 @@ class Provisioner
               SUSE-OpenStack-Cloud-SLE11-6-Pool
               SUSE-OpenStack-Cloud-SLE11-6-Updates
             )
-          when "12.0", "12.1"
+          when "12.0"
+            []
+          when "12.1"
             %w(
               Cloud
               SUSE-OpenStack-Cloud-6-Pool


### PR DESCRIPTION
SLE12 nodes can only be used for ceph, and no Cloud repos are available
for them.