### PR TITLE
Avoid endlessly looping in the deployment queue in some cases

### DIFF
--- a/crowbar_framework/lib/crowbar/deployment_queue.rb
+++ b/crowbar_framework/lib/crowbar/deployment_queue.rb
@@ -182,10 +182,12 @@ module Crowbar
         # 202 means some nodes are not ready, bail out in that case
         # We're re-running the whole apply continuously, until there
         # are no items left in the queue.
+        # We also ignore proposals who can't be committed due to some error
+        # (4xx) with the proposal or some internal error (5xx).
         # FIXME: This is lame, because from the user perspective, we're still
         # applying the first barclamp, while this part was in fact already
         # completed and we're applying next item(s) in the queue.
-        loop_again = true if results.any? { |state| state != 202 }
+        loop_again = true if results.any? { |state| state != 202 && state < 400 }
 
         # For each ready item, apply it.
         logger.debug("process queue: exit")


### PR DESCRIPTION
It can happen that we end up stuck in the deployment queue because a
proposal stays in the queue can't be applied. It happens, for instance,
if the proposal is not valid (or being applied).

So ignore proposals that can't be committed and that results in 4xx or
5xx errors.