### PR TITLE
provisioner: Remove useless bits from kernel boot line for sledgehammer

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -50,8 +50,6 @@ end
 if crowbar_key != ""
   append_line += " crowbar.install.key=#{crowbar_key}"
 end
-# workaround broken IPMI/BMC firmwares not transmitting traffic for 35s (bsc#927997)
-append_line += " ifcfg=dhcp4 netwait=60"
 append_line = append_line.split.join(" ")
 node.set[:provisioner][:sledgehammer_append_line] = append_line
 


### PR DESCRIPTION
ifcfg and netwait are not used when booting in standard SLES (no
linuxrc), so they have no effect. Let's drop them.

Instead, these bits have been put in the sleshammer image.

See discussion in https://bugzilla.suse.com/show_bug.cgi?id=953107