### PR TITLE
Allocate node IP from correct (node) range only after the  node itself was already allocated and not when it is only discovered.

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -136,7 +136,7 @@ if not nodes.nil? and not nodes.empty?
           hostname mnode.name
           macaddress mac_list[i]
           if mnode.macaddress == mac_list[i]
-            ipaddress admin_data_net.address
+            ipaddress admin_data_net.address unless admin_data_net.nil?
             options [
      '      if option arch = 00:06 {
         filename = "discovery/bootia32.efi";

--- a/chef/data_bags/crowbar/migrate/network/020_add_hardware-installing_transition.rb
+++ b/chef/data_bags/crowbar/migrate/network/020_add_hardware-installing_transition.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  d["config"]["transition_list"] = td["config"]["transition_list"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  d["config"]["transition_list"] = td["config"]["transition_list"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-network.json
+++ b/chef/data_bags/crowbar/template-network.json
@@ -257,7 +257,7 @@
     "network": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 11,
+      "schema-revision": 20,
       "element_states": {
         "network": [ "readying", "ready", "applying" ]
       },
@@ -269,7 +269,7 @@
         "environment": "network-base-config",
         "mode": "full",
         "transitions": true,
-        "transition_list": [ "discovered", "reset", "delete" ]
+        "transition_list": [ "discovered", "hardware-installing", "reset", "delete" ]
       }
     }
   }

--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -302,6 +302,54 @@ class NetworkService < ServiceObject
       end
     end
 
+    if state == "hardware-installing"
+
+      node = NodeObject.find_node_by_name name
+
+      # Allocate required addresses
+      range = node.admin? ? "admin" : "host"
+      @logger.debug("Deployer transition: Allocate admin address for #{name}")
+      result = allocate_ip("default", "admin", range, name)
+      @logger.error("Failed to allocate admin address for: #{node.name}: #{result[0]}") if result[0] != 200
+      if result[0] == 200
+        address = result[1]["address"]
+        boot_ip_hex = sprintf("%08X", address.split(".").inject(0) { |acc, i| (acc << 8) + i.to_i })
+      end
+
+      @logger.debug("Deployer transition: Done Allocate admin address for #{name} boot file:#{boot_ip_hex}")
+
+      if node.admin?
+        # If we are the admin node, we may need to add a vlan bmc address.
+        # Add the vlan bmc if the bmc network and the admin network are not the same.
+        # not great to do it this way, but hey.
+        admin_net = Chef::DataBag.load "crowbar/admin_network" rescue nil
+        bmc_net = Chef::DataBag.load "crowbar/bmc_network" rescue nil
+        if admin_net["network"]["subnet"] != bmc_net["network"]["subnet"]
+          @logger.debug("Deployer transition: Allocate bmc_vlan address for #{name}")
+          result = allocate_ip("default", "bmc_vlan", "host", name)
+          @logger.error("Failed to allocate bmc_vlan address for: #{node.name}: #{result[0]}") if result[0] != 200
+          @logger.debug("Deployer transition: Done Allocate bmc_vlan address for #{name}")
+        end
+
+        # Allocate the bastion network ip for the admin node if a bastion
+        # network is defined in the network proposal
+        bastion_net = Chef::DataBag.load "crowbar/bastion_network" rescue nil
+        unless bastion_net.nil?
+          result = allocate_ip("default", "bastion", range, name)
+          if result[0] != 200
+            @logger.error("Failed to allocate bastion address for: #{node.name}: #{result[0]}")
+          else
+            @logger.debug("Allocated bastion address: #{result[1]["address"]} for the admin node.")
+          end
+        end
+      end
+
+      # save this on the node after it's been refreshed with the network info.
+      node = NodeObject.find_node_by_name node.name
+      node.crowbar["crowbar"]["boot_ip_hex"] = boot_ip_hex if boot_ip_hex
+      node.save
+    end
+
     @logger.debug("Network transition: Exiting #{name} for #{state}")
     [200, { name: name }]
   end


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=941528

Note for backporting to Cloud5: get_network_by_type needs to return nil if network is not there