### PR TITLE
Replace mocha mocks with default rspec mocks

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -63,7 +63,6 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
 
   group :test do
     gem "database_cleaner", "~> 1.4.1"
-    gem "mocha", "~> 1.1.0"
     gem "sinatra", "~> 1.4.5"
     gem "webmock", "~> 1.19.0"
     gem "bundler-audit", "~> 0.4.0"

--- a/crowbar_framework/spec/controllers/crowbar_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/crowbar_controller_spec.rb
@@ -22,7 +22,7 @@ describe CrowbarController do
 
   before do
     Proposal.where(barclamp: "crowbar", name: "default").first_or_create(barclamp: "crowbar", name: "default")
-    CrowbarService.any_instance.stubs(:apply_role).returns([200, "OK"])
+    allow_any_instance_of(CrowbarService).to receive(:apply_role).and_return([200, "OK"])
   end
 
   describe "GET index" do
@@ -57,7 +57,7 @@ describe CrowbarController do
     end
 
     it "returns plain text message if version fetching fails" do
-      CrowbarService.any_instance.stubs(:versions).returns([404, "Not found"])
+      allow_any_instance_of(CrowbarService).to receive(:versions).and_return([404, "Not found"])
       get :versions
       expect(response).to be_missing
       expect(response.body).to be == "Not found"
@@ -76,20 +76,21 @@ describe CrowbarController do
     end
 
     it "transitions the node into desired state" do
-      RoleObject.stubs(:find_roles_by_search).returns([])
+      allow_any_instance_of(RoleObject).to receive(:find_roles_by_search).and_return([])
       post :transition, barclamp: "crowbar", id: "default", state: "discovering", name: "testing"
       expect(response).to be_success
     end
 
     it "returns plain text message if transitioning fails" do
-      CrowbarService.any_instance.stubs(:transition).returns([500, "error"])
+      allow_any_instance_of(CrowbarService).to receive(:transition).and_return([500, "error"])
       post :transition, barclamp: "crowbar", id: "default", state: "discovering", name: "testing"
       expect(response).to be_server_error
       expect(response.body).to be == "error"
     end
 
     it "returns node as a hash on success when passed a name" do
-      CrowbarService.any_instance.stubs(:transition).returns([200, { name: "testing" }])
+      allow_any_instance_of(CrowbarService).to receive(:transition).
+        and_return([200, { name: "testing" }])
       post :transition, barclamp: "crowbar", id: "default", state: "discovering", name: "testing"
       expect(response).to be_success
       json = JSON.parse(response.body)
@@ -97,7 +98,8 @@ describe CrowbarController do
     end
 
     it "returns node as a hash on success when passed a node (backward compatibility)" do
-      CrowbarService.any_instance.stubs(:transition).returns([200, NodeObject.find_node_by_name("testing").to_hash])
+      allow_any_instance_of(CrowbarService).to receive(:transition).
+        and_return([200, NodeObject.find_node_by_name("testing").to_hash])
       post :transition, barclamp: "crowbar", id: "default", state: "discovering", name: "testing"
       expect(response).to be_success
       json = JSON.parse(response.body)
@@ -108,7 +110,7 @@ describe CrowbarController do
   describe "GET show" do
     describe "format json" do
       it "returns plain text message if show fails" do
-        CrowbarService.any_instance.stubs(:show_active).returns([500, "Error"])
+        allow_any_instance_of(CrowbarService).to receive(:show_active).and_return([500, "Error"])
         post :show, id: "default", format: "json"
         expect(response).to be_server_error
         expect(response.body).to be == "Error"
@@ -129,7 +131,7 @@ describe CrowbarController do
       end
 
       it "redirects to propsal path on failure" do
-        CrowbarService.any_instance.stubs(:show_active).returns([500, "Error"])
+        allow_any_instance_of(CrowbarService).to receive(:show_active).and_return([500, "Error"])
         get :show, id: "default"
         expect(response).to redirect_to(proposal_barclamp_path(controller: "crowbar", id: "default"))
       end
@@ -138,7 +140,7 @@ describe CrowbarController do
 
   describe "GET elements" do
     it "returns plain text message if elements fails" do
-      CrowbarService.any_instance.stubs(:elements).returns([500, "Error"])
+      allow_any_instance_of(CrowbarService).to receive(:elements).and_return([500, "Error"])
       get :elements
       expect(response).to be_server_error
       expect(response.body).to be == "Error"
