### PR TITLE
provisioner: Do not require rsync of Leap install media

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -449,7 +449,7 @@ node.set[:provisioner][:available_oses] = Mash.new
 node[:provisioner][:supported_oses].each do |os, arches|
   arches.each do |arch, params|
     web_path = "#{provisioner_web}/#{os}/#{arch}"
-    admin_web = "#{web_path}/install"
+    install_url = "#{web_path}/install"
     crowbar_repo_web = "#{web_path}/crowbar-extra"
     os_dir = "#{tftproot}/#{os}/#{arch}"
     os_codename = node[:lsb][:codename]
@@ -504,7 +504,7 @@ node[:provisioner][:supported_oses].each do |os, arches|
     case
     when /^(suse)/ =~ os
       # Add base OS install repo for suse
-      node.set[:provisioner][:repositories][os][arch]["base"] = { "baseurl=#{admin_web}" => true }
+      node.set[:provisioner][:repositories][os][arch]["base"] = { "baseurl=#{install_url}" => true }
 
       ntp_servers = search(:node, "roles:ntp-server")
       ntp_servers_ips = ntp_servers.map { |n| Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address }
@@ -548,9 +548,9 @@ node[:provisioner][:supported_oses].each do |os, arches|
     when /^(redhat|centos)/ =~ os
       # Add base OS install repo for redhat/centos
       if ::File.exist? "#{tftproot}/#{os}/#{arch}/install/repodata"
-        node.set[:provisioner][:repositories][os][arch]["base"] = { "baseurl=#{admin_web}" => true }
+        node.set[:provisioner][:repositories][os][arch]["base"] = { "baseurl=#{install_url}" => true }
       else
-        node.set[:provisioner][:repositories][os][arch]["base"] = { "baseurl=#{admin_web}/Server" => true }
+        node.set[:provisioner][:repositories][os][arch]["base"] = { "baseurl=#{install_url}/Server" => true }
       end
       # Default kickstarts and crowbar_join scripts for redhat.
 
@@ -559,7 +559,7 @@ node[:provisioner][:supported_oses].each do |os, arches|
         owner "root"
         group "root"
         source "crowbar_join.redhat.sh.erb"
