### PR TITLE
provisioner: Fix possible crash in cookbook when node has no ohai data

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -72,7 +72,7 @@ if not nodes.nil? and not nodes.empty?
       end
     end
 
-    arch = mnode[:kernel][:machine]
+    arch = mnode[:kernel][:machine] rescue "x86_64"
 
     # no boot_ip means that no admin network address has been assigned to node,
     # and it will boot into the default discovery image. But it won't help if


### PR DESCRIPTION
If a node has no ohai data for some reason (getting discovered, but ohai
not running in sleshammer for one reason or another), we don't want the
provisioner-server chef-client to crash. So provide a fallback
architecture for that node.