@@ -155,7 +157,7 @@ describe CrowbarController do
 
   describe "GET element_info" do
     it "returns plain text message if element_info fails" do
-      CrowbarService.any_instance.stubs(:element_info).returns([500, "Error"])
+      allow_any_instance_of(CrowbarService).to receive(:element_info).and_return([500, "Error"])
       get :element_info
       expect(response).to be_server_error
       expect(response.body).to be == "Error"
@@ -172,7 +174,7 @@ describe CrowbarController do
 
   describe "GET proposals" do
     it "returns plain text message if proposals fails" do
-      CrowbarService.any_instance.stubs(:proposals).returns([500, "Error"])
+      allow_any_instance_of(CrowbarService).to receive(:proposals).and_return([500, "Error"])
       get :proposals
       expect(response).to be_server_error
       expect(response.body).to be == "Error"
@@ -193,16 +195,16 @@ describe CrowbarController do
 
   describe "DELETE delete" do
     before do
-     CrowbarService.any_instance.stubs(:system).returns(true)
+      allow_any_instance_of(CrowbarService).to receive(:system).and_return(true)
     end
 
     it "deletes and deactivates the instance" do
-      CrowbarService.any_instance.expects(:destroy_active).with("default").once
+      expect_any_instance_of(CrowbarService). to receive(:destroy_active).with("default").once
       delete :delete, name: "default"
     end
 
     it "sets appropriate flash message" do
-      CrowbarService.any_instance.stubs(:destroy_active).returns([200, "Yay!"])
+      allow_any_instance_of(CrowbarService).to receive(:destroy_active).and_return([200, "Yay!"])
       delete :delete, name: "default"
       expect(flash[:notice]).to be == I18n.t("proposal.actions.delete_success")
     end
@@ -213,14 +215,14 @@ describe CrowbarController do
     end
 
     it "returns 500 on failure for json" do
-      CrowbarService.any_instance.stubs(:destroy_active).returns([500, "Error"])
+      allow_any_instance_of(CrowbarService).to receive(:destroy_active).and_return([500, "Error"])
       delete :delete, name: "default", format: "json"
       expect(response).to be_server_error
       expect(response.body).to be == "Error"
     end
 
     it "sets flash on failure for html" do
-      CrowbarService.any_instance.stubs(:destroy_active).returns([500, "Error"])
+      allow_any_instance_of(CrowbarService).to receive(:destroy_active).and_return([500, "Error"])
       delete :delete, name: "default"
       expect(response).to be_redirect
       expect(flash[:alert]).to_not be_nil
@@ -234,8 +236,9 @@ describe CrowbarController do
     # missing nodes. However, this is ok, as users will assign roles to them
     # later.
     before(:each) do
-      CrowbarService.any_instance.expects(:validate_proposal).at_least_once
-      CrowbarService.any_instance.expects(:validate_proposal_elements).returns(true).at_least_once
+      expect_any_instance_of(CrowbarService).to receive(:validate_proposal)
+      expect_any_instance_of(CrowbarService).to receive(:validate_proposal_elements).
+        and_return(true)
     end
 
     it "validates a proposal" do
@@ -245,10 +248,11 @@ describe CrowbarController do
 
   describe "proposal updates" do
     before(:each) do
-      Proposal.any_instance.stubs(:save).returns(true)
-      CrowbarService.any_instance.expects(:validate_proposal).at_least_once
-      CrowbarService.any_instance.expects(:validate_proposal_elements).returns(true).at_least_once
-      CrowbarService.any_instance.expects(:validate_proposal_after_save).at_least_once
+      allow_any_instance_of(Proposal).to receive(:save).and_return(true)
+      expect_any_instance_of(CrowbarService).to receive(:validate_proposal)
+      expect_any_instance_of(CrowbarService).to receive(:validate_proposal_elements).
+        and_return(true)
+      expect_any_instance_of(CrowbarService).to receive(:validate_proposal_after_save)
     end
 
     describe "POST proposal_commit" do

--- a/crowbar_framework/spec/controllers/deploy_queue_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/deploy_queue_controller_spec.rb
@@ -24,7 +24,7 @@ describe DeployQueueController do
     before do
       # We don't have Pacemaker at hand and the helper returns false because of
       # that, need to stub this
