### PR TITLE
Set SES platform to suse-12.1

### DIFF
--- a/crowbar_framework/lib/crowbar/product.rb
+++ b/crowbar_framework/lib/crowbar/product.rb
@@ -29,7 +29,7 @@ module Crowbar
 
     def self.ses_platform
       # Returns the platform used for SES
-      "suse-12.0"
+      "suse-12.1"
     end
   end
 end


### PR DESCRIPTION
This is suitable only for SES 2.1+

Signed-off-by: Tim Serong <tserong@suse.com>