### PR TITLE
provisioner: Remove outdated running/enabled attribute on service

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -300,8 +300,6 @@ if node[:platform_family] == "suse"
     end
 
     service "xinetd" do
-      running node[:provisioner][:enable_pxe] ? true : false
-      enabled node[:provisioner][:enable_pxe] ? true : false
       action node[:provisioner][:enable_pxe] ? ["enable", "start"] : ["disable", "stop"]
       supports reload: true
       subscribes :reload, resources(service: "tftp"), :immediately


### PR DESCRIPTION
This only worked for very old versions of chef, and is not needed
anymore with the specified actions.