-        variables(admin_web: admin_web,
+        variables(admin_web: install_url,
                   os_codename: os_codename,
                   crowbar_repo_web: crowbar_repo_web,
                   admin_ip: admin_ip,
@@ -568,14 +568,14 @@ node[:provisioner][:supported_oses].each do |os, arches|
       end
 
     when /^ubuntu/ =~ os
-      node.set[:provisioner][:repositories][os][arch]["base"] = { admin_web => true }
+      node.set[:provisioner][:repositories][os][arch]["base"] = { install_url => true }
       # Default files needed for Ubuntu.
 
       template "#{os_dir}/net-post-install.sh" do
         mode 0644
         owner "root"
         group "root"
-        variables(admin_web: admin_web,
+        variables(admin_web: install_url,
                   os_codename: os_codename,
                   repos: node[:provisioner][:repositories][os][arch],
                   admin_ip: admin_ip,
@@ -588,7 +588,7 @@ node[:provisioner][:supported_oses].each do |os, arches|
         owner "root"
         group "root"
         source "crowbar_join.ubuntu.sh.erb"
-        variables(admin_web: admin_web,
+        variables(admin_web: install_url,
                   os_codename: os_codename,
                   crowbar_repo_web: crowbar_repo_web,
                   admin_ip: admin_ip,

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -205,7 +205,7 @@ if not nodes.nil? and not nodes.empty?
         node_cfg_dir = "#{tftproot}/nodes/#{mnode[:fqdn]}"
         node_url = "#{provisioner_web}/nodes/#{mnode[:fqdn]}"
         os_url = "#{provisioner_web}/#{os}/#{arch}"
-        install_url = "#{os_url}/install"
+        install_url = node[:provisioner][:available_oses][os][arch][:install_url]
 
         directory node_cfg_dir do
           action :create

--- a/chef/data_bags/crowbar/template-provisioner.json
+++ b/chef/data_bags/crowbar/template-provisioner.json
@@ -87,6 +87,13 @@
             "append": " "
           }
         },
+        "opensuse-42.1": {
+          "x86_64": {
+            "initrd": "boot/x86_64/loader/initrd",
+            "kernel": "boot/x86_64/loader/linux",
+            "append": " "
+          }
+        },
         "windows-6.2": {
           "x86_64": {
             "initrd": " ",

--- a/chef/data_bags/crowbar/template-provisioner.json
+++ b/chef/data_bags/crowbar/template-provisioner.json
@@ -91,7 +91,8 @@
           "x86_64": {
             "initrd": "boot/x86_64/loader/initrd",
             "kernel": "boot/x86_64/loader/linux",
-            "append": " "
+            "append": " ",
+            "install_url": "http://download.opensuse.org/distribution/leap/42.1/repo/oss/"
           }
         },
         "windows-6.2": {

--- a/chef/data_bags/crowbar/template-provisioner.schema
+++ b/chef/data_bags/crowbar/template-provisioner.schema
@@ -38,7 +38,8 @@
                         "append": { "type": "str", "required": true },
                         "kernel": { "type": "str", "required": true },
                         "initrd": { "type": "str", "required": true },
-                        "require_install_dir": { "type": "bool", "required": false }
+                        "require_install_dir": { "type": "bool", "required": false },
+                        "install_url": { "type": "str", "required": false }
                       }
                     }
 	          }

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -289,6 +289,7 @@ class CrowbarService < ServiceObject
   end
 
   def self.pretty_target_platform(target_platform)
+    return "openSUSE Leap 42.1" if target_platform == "opensuse-42.1"
     return "SLES 12 SP1" if target_platform == "suse-12.1"
     return "SLES 12" if target_platform == "suse-12.0"
     return "SLES 11 SP4" if target_platform == "suse-11.4"
@@ -313,6 +314,7 @@ class CrowbarService < ServiceObject
 
   def self.support_software_raid
     [
+      "opensuse-42.1",
       "suse-12.1",
       "suse-12.0",
       "suse-11.4",

--- a/crowbar_framework/config/repos-cloud.yml
+++ b/crowbar_framework/config/repos-cloud.yml
@@ -97,3 +97,75 @@ suse-12.1:
       required: "recommended"
       url:
       ask_on_error: false
+opensuse-42.1:
+  x86_64:
+    leap-42_1:
+      name: "openSUSE-Leap"
+      required: "mandatory"
+      features: ["os", "ha", "ceph"]
+      repomd:
+        tag: ["obsproduct://build.opensuse.org/openSUSE:Leap:42.1/openSUSE/42.1/ftp/x86_64",
+              "obsproduct://build.opensuse.org/openSUSE:Leap:42.1/openSUSE/42.1/cd/x86_64"]
+        key_md5: "d8039df72c407bc7dd7c1d9c66d58627"
+      url: "http://download.opensuse.org/distribution/leap/42.1/repo/oss/"
+      smt_path:
+      ask_on_error: false
+    leap-42_1-update:
+      name: "openSUSE-Leap-Update"
+      required: "mandatory"
+      features: ["os", "ha", "ceph"]
+      repomd:
+        tag: "obsrepository://build.opensuse.org/openSUSE:Leap:42.1:Update/standard"
+        key_md5: "d8039df72c407bc7dd7c1d9c66d58627"
+      url: "http://download.opensuse.org/update/leap/42.1/oss/"
+      smt_path:
+      ask_on_error: false
+    chef-10:
+      name: "Chef-10"
+      required: "mandatory"
+      #repomd:
+      #  tag: "obsrepository://build.opensuse.org/systemsmanagement:chef:10/openSUSE_Leap_42.1"
+      #  key_md5: "52a2a3f69993789a5362844ec81442dd"
+      #url: "http://download.opensuse.org/repositories/systemsmanagement:/chef:/10/openSUSE_Leap_42.1"
+      repomd:
+        tag: "obsrepository://build.opensuse.org/home:vuntz:crowbar:3.0/openSUSE_Leap_42.1"
+        key_md5: "aef42abc9d4311b5f72f46db225f2575"
+      url: "http://download.opensuse.org/repositories/home:/vuntz:/crowbar:/3.0/openSUSE_Leap_42.1"
+      smt_path:
+      priority: 90
+      ask_on_error: false
+    openstack-liberty:
+      name: "OpenStack-Liberty"
+      required: "mandatory"
+      features: ["openstack"]
+      repomd:
+        tag: ["obsrepository://build.opensuse.org/Cloud:OpenStack:Liberty/openSUSE_Leap_42.1",
+              "obsrepository://build.opensuse.org/Cloud:OpenStack:Liberty:Staging/openSUSE_Leap_42.1"]
+        key_md5: "52a2a3f69993789a5362844ec81442dd"
+      url: "http://download.opensuse.org/repositories/Cloud:/OpenStack:/Liberty/openSUSE_Leap_42.1/"
+      smt_path:
+      priority: 90
+      ask_on_error: false
+    ceph-hammer:
+      # Was submitted to Leap, but not there yet
+      name: "Ceph-Hammer"
+      required: "optional"
+      features: ["ceph"]
+      repomd:
+        tag: "obsrepository://build.opensuse.org/home:smithfarm:leap/openSUSE_Leap_42.1"
+        key_md5: "1fbfef4396ba362577f4393eb09dca32"
+      url: "http://download.opensuse.org/repositories/home:/smithfarm:/leap/openSUSE_Leap_42.1/"
+      smt_path:
+      priority: 90
+      ask_on_error: false
+    ceph-calamari:
+      # Calamari is in a separate project due to the old django dep
+      name: "Ceph-Calamari"
+      required: "optional"
+      repomd:
+        tag: "obsrepository://build.opensuse.org/systemsmanagement:calamari/openSUSE_Leap_42.1"
+        key_md5: "081f86b11a9fc2d1a4ab0b32ec3e3812"
+      url: "http://download.opensuse.org/repositories/systemsmanagement:/calamari/openSUSE_Leap_42.1/"
+      smt_path:
+      priority: 90
+      ask_on_error: false

--- a/updates/control.sh
+++ b/updates/control.sh
@@ -40,6 +40,7 @@ function is_suse() {
     if [ -f /etc/os-release ]; then
         . /etc/os-release
         [ "$NAME" == "SLES" ] && return
+        [ "$NAME" == "openSUSE Leap" ] && return
     fi
 
     return 1


### PR DESCRIPTION
(ignore the first commit, it's from https://github.com/crowbar/crowbar-core/pull/159)

If /srv/tftpboot/opensuse-42.1/x86_64/install/ exists but does not
contain the required files, we will download the minimal bits that are
needed to allow Leap installation.

It's very debatable whether this should be done in the chef cookbook or
elsewhere, and the "security check" is quite weak (just a md5sum
check)...
