### PR TITLE
provisioner: Cleanup path to kernel/initrd used in boot files

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -158,8 +158,8 @@ EOC
         variables(append_line: "#{append_line} crowbar.state=discovery",
                   install_name: "Crowbar Discovery Image",
                   admin_ip: admin_ip,
-                  initrd: "#{arch}/initrd0.img",
-                  kernel: "#{arch}/vmlinuz0")
+                  initrd: "discovery/#{arch}/initrd0.img",
+                  kernel: "discovery/#{arch}/vmlinuz0")
       end
 
       bash "Build UEFI netboot loader with grub" do
@@ -635,12 +635,12 @@ node[:provisioner][:supported_oses].each do |os, arches|
     node.set[:provisioner][:available_oses][os] ||= Mash.new
     node.set[:provisioner][:available_oses][os][arch] ||= Mash.new
     if /^(hyperv|windows)/ =~ os
-      node.set[:provisioner][:available_oses][os][arch][:kernel] = "../../../#{os}/#{kernel}"
+      node.set[:provisioner][:available_oses][os][arch][:kernel] = "#{os}/#{kernel}"
       node.set[:provisioner][:available_oses][os][arch][:initrd] = " "
       node.set[:provisioner][:available_oses][os][arch][:append_line] = " "
     else
-      node.set[:provisioner][:available_oses][os][arch][:kernel] = "../../../#{os}/#{arch}/install/#{kernel}"
-      node.set[:provisioner][:available_oses][os][arch][:initrd] = "../../../#{os}/#{arch}/install/#{initrd}"
+      node.set[:provisioner][:available_oses][os][arch][:kernel] = "#{os}/#{arch}/install/#{kernel}"
+      node.set[:provisioner][:available_oses][os][arch][:initrd] = "#{os}/#{arch}/install/#{initrd}"
       node.set[:provisioner][:available_oses][os][arch][:append_line] = append
     end
     node.set[:provisioner][:available_oses][os][arch][:disabled] = missing_files

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -340,6 +340,8 @@ if not nodes.nil? and not nodes.empty?
         append_line = append.join(" ")
         install_name = node[:provisioner][:available_oses][os][arch][:install_name]
         install_label = "OS Install (#{os})"
+        relative_to_pxelinux = "../../../"
+        relative_to_tftpboot = ""
         initrd = node[:provisioner][:available_oses][os][arch][:initrd]
         kernel = node[:provisioner][:available_oses][os][arch][:kernel]
 
@@ -348,8 +350,10 @@ if not nodes.nil? and not nodes.empty?
         append_line = "#{node[:provisioner][:sledgehammer_append_line]} crowbar.hostname=#{mnode[:fqdn]} crowbar.state=#{new_group}"
         install_name = new_group
         install_label = "Crowbar Discovery Image (#{new_group})"
-        initrd = "../initrd0.img"
-        kernel = "../vmlinuz0"
+        relative_to_pxelinux = "../"
+        relative_to_tftpboot = "discovery/#{arch}/"
+        initrd = "initrd0.img"
+        kernel = "vmlinuz0"
 
       end
 
@@ -362,8 +366,8 @@ if not nodes.nil? and not nodes.empty?
           source t[:src]
           variables(append_line: append_line,
                     install_name: install_name,
-                    initrd: initrd,
-                    kernel: kernel)
+                    initrd: "#{relative_to_pxelinux}#{initrd}",
+                    kernel: "#{relative_to_pxelinux}#{kernel}")
         end unless t[:file].nil?
       end
 
@@ -385,8 +389,8 @@ if not nodes.nil? and not nodes.empty?
           variables(append_line: append_line,
                     install_name: install_label,
                     admin_ip: admin_ip,
-                    initrd: initrd,
-                    kernel: kernel)
+                    initrd: "#{relative_to_tftpboot}#{initrd}",
+                    kernel: "#{relative_to_tftpboot}#{kernel}")
         end
 
         bash "Build UEFI netboot loader with grub for #{mnode[:fqdn]} (#{new_group})" do

--- a/chef/cookbooks/provisioner/templates/default/grub.conf.erb
+++ b/chef/cookbooks/provisioner/templates/default/grub.conf.erb
@@ -20,8 +20,8 @@ menuentry '<%= @install_name %>' --class os {
      net_ls_routes
 
      echo 'Loading Linux ...'
-     linux (tftp)/discovery/<%= @kernel %> <%= @append_line %>
+     linux (tftp)/<%= @kernel %> <%= @append_line %>
 
      echo 'Loading initial ramdisk ...'
-     initrd (tftp)/discovery/<%= @initrd %>
+     initrd (tftp)/<%= @initrd %>
 }


### PR DESCRIPTION
The current setup happened to work, but only because grub2 was nice
enough to understand "(tftp)/discovery/../../../" as "(tftp)/". Let's
play it a bit safer.