### PR TITLE
Throw proper error on disable interface

### DIFF
--- a/crowbar_framework/app/controllers/network_controller.rb
+++ b/crowbar_framework/app/controllers/network_controller.rb
@@ -125,22 +125,28 @@ class NetworkController < BarclampController
 
   add_help(:disable_interface, [:id, :network, :name], [:post])
   def disable_interface
-    code, message = @service_object.disable_interface(
-      params[:id],
-      params[:network],
-      params[:name]
-    )
-
     respond_to do |format|
-      case code
-      when 200
-        format.json { head :ok }
-      else
-        format.json do
-          render json: { error: message }, status: code
-        end
+      format.json do
+        render json: { error: "Disabling is unsupported" }, status: 500
       end
     end
+
+    # code, message = @service_object.disable_interface(
+    #   params[:id],
+    #   params[:network],
+    #   params[:name]
+    # )
+
+    # respond_to do |format|
+    #   case code
+    #   when 200
+    #     format.json { head :ok }
+    #   else
+    #     format.json do
+    #       render json: { error: message }, status: code
+    #     end
+    #   end
+    # end
   end
 
   def switch


### PR DESCRIPTION
As tracked on bsc#951550 the method to disable network interfaces is not
implemented yet. To display a proper error message on the crowbar client
instead of "Internal server error" we will return a proper message now.

https://bugzilla.suse.com/show_bug.cgi?id=951550