### PR TITLE
Fix repotag that is used for checking Cloud 6 media

### DIFF
--- a/crowbar_framework/config/repos-cloud.yml
+++ b/crowbar_framework/config/repos-cloud.yml
@@ -91,7 +91,7 @@ suse-12.1:
       required: "mandatory"
       features: ["openstack"]
       repomd:
-        tag: ["obsproduct://build.suse.de/SUSE:SLE-12:SP1:Products:Cloud6/suse-openstack-cloud/6/POOL/x86_64",
+        tag: ["obsproduct://build.suse.de/SUSE:SLE-12-SP1:Update:Products:Cloud6/suse-openstack-cloud/6/cd/x86_64",
               "obsproduct://build.suse.de/Devel:Cloud:6:Staging/suse-openstack-cloud/6/cd/x86_64",
               "obsproduct://build.suse.de/Devel:Cloud:6/suse-openstack-cloud/6/cd/x86_64"]
         key_md5: ["9a62177e1c6852d48453ed3909956d6b", "6e2920076653964b7de9d6d0421955bb"]
@@ -102,7 +102,7 @@ suse-12.1:
       required: "mandatory"
       features: ["openstack"]
 #      repomd:
-#        tag: "obsproduct://build.suse.de/SUSE:SLE-12:SP1:Products:Cloud6/suse-openstack-cloud/6/POOL/x86_64"
+#        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP1:Update:Products:Cloud6/suse-openstack-cloud/6/POOL/x86_64"
 #        key_md5: "9a62177e1c6852d48453ed3909956d6b"
       url:
       smt_path: "SUSE/Products/OpenStack-Cloud/6/x86_64/product"


### PR DESCRIPTION
We didn't have the right URL for the official build...