### PR TITLE
Fix ifcfg template for openvswitch device

### DIFF
--- a/chef/cookbooks/network/templates/default/suse-cfg.erb
+++ b/chef/cookbooks/network/templates/default/suse-cfg.erb
@@ -18,13 +18,9 @@ iface=@interfaces[@nic.name]
 -%>
 NAME=<%=quote(@nic.name)%>
 <% if iface["ovs_slave"] -%>
-STARTMODE=hotplug
 MASTER_DEVICE=ovs-system
-<% elsif @nic.kind_of?(Nic::OvsBridge) || iface["ovs_master"] -%>
-STARTMODE=hotplug
-<% else -%>
-STARTMODE=auto
 <% end -%>
+STARTMODE=auto
 <% if iface["slave"] || iface["ovs_master"] -%>
 BOOTPROTO=none
 <% else -%>
@@ -40,6 +36,11 @@ ETHTOOL_OPTIONS="-K iface <%= @ethtool_options -%>"
    when @nic.kind_of?(Nic::Bridge) -%>
 BRIDGE=yes
 BRIDGE_PORTS=<%=quote(iface["slaves"])%>
+<% when @nic.kind_of?(Nic::OvsBridge) -%>
+OVS_BRIDGE=yes
+<%   iface["slaves"].each_with_index do |slave, i| -%>
+OVS_BRIDGE_PORT_DEVICE_<%=i%>=<%=quote(slave)%>
+<%   end -%>
 <% when @nic.kind_of?(Nic::Vlan) -%>
 VLAN_ID=<%=iface["vlan"]%>
 ETHERDEVICE=<%=quote(iface["parent"])%>


### PR DESCRIPTION
According to the SLES12-SP1 documentation STARTMODE can be "auto" for
OvsBridges as well.
We need the OVS_BRIDGE='yes' and OVS_BRIDGE_PORT_DEVICE_* settings as wicked
will remove the bridge during shutdown and recreate them at boottime. (Which
went unnoticed until recently because of a bug in the openvswitch service
dependencies)