### PR TITLE
logging: Prefer rsyslog to systemd-logger on Leap

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -305,6 +305,9 @@ sync
       <package>supportutils-plugin-suse-openstack-cloud</package>
   <% end -%>
 <% end -%>
+<% if @platform == "opensuse" -%>
+      <package>rsyslog</package>
+<% end -%>
 <% @packages.each do |package| -%>
       <package><%= package %></package>
 <% end -%>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -317,6 +317,11 @@ zypper --non-interactive install --auto-agree-with-licenses suse-openstack-cloud
 <% end -%>
 zypper --non-interactive install $PACKAGES_INSTALL<%= " '#{@packages.join("' '")}'" unless @packages.empty? %>
 
+<% if @platform == "opensuse" -%>
+# we need rsyslog, not systemd-logger
+zypper --non-interactive remove systemd-logger
+<% end -%>
+
 # Fail early if we know we can't succeed because of a missing chef-client
 if ! which chef-client &> /dev/null; then
   echo "chef-client is not available."


### PR DESCRIPTION
An alternative is to remove the systemd-logger in the cookbook. But this
way seems cleaner (for now).