### PR TITLE
Added undocumented db:cleanup rake task

### DIFF
--- a/crowbar_framework/lib/tasks/database.rake
+++ b/crowbar_framework/lib/tasks/database.rake
@@ -1,0 +1,37 @@
+#
+# Copyright 2011-2013, Dell
+# Copyright 2013-2015, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+namespace :db do
+  task :cleanup => [:environment, :load_config] do
+    paths = ActiveRecord::Tasks::DatabaseTasks.migrations_paths
+
+    ActiveRecord::Migrator.tap do |migrator|
+      proxies = migrator.migrations(paths)
+      reversed = proxies.reverse
+
+      reversed.each do |proxy|
+        next if proxy.name == "CreateSessions"
+        proxy.migrate(:down)
+      end
+
+      proxies.each do |proxy|
+        next if proxy.name == "CreateSessions"
+        proxy.migrate(:up)
+      end
+    end
+  end
+end


### PR DESCRIPTION
To reset the database to a proper state where we can keep the session
information working I have written a custom rake task within the db
namespace. It is in purpose undocumented (no task description) to
prevent a manual execution.