### PR TITLE
Allow defining a priority for each repo

### DIFF
--- a/chef/cookbooks/provisioner/libraries/repositories.rb
+++ b/chef/cookbooks/provisioner/libraries/repositories.rb
@@ -37,7 +37,11 @@ class Provisioner
             {}
           end
           next if repo["url"].nil?
-          repositories[repo["name"]] = { url: repo["url"], ask_on_error: repo["ask_on_error"] }
+          repositories[repo["name"]] = {
+            url: repo["url"],
+            ask_on_error: repo["ask_on_error"] || false,
+            priority: repo["priority"] || 99
+          }
         end
 
         repositories

--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -304,7 +304,7 @@ if node[:platform_family] == "suse" && !node.roles.include?("provisioner-server"
       current_url = nil
       current_priority = nil
 
-      out = %x{LANG=C zypper --non-interactive repos #{name} 2> /dev/null}
+      out = `LANG=C zypper --non-interactive repos #{name} 2> /dev/null`
       out.split("\n").each do |line|
         attribute, value = line.split(":", 2)
         next if value.nil?
@@ -320,13 +320,13 @@ if node[:platform_family] == "suse" && !node.roles.include?("provisioner-server"
       if current_url != attrs[:url]
         unless current_url.nil? || current_url.empty?
           Chef::Log.info("Removing #{name} zypper repository pointing to wrong URI...")
-          %x{zypper --non-interactive removerepo #{name}}
+          `zypper --non-interactive removerepo #{name}`
         end
         Chef::Log.info("Adding #{name} zypper repository...")
-        %x{zypper --non-interactive addrepo --refresh #{attrs[:url]} #{name}}
+        `zypper --non-interactive addrepo --refresh #{attrs[:url]} #{name}`
       end
       if current_priority != attrs[:priority]
-        %x{zypper --non-interactive modifyrepo --priority #{attrs[:priority]} #{name}}
+        `zypper --non-interactive modifyrepo --priority #{attrs[:priority]} #{name}`
       end
     end
     # install additional packages

--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -301,15 +301,32 @@ if node[:platform_family] == "suse" && !node.roles.include?("provisioner-server"
     # make sure the repos are properly setup
     repos = Provisioner::Repositories.get_repos(node[:platform], node[:platform_version], node[:kernel][:machine])
     for name, attrs in repos
-      url = %x{zypper --non-interactive repos #{name} 2> /dev/null | grep "^URI " | cut -d : -f 2-}
-      url.strip!
-      if url != attrs[:url]
-        unless url.empty?
+      current_url = nil
+      current_priority = nil
+
+      out = %x{LANG=C zypper --non-interactive repos #{name} 2> /dev/null}
+      out.split("\n").each do |line|
+        attribute, value = line.split(":", 2)
+        next if value.nil?
+        attribute.strip!
+        value.strip!
+        if attribute == "URI"
+          current_url = value
+        elsif attribute == "Priority"
+          current_priority = value
+        end
+      end
+
+      if current_url != attrs[:url]
+        unless current_url.nil? || current_url.empty?
           Chef::Log.info("Removing #{name} zypper repository pointing to wrong URI...")
           %x{zypper --non-interactive removerepo #{name}}
         end
         Chef::Log.info("Adding #{name} zypper repository...")
         %x{zypper --non-interactive addrepo --refresh #{attrs[:url]} #{name}}
+      end
+      if current_priority != attrs[:priority]
+        %x{zypper --non-interactive modifyrepo --priority #{attrs[:priority]} #{name}}
       end
     end
     # install additional packages

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -35,6 +35,9 @@
         <product><%= name %></product>
         <product_dir>/</product_dir>
         <media_url><%= @repos[name][:url] %></media_url>
+        <% unless @repos[name][:priority] == 99 -%>
+        <priority><%= @repos[name][:priority] %></priority>
+        <% end -%>
         <!-- See bnc#787157 for discussion on ask_on_error -->
         <ask_on_error config:type="boolean"><%= @repos[name][:ask_on_error] || 'false' %></ask_on_error>
       </listentry>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -278,6 +278,9 @@ fi
 
 <% @repos.keys.sort.each do |name| %>
 zypper -n ar "<%= @repos[name][:url] %>" "<%= name %>"
+  <% unless @repos[name][:priority] == 99 -%>
+zypper -n mr -p "<%= @repos[name][:priority] %>" "<%= name %>"
+  <% end -%>
 <% end %>
 <% if @repos.keys.include? "PTF" -%>
 

--- a/crowbar_framework/lib/crowbar/repository.rb
+++ b/crowbar_framework/lib/crowbar/repository.rb
@@ -53,7 +53,7 @@ module Crowbar
                   # for repos that exist in our hard-coded file, we only allow
                   # overwriting a subset of attributes
                   if @all_repos[platform][arch].key? id
-                    %w(url ask_on_error).each do |key|
+                    %w(url priority ask_on_error).each do |key|
                       @all_repos[platform][arch][id][key] = repo[key] if repo.key? key
                     end
                   else
@@ -239,6 +239,10 @@ module Crowbar
         "http://#{Repository.admin_ip}:#{Repository.web_port}/#{@platform}/#{@arch}/repos/#{name}/"
     end
 
+    def priority
+      @config["priority"] || 99
+    end
+
     def active?
       db = data_bag
       !db.nil? && db.include?(data_bag_item_name)
@@ -264,6 +268,7 @@ module Crowbar
       item["id"] = data_bag_item_name
       item["name"] = name
       item["url"] = url
+      item["priority"] = priority
       item["ask_on_error"] = @config["ask_on_error"] || false
       item
     end


### PR DESCRIPTION
This is needed for Leap, where we want to prefer packages from
Cloud:OpenStack:* to the ones from the main Leap repo.