### PR TITLE
Start apache2.service while crowbar.service start

### DIFF
--- a/chef/cookbooks/crowbar/files/default/crowbar.service
+++ b/chef/cookbooks/crowbar/files/default/crowbar.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Crowbar
 After=network.target syslog.target remote-fs.target chef-server.service
+Requires=apache2.service
 
 [Service]
 Type=simple

--- a/configs/crowbar.service
+++ b/configs/crowbar.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Crowbar
 After=network.target syslog.target remote-fs.target chef-server.service
+Requires=apache2.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
Starting crowbar without the apache service makes no sense since we use
the apache proxy to reach the crowbar web UI. This change makes sure
that the service is always started.