-      ServiceObject.stubs(:is_cluster?).returns(true)
+      allow(ServiceObject).to receive(:is_cluster?).and_return(true)
     end
 
     let(:prop) { Proposal.where(barclamp: "crowbar", name: "default").first_or_create(barclamp: "crowbar", name: "default") }
@@ -41,12 +41,13 @@ describe DeployQueueController do
     describe "with existing nodes" do
       before do
         # Simulate the expansion to a node whose look up we can fake
-        ServiceObject.stubs(:expand_nodes_for_all).returns([["testing.crowbar.com"],[]])
+        allow(ServiceObject).to receive(:expand_nodes_for_all).
+          and_return([["testing.crowbar.com"], []])
       end
 
       it "is successful when a prop with clusters is deployed" do
         # Is now deploying
-        @controller.stubs(:currently_deployed).returns(prop)
+        allow(@controller).to receive(:currently_deployed).and_return(prop)
 
         get :index
         expect(response).to be_success
@@ -54,7 +55,7 @@ describe DeployQueueController do
 
       it "is successful when there are clusters in the queue" do
         # Is queued
-        @controller.stubs(:deployment_queue).returns(queue)
+        allow(@controller).to receive(:deployment_queue).and_return(queue)
 
         get :index
         expect(response).to be_success
@@ -64,19 +65,20 @@ describe DeployQueueController do
     describe "with non-existing nodes" do
       before do
         # Cluster referencing a non-existent node (deleted)
-        ServiceObject.stubs(:expand_nodes_for_all).returns([["I just dont exist"],[]])
+        allow(ServiceObject).to receive(:expand_nodes_for_all).
+          and_return([["I just dont exist"], []])
       end
 
       it "is successful when a prop with clusters is deployed" do
         # Is now deploying
-        @controller.stubs(:currently_deployed).returns(prop)
+        allow(@controller).to receive(:currently_deployed).and_return(prop)
 
         get :index
         expect(response).to be_success
       end
 
       it "is successful for clusters in the queue" do
-        @controller.stubs(:deployment_queue).returns(queue)
+        allow(@controller).to receive(:deployment_queue).and_return(queue)
 
         get :index
         expect(response).to be_success

--- a/crowbar_framework/spec/controllers/machines_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/machines_controller_spec.rb
@@ -19,12 +19,12 @@ require "spec_helper"
 
 describe MachinesController do
   before do
-    NodeObject.any_instance.stubs(:system).returns(true)
+    allow_any_instance_of(NodeObject).to receive(:system).and_return(true)
   end
 
   describe "GET index" do
     before do
-      File.stubs(:exist?).returns(true)
+      allow(File).to receive(:exist?).and_return(true)
     end
 
     it "is successful" do
@@ -65,7 +65,7 @@ describe MachinesController do
 
     context "without nodes" do
       before do
-        NodeObject.stubs(:find_all_nodes).returns([])
+        allow(NodeObject).to receive(:find_all_nodes).and_return([])
       end
 
       it "renders json" do
@@ -121,7 +121,7 @@ describe MachinesController do
   describe "POST role" do
     context "for existent node" do
       it "assignes role compute" do
-        NodeObject.any_instance.expects(:intended_role=).with("compute").once
+        expect_any_instance_of(NodeObject).to receive(:intended_role=).with("compute")
 
         post :role, name: "testing", role: "compute", format: "json"
         expect(response).to have_http_status(:ok)
@@ -134,8 +134,8 @@ describe MachinesController do
     end
 
     it "return 422 (unprocessable_entity) http status when save fails" do
-      NodeObject.any_instance.stubs(:save).returns(false)
-      NodeObject.any_instance.expects(:intended_role=).with("compute").once
+      allow_any_instance_of(NodeObject).to receive(:save).and_return(false)
+      expect_any_instance_of(NodeObject).to receive(:intended_role=).with("compute")
 
       post :role, name: "testing", role: "compute", format: "json"
 
@@ -146,7 +146,7 @@ describe MachinesController do
   describe "POST rename" do
     context "for existent node" do
       it "renames a node to tester" do
-        NodeObject.any_instance.expects(:alias=).with("tester").once
+        expect_any_instance_of(NodeObject).to receive(:alias=).with("tester")
 
         post :rename, name: "testing", alias: "tester", format: "json"
         expect(response).to have_http_status(:ok)
