### PR TITLE
provisioner: Totally ignore PTF repo in crowbar_register when disabled

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -279,9 +279,11 @@ fi
 <% @repos.keys.sort.each do |name| %>
 zypper -n ar "<%= @repos[name][:url] %>" "<%= name %>"
 <% end %>
+<% if @repos.keys.include? "PTF" -%>
 
 # PTF has an unknown key, and this is expected
 zypper -n --gpg-auto-import-keys refresh -r PTF
+<% end -%>
 
 ZYPPER_REF_OPT=
 test $CROWBAR_AUTO_IMPORT_KEYS -eq 1 && ZYPPER_REF_OPT=--gpg-auto-import-keys


### PR DESCRIPTION
crowbar_register tries to auto import the GPG key of the PTF repo, but
that doesn't make sense when the repo is disabled.