### PR TITLE
Add suse-12.1/s390x

### DIFF
--- a/chef/data_bags/crowbar/template-provisioner.json
+++ b/chef/data_bags/crowbar/template-provisioner.json
@@ -80,6 +80,11 @@
             "initrd": "boot/ppc64le/initrd",
             "kernel": "boot/ppc64le/linux",
             "append": " "
+          },
+          "s390x": {
+            "initrd": "boot/s390x/initrd",
+            "kernel": "boot/s390x/linux",
+            "append": " "
           }
         },
         "windows-6.2": {


### PR DESCRIPTION
We need this entry so that the crowbar_register.sh scripts
get generated properly.