@@ -159,8 +159,8 @@ describe MachinesController do
     end
 
     it "return 422 (unprocessable_entity) http status when save fails" do
-      NodeObject.any_instance.stubs(:save).returns(false)
-      NodeObject.any_instance.expects(:alias=).with("tester").once
+      allow_any_instance_of(NodeObject).to receive(:save).and_return(false)
+      expect_any_instance_of(NodeObject).to receive(:alias=).with("tester")
 
       post :rename, name: "testing", alias: "tester", format: "json"
 
@@ -175,7 +175,7 @@ describe MachinesController do
     describe "POST #{action}" do
       context "for existent node" do
         it "invokes #{action}" do
-          NodeObject.any_instance.expects(action).once
+          expect_any_instance_of(NodeObject).to receive(action)
 
           post action, name: "testing", format: "json"
           expect(response).to have_http_status(:ok)
@@ -186,10 +186,6 @@ describe MachinesController do
         it "return 404 (not found) http status" do
           post action, name: "nonexistent", format: "json"
           expect(response).to have_http_status(:not_found)
-        end
-
-        it "prevents #{action}" do
-          NodeObject.any_instance.expects(action).never
         end
       end
     end
@@ -209,14 +205,14 @@ describe MachinesController do
     describe "POST #{action}" do
       context "for existent node" do
         it "invokes #{action}" do
-          NodeObject.any_instance.expects(action).once
+          expect_any_instance_of(NodeObject).to receive(action)
 
           post action, name: "testing", format: "json"
           expect(response).to have_http_status(:ok)
         end
 
         it "return 403 (forbidden) http status for admin node" do
-          NodeObject.any_instance.stubs(:admin?).returns(true)
+          allow_any_instance_of(NodeObject).to receive(:admin?).and_return(true)
           post action, name: "testing", format: "json"
           expect(response).to have_http_status(:forbidden)
         end
@@ -226,10 +222,6 @@ describe MachinesController do
         it "renders 404" do
           post action, name: "nonexistent", format: "json"
           expect(response).to have_http_status(:not_found)
-        end
-
-        it "prevents #{action}" do
-          NodeObject.any_instance.expects(action).never
         end
       end
     end

--- a/crowbar_framework/spec/controllers/support_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/support_controller_spec.rb
@@ -27,12 +27,14 @@ describe SupportController do
     end
 
     it "is successful notifying about new export" do
-      @controller.stubs(:default_export_hash).returns(Utils::ExtendedHash.new({
-        waiting: false,
-        counter: 1,
-        current: "foo.tar.gz",
-        files: { chef: ["foo.tar.gz"], logs: [], other: [], support_configs: [], bc_import: [] }
-      }))
+      allow(@controller).to receive(:default_export_hash).and_return(
+        Utils::ExtendedHash.new(
+          waiting: false,
+          counter: 1,
+          current: "foo.tar.gz",
+          files: { chef: ["foo.tar.gz"], logs: [], other: [], support_configs: [], bc_import: [] }
+        )
+      )
 
       get :index
       expect(response).to be_success
@@ -41,7 +43,7 @@ describe SupportController do
 
   describe "GET export_chef" do
     it "displays flash message on error" do
-      NodeObject.stubs(:all).raises(StandardError)
+      allow(NodeObject).to receive(:all) { raise StandardError }
       get :export_chef
       expect(response).to redirect_to(utils_url)
       expect(flash[:alert]).to_not be_empty
@@ -50,9 +52,8 @@ describe SupportController do
     it "exports known data into db dir" do
       begin
         now = Time.now
-        Time.stubs(:now).returns(now)
-
-        Process.stubs(:fork).returns(0)
+        allow(Time).to receive(:now).and_return(now)
+        allow(Process).to receive(:fork).and_return(0)
 
         filename = "crowbar-chef-#{now.strftime("%Y%m%d-%H%M%S")}.tgz"
         export = Rails.root.join("db", filename)

--- a/crowbar_framework/spec/lib/remote_node_spec.rb
+++ b/crowbar_framework/spec/lib/remote_node_spec.rb
@@ -19,17 +19,17 @@ require "spec_helper"
 describe RemoteNode do
   context "reboot_done?" do
     it "should return true because boottime is higher than reboot requesttime" do
