### PR TITLE
Renew DHCP lease after hardware-installing transtion

### DIFF
--- a/updates/control.sh
+++ b/updates/control.sh
@@ -234,6 +234,20 @@ run_hooks() {
     done
 }
 
+renew_dhcp_after_hwinstalling () {
+    # The Admin IP address of the node is allocated in the
+    # "hardware-installing" transition. Force a renewal here get the new IP
+    # address and avoid it changing at an unexpected time during the
+    # subsequent transitions
+    if [[ $1 = 'hardware-installing' ]]; then
+        echo "Forcing DHCP renewal after Admin IP allocation"
+        ifup $BOOTDEV > /dev/null
+        echo "New local IP Addresses:"
+        ip a | awk '/127.0.0./ { next; } /inet / { print }'
+    fi
+    return 0
+}
+
 walk_node_through () {
     # $1 = hostname for chef-client run
     # $@ = states to walk through
@@ -242,6 +256,7 @@ walk_node_through () {
     while (( $# > 1)); do
         state="$1"
         post_state "$name" "$1" && \
+            renew_dhcp_after_hwinstalling $1 && \
             run_hooks "$HOSTNAME" "$1" pre && \
             chef-client -S http://$ADMIN_IP:4000/ -N "$name" && \
             run_hooks "$HOSTNAME" "$1" post || \


### PR DESCRIPTION
During the "hardware-installing" transition a new admin IP Address (from the
"host" ranges) gets allocated to the node. Force a DHCP renewal to change to
the new IP Address directly after the transition. This avoids having the IP
Address changed at a later (unpredictable) time during the remainder of the
sledgehammer phase.