### PR TITLE
Downgrade versions for a few rubygems we depend on

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -40,13 +40,13 @@ gem "easy_diff", "~> 0.0.5"
 gem "ohai", "~> 6.24.2"
 gem "chef", "~> 10.32.2"
 
-gem "mixlib-shellout", "~> 1.4.0",
+gem "mixlib-shellout", "~> 1.3.0",
     require: "mixlib/shellout"
 
 gem "activerecord-session_store", "~> 0.1.0",
     require: "activerecord/session_store"
 
-gem "mime-types", "~> 1.25.1",
+gem "mime-types", "~> 1.25.0",
     require: "mime/types"
 
 unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"

--- a/crowbar_framework/config/boot.rb
+++ b/crowbar_framework/config/boot.rb
@@ -92,7 +92,7 @@ else
   require "easy_diff"
 
   # chef related
-  gem "mixlib-shellout", version: "~> 1.4"
+  gem "mixlib-shellout", version: "~> 1.3"
   require "mixlib/shellout"
 
   gem "ohai", version: "~> 6.24"


### PR DESCRIPTION
This should allow us to use the SLE12 packages.