-      RemoteNode.stubs(:ssh_cmd_get_boottime).returns(100).once
+      allow(RemoteNode).to receive(:ssh_cmd_get_boottime).and_return(100).once
       expect(RemoteNode.reboot_done?("localhost", 1)).to eql true
     end
 
     it "should return false because boottime is lower than reboot requesttime" do
-      RemoteNode.stubs(:ssh_cmd_get_boottime).returns(100).once
+      allow(RemoteNode).to receive(:ssh_cmd_get_boottime).and_return(100).once
       expect(RemoteNode.reboot_done?("localhost", 999)).to eql false
     end
 
     it "should return false because boottime equal to reboot requesttime" do
-      RemoteNode.stubs(:ssh_cmd_get_boottime).returns(10).once
+      allow(RemoteNode).to receive(:ssh_cmd_get_boottime).and_return(10).once
       expect(RemoteNode.reboot_done?("localhost", 10)).to eql false
     end
 
@@ -39,19 +39,20 @@ describe RemoteNode do
   end
   context "ssh get boottime" do
     it "should handle unsucessful ssh command" do
-      logger = mock("Logger")
-      logger.expects(:info).with(regexp_matches(/ssh-cmd .* to get datetime not successful/))
-      RemoteNode.stubs(:ssh_cmd_base).returns(["false", "&&"]).once
+      logger = double("Rails.logger").as_null_object
+      allow(Rails).to receive(:logger).and_return(logger)
+      expect(logger).to receive(:info).with(/ssh-cmd .* to get datetime not successful/)
+      allow(RemoteNode).to receive(:ssh_cmd_base).and_return(["false", "&&"]).once
       expect(RemoteNode.ssh_cmd_get_boottime("localhost", logger: logger)).to eql 0
     end
 
     it "should handle sucessful ssh command" do
-      RemoteNode.stubs(:ssh_cmd_base).returns(["eval"]).once
+      allow(RemoteNode).to receive(:ssh_cmd_base).and_return(["eval"]).once
       expect(RemoteNode.ssh_cmd_get_boottime("localhost")).to be > 0
     end
 
     it "should handle invalid input from ssh command" do
-      RemoteNode.stubs(:ssh_cmd_base).returns(["echo", "invalid", "#"]).once
+      allow(RemoteNode).to receive(:ssh_cmd_base).and_return(["echo", "invalid", "#"]).once
       expect(RemoteNode.ssh_cmd_get_boottime("localhost")).to eql 0
     end
   end

--- a/crowbar_framework/spec/models/chef_object_spec.rb
+++ b/crowbar_framework/spec/models/chef_object_spec.rb
@@ -38,7 +38,7 @@ describe ChefObject do
     end
 
     it "returns empty node on failure" do
-      Chef::Search::Query.stubs(:new).raises(StandardError)
+      allow(Chef::Search::Query).to receive(:new) { raise StandardError }
       expect(chef_object.query_chef).to be_a(Chef::Node)
     end
   end

--- a/crowbar_framework/spec/models/crowbar_service_spec.rb
+++ b/crowbar_framework/spec/models/crowbar_service_spec.rb
@@ -19,8 +19,8 @@ require File.expand_path(File.join(File.dirname(__FILE__), "..", "spec_helper"))
 
 describe CrowbarService do
   before do
-    CrowbarService.any_instance.stubs(:system).returns(false)
-    CrowbarService.any_instance.stubs(:run_remote_chef_client).returns(0)
+    allow_any_instance_of(CrowbarService).to receive(:system).and_return(false)
+    allow_any_instance_of(CrowbarService).to receive(:run_remote_chef_client).and_return(0)
   end
 
   let(:crowbar) { c = CrowbarService.new(Logger.new("/dev/null")); c.bc_name = "crowbar"; c }
@@ -32,13 +32,13 @@ describe CrowbarService do
     end
 
     it "returns 404 if node not found" do
-      NodeObject.stubs(:find_node_by_name).returns(nil)
+      allow(NodeObject).to receive(:find_node_by_name).and_return(nil)
       response = crowbar.transition("default", "missing", "a state")
       expect(response.first).to be == 404
     end
 
     it "returns 200 on successful transition" do
