### PR TITLE
Fixed pid check for puma server

### DIFF
--- a/crowbar_framework/config/application.rb
+++ b/crowbar_framework/config/application.rb
@@ -19,7 +19,7 @@ require File.expand_path("../boot", __FILE__)
 
 module Crowbar
   class Application < Rails::Application
-    SERVER_PID = system("[ps ax | grep 'puma master' | grep -v grep].split(' ')[0]")
+    SERVER_PID = %x[pgrep --oldest puma | head -n1].strip
 
     config.autoload_paths += %W(
       #{config.root}/lib


### PR DESCRIPTION
Within https://github.com/crowbar/crowbar-core/pull/45/files#diff-787c000d1f70896054fa797cce1b3556R22 the check for the puma server PID have been messed up. This should fix it.