### PR TITLE
provisioner: Fix use of wrong attribute to get platform version

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -306,7 +306,7 @@ if node[:platform_family] == "suse" && !node.roles.include?("provisioner-server"
 
   if node[:platform_family] == "suse"
     ## make sure the repos are properly setup
-    repos = Provisioner::Repositories.get_repos(provisioner_server_node, node[:platform], node[:platform])
+    repos = Provisioner::Repositories.get_repos(provisioner_server_node, node[:platform], node[:platform_version])
     for name, attrs in repos
       url = %x{zypper --non-interactive repos #{name} 2> /dev/null | grep "^URI " | cut -d : -f 2-}
       url.strip!


### PR DESCRIPTION
This got introduced in https://github.com/crowbar/crowbar-core/pull/53