-      RoleObject.stubs(:find_roles_by_search).returns([])
+      allow(RoleObject).to receive(:find_roles_by_search).and_return([])
       response = crowbar.transition("default", "testing", "a state")
       expect(response.first).to be == 200
     end
@@ -49,22 +49,22 @@ describe CrowbarService do
       end
 
       it "sets the state debug and state" do
-        NodeObject.stubs(:find_node_by_name).returns(@node)
+        allow(NodeObject).to receive(:find_node_by_name).and_return(@node)
         crowbar.transition("default", @node.name, "a state")
         expect(@node.state).to be == "a state"
         expect(@node.crowbar["crowbar"]["state_debug"]).to_not be_empty
       end
 
       it "saves the node" do
-        NodeObject.stubs(:find_node_by_name).returns(@node)
-        @node.expects(:save).at_least_once
+        allow(NodeObject).to receive(:find_node_by_name).and_return(@node)
+        expect(@node).to receive(:save).at_least(:once)
         crowbar.transition("default", @node.name, "a state")
       end
     end
 
     describe "to testing" do
       it "creates new node if not found" do
-        NodeObject.expects(:create_new).with("missing").returns(nil).once
+        expect(NodeObject).to receive(:create_new).with("missing").and_return(nil).at_least(:once)
         crowbar.transition("default", "missing", "testing")
       end
     end
@@ -75,18 +75,19 @@ describe CrowbarService do
       end
 
       it "adds role to the node if admin" do
-        crowbar.expects(:add_role_to_instance_and_node).once
+        expect(crowbar).to receive(:add_role_to_instance_and_node).at_least(:once)
         crowbar.transition("default", "admin", "discovering")
       end
 
       it "creates new node if not found" do
-        NodeObject.stubs(:find_node_by_name).returns(nil)
-        NodeObject.expects(:create_new).returns(nil).once
+        allow(NodeObject).to receive(:find_node_by_name).and_return(nil)
+        expect(NodeObject).to receive(:create_new).and_return(nil).at_least(:once)
+        crowbar.transition("default", "admin", "discovering")
         crowbar.transition("default", "missing", "discovering")
       end
 
       it "check that the node is initially not allocated" do
-        NodeObject.stubs(:find_node_by_name).returns(@node)
+        allow(NodeObject).to receive(:find_node_by_name).and_return(@node)
         crowbar.transition("default", "testing", "discovering")
         expect(@node.allocated?).to be false
       end
@@ -98,7 +99,7 @@ describe CrowbarService do
       end
 
       it "forces nodes transition to a given state" do
-        NodeObject.stubs(:find_node_by_name).returns(@node)
+        allow(NodeObject).to receive(:find_node_by_name).and_return(@node)
         crowbar.transition("default", "testing", "hardware-installing")
         expect(@node.state).to be == "hardware-installing"
       end
@@ -110,7 +111,7 @@ describe CrowbarService do
       end
 
       it "forces nodes transition to a given state" do
-        NodeObject.stubs(:find_node_by_name).returns(@node)
+        allow(NodeObject).to receive(:find_node_by_name).and_return(@node)
         crowbar.transition("default", "testing", "hardware-updating")
         expect(@node.state).to be == "hardware-updating"
       end
@@ -122,7 +123,7 @@ describe CrowbarService do
       end
 
       it "forces nodes transition to a given state" do
-        NodeObject.stubs(:find_node_by_name).returns(@node)
+        allow(NodeObject).to receive(:find_node_by_name).and_return(@node)
         crowbar.transition("default", "testing", "update")
         expect(@node.state).to be == "update"
       end

--- a/crowbar_framework/spec/models/node_object_spec.rb
+++ b/crowbar_framework/spec/models/node_object_spec.rb
@@ -75,13 +75,13 @@ describe NodeObject do
       let(:key) { "a key" }
 
       it "sets the key if the platform requires one" do
-        CrowbarService.stubs(:require_license_key?).returns(true)
+        allow(CrowbarService).to receive(:require_license_key?).and_return(true)
         node.license_key = key
         expect(node.license_key).to be == key
       end
 
       it "leaves it blank if platform does not need a key" do
-        CrowbarService.stubs(:require_license_key?).returns(false)
+        allow(CrowbarService).to receive(:require_license_key?).and_return(false)
         node.license_key = key
         expect(node.license_key).to be_blank
       end
@@ -94,7 +94,7 @@ describe NodeObject do
 
     it "doesnt allow duplicates" do
       # Stub out chef call
