### PR TITLE
webui: Do not have branding js/css compiled in application js/css

### DIFF
--- a/crowbar_framework/app/assets/javascripts/application.js
+++ b/crowbar_framework/app/assets/javascripts/application.js
@@ -8,7 +8,6 @@
 //= require fontawesome
 //= require_self
 //= require installer
-//= require branding
 
 jQuery(document).ready(function($) {
   $('textarea.editor').each(function() {

--- a/crowbar_framework/app/assets/stylesheets/application.scss
+++ b/crowbar_framework/app/assets/stylesheets/application.scss
@@ -14,5 +14,3 @@
 @import "content/drag";
 @import "content/table";
 @import "content/footer";
-
-@import "branding";

--- a/crowbar_framework/app/helpers/application_helper.rb
+++ b/crowbar_framework/app/helpers/application_helper.rb
@@ -73,6 +73,8 @@ module ApplicationHelper
         files.push "barclamps/#{barclamp_name}/application"
       end
 
+      files.push "branding"
+
       files
     end
   end
@@ -113,6 +115,8 @@ module ApplicationHelper
       if barclamp_path.file?
         files.push "barclamps/#{barclamp_name}/application"
       end
+
+      files.push "branding"
 
       files
     end

--- a/crowbar_framework/public/403.html
+++ b/crowbar_framework/public/403.html
@@ -10,7 +10,9 @@
     <meta content="IE=edge" http-equiv="X-UA-Compatible" />
 
     <link rel="stylesheet" href="/assets/application.css" />
+    <link rel="stylesheet" href="/assets/branding.css" />
     <script src="/assets/application.js"></script>
+    <script src="/assets/branding.js"></script>
 
     <!--[if lt IE 9]>
     <link rel="stylesheet" href="/assets/ie.css" />

--- a/crowbar_framework/public/404.html
+++ b/crowbar_framework/public/404.html
@@ -10,7 +10,9 @@
     <meta content="IE=edge" http-equiv="X-UA-Compatible" />
 
     <link rel="stylesheet" href="/assets/application.css" />
+    <link rel="stylesheet" href="/assets/branding.css" />
     <script src="/assets/application.js"></script>
+    <script src="/assets/branding.js"></script>
 
     <!--[if lt IE 9]>
     <link rel="stylesheet" href="/assets/ie.css" />

--- a/crowbar_framework/public/422.html
+++ b/crowbar_framework/public/422.html
@@ -10,7 +10,9 @@
     <meta content="IE=edge" http-equiv="X-UA-Compatible" />
 
     <link rel="stylesheet" href="/assets/application.css" />
+    <link rel="stylesheet" href="/assets/branding.css" />
     <script src="/assets/application.js"></script>
+    <script src="/assets/branding.js"></script>
 
     <!--[if lt IE 9]>
     <link rel="stylesheet" href="/assets/ie.css" />

--- a/crowbar_framework/public/500.html
+++ b/crowbar_framework/public/500.html
@@ -10,7 +10,9 @@
     <meta content="IE=edge" http-equiv="X-UA-Compatible" />
 
     <link rel="stylesheet" href="/assets/application.css" />
+    <link rel="stylesheet" href="/assets/branding.css" />
     <script src="/assets/application.js"></script>
+    <script src="/assets/branding.js"></script>
 
     <!--[if lt IE 9]>
     <link rel="stylesheet" href="/assets/ie.css" />


### PR DESCRIPTION
This is an issue when compiling the assets as this means that we can't
simply replace the compiled branding bits, but we have to re-compile the
application assets.

cc @tboerger 