### PR TITLE
fix locale after theming update

### DIFF
--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -79,11 +79,7 @@ en:
       title: 'Utilities'
       logs: 'Exported Items'
       repositories: 'Repositories'
-    help:
-      title: 'Help'
-      docs: 'Documentation'
-      crowbar_users: 'Crowbar Users Guide'
-      wiki: 'Online Help'
+    help: 'Help'
 
   layouts:
     application:


### PR DESCRIPTION
This should fix recent installation failures (see https://trello.com/c/cXXNRuVe/64-actionview-template-error-hash-does-not-contain-any-of-parameters-text-icon).

@tboerger suggested this, I'm creating it so it can be merged ASAP