### PR TITLE
Fix crowbar checks while crowbar is not installed

### DIFF
--- a/crowbar_framework/config/initializers/checks.rb
+++ b/crowbar_framework/config/initializers/checks.rb
@@ -33,10 +33,6 @@ unless caller.grep(/rake/).present? || (ENV["SKIP_CHECKS"] && ENV["SKIP_CHECKS"]
     raise "No local interface is configured with an correct ip address."
   end
 
-  unless network_checks.network_valid?
-    raise "Failed to validate network.json configuration. Please check and fix with yast2 crowbar."
-  end
-
   unless network_checks.firewall_disabled?
     raise "Firewall is not completely disabled."
   end


### PR DESCRIPTION
We can't run this test before crowbar is installed this means the server
will not start. But after the installation the test is not needed
anymore because it's done by install-chef-suse and can't changed later.