### PR TITLE
webui: Automatically create symlinks to SMT repositories

### DIFF
--- a/crowbar_framework/lib/crowbar/repository.rb
+++ b/crowbar_framework/lib/crowbar/repository.rb
@@ -264,7 +264,7 @@ module Crowbar
     private
 
     def repos_path
-      Pathname.new(File.join("/srv/tftpboot", @platform, @arch, "repos"))
+      Pathname.new("/srv/tftpboot").join(@platform, @arch, "repos")
     end
 
     def repo_path

--- a/crowbar_framework/lib/crowbar/repository.rb
+++ b/crowbar_framework/lib/crowbar/repository.rb
@@ -266,19 +266,23 @@ module Crowbar
       Pathname.new(File.join("/srv/tftpboot", @platform, @arch, "repos"))
     end
 
+    def repo_path
+      repos_path.join(name)
+    end
+
     def repodata_path
-      repos_path.join(name, "repodata")
+      repo_path.join("repodata")
     end
 
     def repodata_media_path
-      repos_path.join(name, "suse", "repodata")
+      repo_path.join("suse", "repodata")
     end
 
     #
     # validation helpers
     #
     def check_directory
-      repos_path.join(name).directory?
+      repo_path.directory?
     end
 
     def check_repo_tag

--- a/crowbar_framework/lib/crowbar/repository.rb
+++ b/crowbar_framework/lib/crowbar/repository.rb
@@ -203,6 +203,7 @@ module Crowbar
       @arch = arch
       @id = repo
       @config = Repository.registry[@platform][@arch][@id]
+      ensure_link_smt_path
     end
 
     def remote?
@@ -270,12 +271,24 @@ module Crowbar
       repos_path.join(name)
     end
 
+    def smt_path
+      unless @config["smt_path"].blank?
+        Pathname.new("/srv/www/htdocs/repo").join(@config["smt_path"])
+      end
+    end
+
     def repodata_path
       repo_path.join("repodata")
     end
 
     def repodata_media_path
       repo_path.join("suse", "repodata")
+    end
+
+    def ensure_link_smt_path
+      unless remote? || smt_path.nil? || repo_path.directory? || !smt_path.directory?
+        system("sudo", "-i", "ln", "-s", smt_path.to_s, repo_path.to_s)
+      end
     end
 
     #


### PR DESCRIPTION
If a repo doesn't exist but is mirrored by the local SMT, automatically
create a symlink to it.