-      NodeObject.any_instance.stubs(:update_alias).returns(true)
+      allow_any_instance_of(NodeObject).to receive(:update_alias).and_return(true)
 
       expect {
         testing_node.alias = "admin"

--- a/crowbar_framework/spec/models/proposal_spec.rb
+++ b/crowbar_framework/spec/models/proposal_spec.rb
@@ -2,7 +2,8 @@ require "spec_helper"
 
 describe Proposal do
   before do
-    Proposal.any_instance.stubs(:update_corresponding_proposal_object).returns(true)
+    allow_any_instance_of(Proposal).to receive(:update_corresponding_proposal_object).
+      and_return(true)
   end
 
   let(:proposal) { Proposal.new(barclamp: "crowbar", name: "default") }

--- a/crowbar_framework/spec/models/service_object_spec.rb
+++ b/crowbar_framework/spec/models/service_object_spec.rb
@@ -54,7 +54,7 @@ describe ServiceObject do
 
   describe "validate_proposal" do
     it "raises ValidationFailed on missing schema" do
-      service_object.stubs(:proposal_schema_directory).returns("/idontexist")
+      allow(service_object).to receive(:proposal_schema_directory).and_return("/idontexist")
       expect {
         service_object.validate_proposal(proposal.raw_data)
       }.to raise_error(Chef::Exceptions::ValidationFailed)
@@ -62,7 +62,8 @@ describe ServiceObject do
 
     it "validates the proposal" do
       prop = proposal
-      CrowbarValidator.any_instance.expects(:validate).with(prop.raw_data).once.returns([])
+      expect_any_instance_of(CrowbarValidator).to receive(:validate).
+        with(prop.raw_data).and_return([])
       service_object.validate_proposal(prop.raw_data)
     end
 
@@ -84,7 +85,8 @@ describe ServiceObject do
       it "limits the number of elements in a role" do
         dns_proposal.elements["dns-client"] = ["admin"]
 
-        dns_service.stubs(:role_constraints).returns({ "dns-client" => { "count" => 0, "admin" => true } })
+        allow(dns_service).to receive(:role_constraints).
+          and_return("dns-client" => { "count" => 0, "admin" => true })
         dns_service.validate_proposal_constraints(dns_proposal)
         expect(dns_service.validation_errors).to_not be_empty
         expect(dns_service.validation_errors.first).to match(/accept up to 0 elements only/)
@@ -95,7 +97,7 @@ describe ServiceObject do
       it "does not allow admin nodes to be assigned by default" do
         dns_proposal.elements["dns-client"] = ["admin"]
 
-        dns_service.stubs(:role_constraints).returns({ "dns-client" => { } })
+        allow(dns_service).to receive(:role_constraints).and_return("dns-client" => {})
         dns_service.validate_proposal_constraints(dns_proposal)
         expect(dns_service.validation_errors).to_not be_empty
         expect(dns_service.validation_errors.first).to match(/does not accept admin nodes/)
@@ -107,7 +109,8 @@ describe ServiceObject do
         dns_proposal.elements["dns-client"] = ["admin"]
         dns_proposal.elements["dns-server"] = ["admin"]
 
-        dns_service.stubs(:role_constraints).returns({ "dns-client" => { "unique" => true, "admin" => true } })
+        allow(dns_service).to receive(:role_constraints).
+          and_return("dns-client" => { "unique" => true, "admin" => true })
         dns_service.validate_proposal_constraints(dns_proposal)
         expect(dns_service.validation_errors).to_not be_empty
         expect(dns_service.validation_errors.first).to match(/cannot be assigned to another role/)
@@ -118,8 +121,9 @@ describe ServiceObject do
       it "does not allow clusters of nodes to be assigned" do
         dns_proposal.elements["dns-client"] = ["cluster:test"]
 
-        dns_service.stubs(:role_constraints).returns({ "dns-client" => { "cluster" => false, "admin" => true } })
-        dns_service.stubs(:is_cluster?).returns(true)
+        allow(dns_service).to receive(:role_constraints).
+          and_return("dns-client" => { "cluster" => false, "admin" => true })
+        allow(dns_service).to receive(:is_cluster?).and_return(true)
         dns_service.validate_proposal_constraints(dns_proposal)
         expect(dns_service.validation_errors).to_not be_empty
         expect(dns_service.validation_errors.first).to match(/does not accept clusters/)
@@ -131,10 +135,10 @@ describe ServiceObject do
         dns_proposal.elements["dns-client"] = ["test"]
         dns_proposal.elements["dns-server"] = ["test"]
 
-        dns_service.stubs(:role_constraints).returns({
+        allow(dns_service).to receive(:role_constraints).and_return(
           "dns-server" => { "conflicts_with" => ["dns-client", "hawk-server"], "admin" => true },
           "dns-client" => { "conflicts_with" => ["dns-server", "hawk-server"], "admin" => true }
-        })
+        )
 
         dns_service.validate_proposal_constraints(dns_proposal)
         expect(dns_service.validation_errors).to_not be_empty
@@ -148,31 +152,33 @@ describe ServiceObject do
       end
 
       it "allows nodes of matched platform using operator >=" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
               "platform" => { "ubuntu" => ">= 10.10" }
             }
