### PR TITLE
provisioner: Better support for multiple architectures for discovery

### DIFF
--- a/chef/cookbooks/provisioner/recipes/dhcp_update.rb
+++ b/chef/cookbooks/provisioner/recipes/dhcp_update.rb
@@ -11,13 +11,13 @@ pool_opts = {
        option dhcp-parameter-request-list = concat(option dhcp-parameter-request-list,d0,d1,d2,d3);
      }',
              'if option arch = 00:06 {
-       filename = "discovery/efi/bootia32.efi";
+       filename = "discovery/ia32/efi/bootia32.efi";
      } else if option arch = 00:07 {
-       filename = "discovery/efi/bootx64.efi";
+       filename = "discovery/x86_64/efi/bootx64.efi";
      } else if option arch = 00:09 {
-       filename = "discovery/efi/bootx64.efi";
+       filename = "discovery/x86_64/efi/bootx64.efi";
      } else {
-       filename = "discovery/bios/pxelinux.0";
+       filename = "discovery/x86_64/bios/pxelinux.0";
      }',
              "next-server #{admin_ip}"],
   "host" => ["deny unknown-clients"]

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -72,12 +72,14 @@ if not nodes.nil? and not nodes.empty?
       end
     end
 
+    arch = mnode[:kernel][:machine]
+
     # no boot_ip means that no admin network address has been assigned to node,
     # and it will boot into the default discovery image. But it won't help if
     # we're trying to delete the node.
     if boot_ip_hex
-      pxefile = "#{discovery_dir}/#{pxecfg_subdir}/#{boot_ip_hex}"
-      uefi_dir = "#{discovery_dir}/#{uefi_subdir}"
+      pxefile = "#{discovery_dir}/#{arch}/#{pxecfg_subdir}/#{boot_ip_hex}"
+      uefi_dir = "#{discovery_dir}/#{arch}/#{uefi_subdir}"
       if use_elilo
         uefifile = "#{uefi_dir}/#{boot_ip_hex}.conf"
         grubdir = nil
@@ -172,13 +174,13 @@ if not nodes.nil? and not nodes.empty?
     option dhcp-parameter-request-list = concat(option dhcp-parameter-request-list,d0,d1,d2,d3);
   }',
               "if option arch = 00:06 {
-    filename = \"discovery/efi/#{boot_ip_hex}.efi\";
+    filename = \"discovery/ia32/efi/#{boot_ip_hex}.efi\";
   } else if option arch = 00:07 {
-    filename = \"discovery/efi/#{boot_ip_hex}.efi\";
+    filename = \"discovery/x86_64/efi/#{boot_ip_hex}.efi\";
   } else if option arch = 00:09 {
-    filename = \"discovery/efi/#{boot_ip_hex}.efi\";
+    filename = \"discovery/x86_64/efi/#{boot_ip_hex}.efi\";
   } else {
-    filename = \"discovery/bios/pxelinux.0\";
+    filename = \"discovery/x86_64/bios/pxelinux.0\";
   }",
               "next-server #{admin_ip}"
             ]

--- a/updates/control_lib.sh
+++ b/updates/control_lib.sh
@@ -167,12 +167,14 @@ wait_for_pxe() {
         echo -n "waiting for pxe file to be: $mode "
     fi
 
+    arch=`uname -m`
+
     until [ 1 = $done ] ; do
         if [ -n "$state" ]; then
-            curl --fail --silent --connect-timeout 5 "http://$ADMIN_IP:8091/discovery/pxelinux.cfg/$MYHEXIP" | grep -q "^DEFAULT $state$"
+            curl --fail --silent --connect-timeout 5 "http://$ADMIN_IP:8091/discovery/$arch/bios/pxelinux.cfg/$MYHEXIP" | grep -q "^DEFAULT $state$"
             ret=$?
         else
-            curl --fail --silent --head --connect-timeout 5 "http://$ADMIN_IP:8091/discovery/pxelinux.cfg/$MYHEXIP" > /dev/null
+            curl --fail --silent --head --connect-timeout 5 "http://$ADMIN_IP:8091/discovery/$arch/bios/pxelinux.cfg/$MYHEXIP" > /dev/null
             ret=$?
         fi
 


### PR DESCRIPTION
We also use a per-architecture directory for discovery now.

~~Note that this contains https://github.com/crowbar/crowbar-core/pull/83, and gating will fail because sleshammer needs to be updated accordingly.~~

~~Note that this contains https://github.com/crowbar/crowbar-core/pull/81~~