### PR TITLE
Minimal work to enable Leap nodes

### DIFF
--- a/chef/data_bags/crowbar/template-provisioner.json
+++ b/chef/data_bags/crowbar/template-provisioner.json
@@ -87,6 +87,13 @@
             "append": " "
           }
         },
+        "opensuse-42.1": {
+          "x86_64": {
+            "initrd": "boot/x86_64/loader/initrd",
+            "kernel": "boot/x86_64/loader/linux",
+            "append": " "
+          }
+        },
         "windows-6.2": {
           "x86_64": {
             "initrd": " ",

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -289,6 +289,7 @@ class CrowbarService < ServiceObject
   end
 
   def self.pretty_target_platform(target_platform)
+    return "openSUSE Leap 42.1" if target_platform == "opensuse-42.1"
     return "SLES 12 SP1" if target_platform == "suse-12.1"
     return "SLES 12" if target_platform == "suse-12.0"
     return "SLES 11 SP4" if target_platform == "suse-11.4"
@@ -313,6 +314,7 @@ class CrowbarService < ServiceObject
 
   def self.support_software_raid
     [
+      "opensuse-42.1",
       "suse-12.1",
       "suse-12.0",
       "suse-11.4",

--- a/updates/control.sh
+++ b/updates/control.sh
@@ -40,6 +40,7 @@ function is_suse() {
     if [ -f /etc/os-release ]; then
         . /etc/os-release
         [ "$NAME" == "SLES" ] && return
+        [ "$NAME" == "openSUSE Leap" ] && return
     fi
 
     return 1


### PR DESCRIPTION
This change only makes it possible to enable Leap when allocating a
node (assuming that the install media is available), but several other
changes are needed to have working Leap support.