-          })
+          }
+        )
         dns_service.validate_proposal_constraints(dns_proposal)
         expect(dns_service.validation_errors.length).to be == 0
       end
 
       it "does not allow nodes of matched platform using operator >=" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
               "platform" => { "ubuntu" => ">= 10.10.1" }
             }
-          })
+          }
+        )
         dns_service.validate_proposal_constraints(dns_proposal)
         expect(dns_service.validation_errors.length).to be == 1
       end
 
       it "allows nodes of matched platform using operator >" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
@@ -184,7 +190,7 @@ describe ServiceObject do
       end
 
       it "does not allow nodes of matched platform using operator >" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
@@ -196,7 +202,7 @@ describe ServiceObject do
       end
 
       it "allows nodes of matched platform using operator <=" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
@@ -208,7 +214,7 @@ describe ServiceObject do
       end
 
       it "does not allow nodes of matched platform using operator <=" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
@@ -220,7 +226,7 @@ describe ServiceObject do
       end
 
       it "allows nodes of matched platform using operator ==" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
@@ -232,7 +238,7 @@ describe ServiceObject do
       end
 
       it "does not allow nodes of matched platform using operator ==" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
@@ -244,7 +250,7 @@ describe ServiceObject do
       end
 
       it "allows nodes of matched platform with fancy versioning" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
@@ -256,7 +262,7 @@ describe ServiceObject do
       end
 
       it "allows nodes of matched platform using regular expressions" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
@@ -268,7 +274,7 @@ describe ServiceObject do
       end
 
       it "allows nodes of matched platform using regular expressions (multiple platforms)" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
@@ -280,7 +286,7 @@ describe ServiceObject do
       end
 
       it "does not allow nodes of a different platform" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
@@ -292,7 +298,7 @@ describe ServiceObject do
       end
 
       it "does not allow nodes of a different platform (multiple parforms)" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,
@@ -304,7 +310,7 @@ describe ServiceObject do
       end
 
       it "does not allow nodes of a Ubuntu" do
-        dns_service.stubs(:role_constraints).returns(
+        allow(dns_service).to receive(:role_constraints).and_return(
           {
             "dns-client" => {
               "admin" => true ,

--- a/crowbar_framework/spec/spec_helper.rb
+++ b/crowbar_framework/spec/spec_helper.rb
@@ -63,7 +63,7 @@ RSpec.configure do |config|
   #
   # If you prefer to use mocha, flexmock or RR, uncomment the appropriate line:
   #
-  config.mock_with :mocha
+  config.mock_with :rspec
   # config.mock_with :flexmock
   # config.mock_with :rr
 
@@ -102,9 +102,9 @@ RSpec.configure do |config|
   config.infer_spec_type_from_file_location!
 
   config.before do
-    ChefObject.stubs(:cloud_domain).returns("crowbar.com")
-
-    Proposal.any_instance.stubs(:properties_template_dir).returns(Rails.root.join("spec/fixtures/data_bags"))
+    allow(ChefObject).to receive(:cloud_domain).and_return("crowbar.com")
+    allow_any_instance_of(Proposal).to receive(:properties_template_dir).
+      and_return(Rails.root.join("spec/fixtures/data_bags"))
   end
 
   config.append_before(:each) do


### PR DESCRIPTION
Rspec has since version 3.0 a similar features and mocha isn't
maintained properly.