### PR TITLE
Added partial path to location at SMT server

### DIFF
--- a/crowbar_framework/config/repos-cloud.yml
+++ b/crowbar_framework/config/repos-cloud.yml
@@ -9,6 +9,7 @@ suse-12.0:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12:GA/SLES/12/POOL/x86_64"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Products/SLE-SERVER/12/x86_64/product"
       ask_on_error: false
     sles12-updates:
       name: "SLES12-Updates"
@@ -18,6 +19,7 @@ suse-12.0:
         tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12:x86_64/update"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Updates/SLE-SERVER/12/x86_64/update"
       ask_on_error: false
     sle12-ha-pool:
       name: "SLE12-HA-Pool"
@@ -45,6 +47,7 @@ suse-12.0:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12:Update:Products:SES2/ses/2/POOL/x86_64"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/products/storage/2/x86_64/product"
       ask_on_error: false
     suse-enterprise-storage-2-updates:
       name: "SUSE-Enterprise-Storage-2-Updates"
@@ -54,6 +57,7 @@ suse-12.0:
         tag: "obsrepository://build.suse.de/SUSE:Updates:Storage:2:x86_64/update"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Updates/Storage/2/x86_64/update"
       ask_on_error: false
     ptf:
       name: "PTF"
@@ -70,6 +74,7 @@ suse-12.1:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP1:GA/SLES/12.1/POOL/x86_64"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Products/SLE-SERVER/12-SP1/x86_64/product"
       ask_on_error: false
     sles12-sp1-updates:
       name: "SLES12-SP1-Updates"
@@ -79,6 +84,7 @@ suse-12.1:
         tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP1:x86_64/update"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Updates/SLE-SERVER/12-SP1/x86_64/update"
       ask_on_error: false
     cloud:
       name: "Cloud"
@@ -99,6 +105,7 @@ suse-12.1:
 #        tag: "obsproduct://build.suse.de/SUSE:SLE-12:SP1:Products:Cloud6/suse-openstack-cloud/6/POOL/x86_64"
 #        key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Products/OpenStack-Cloud/6/x86_64/product"
       ask_on_error: false
     suse-openstack-cloud-6-updates:
       name: "SUSE-OpenStack-Cloud-6-Updates"
@@ -108,6 +115,7 @@ suse-12.1:
 #        tag: "obsrepository://build.suse.de/SUSE:Updates:OpenStack-Cloud:6:x86_64/update"
 #        key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Updates/OpenStack-Cloud/6/x86_64/update"
       ask_on_error: false
     sle12-sp1-ha-pool:
       name: "SLE12-SP1-HA-Pool"
@@ -117,6 +125,7 @@ suse-12.1:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP1:GA/sle-ha/12.1/POOL/x86_64"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Products/SLE-HA/12-SP1/x86_64/product"
       ask_on_error: false
     sle12-sp1-ha-updates:
       name: "SLE12-SP1-HA-Updates"
@@ -126,6 +135,7 @@ suse-12.1:
         tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-HA:12-SP1:x86_64/update"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Updates/SLE-HA/12-SP1/x86_64/update"
       ask_on_error: false
     ptf:
       name: "PTF"

--- a/crowbar_framework/config/repos-ses.yml
+++ b/crowbar_framework/config/repos-ses.yml
@@ -9,6 +9,7 @@ suse-12.0:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12:GA/SLES/12/POOL/x86_64"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Products/SLE-SERVER/12/x86_64/product"
       ask_on_error: false
     sles12-updates:
       name: "SLES12-Updates"
@@ -18,6 +19,7 @@ suse-12.0:
         tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12:x86_64/update"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Updates/SLE-SERVER/12/x86_64/update"
       ask_on_error: false
     sle12-ha-pool:
       name: "SLE12-HA-Pool"
@@ -45,6 +47,7 @@ suse-12.0:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12:Update:Products:SES2/ses/2/POOL/x86_64"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/products/storage/2/x86_64/product"
       ask_on_error: false
     suse-enterprise-storage-2-updates:
       name: "SUSE-Enterprise-Storage-2-Updates"
@@ -54,6 +57,7 @@ suse-12.0:
         tag: "obsrepository://build.suse.de/SUSE:Updates:Storage:2:x86_64/update"
         key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
+      smt_path: "SUSE/Updates/Storage/2/x86_64/update"
       ask_on_error: false
     ptf:
       name: "PTF"


### PR DESCRIPTION
We could probably just use the product name and version (like `SLE-SERVER/12`), but isn't this bit more readable? 

(But I'm fine with any way)