### PR TITLE
Fix color of list headings

### DIFF
--- a/crowbar_framework/vendor/assets/stylesheets/variables.scss
+++ b/crowbar_framework/vendor/assets/stylesheets/variables.scss
@@ -441,9 +441,9 @@ $list-group-border: #ddd;
 $list-group-border-radius: $border-radius-base;
 
 $list-group-hover-bg: #f5f5f5;
-$list-group-active-color: $component-active-color;
-$list-group-active-bg: $component-active-bg;
-$list-group-active-border: $list-group-active-bg;
+$list-group-active-color: #333;
+$list-group-active-bg: #fff;
+$list-group-active-border: #ddd;
 
 $list-group-link-color: #555;
 $list-group-link-heading-color: #333;


### PR DESCRIPTION
Color before fix:
![cinder_before](https://cloud.githubusercontent.com/assets/4128547/11817022/56564116-a353-11e5-949c-98fcd07d7494.png)

Color after fix:
![cinder_fixed](https://cloud.githubusercontent.com/assets/4128547/11817029/5c47601e-a353-11e5-84fd-cf7d59c7e1af.png)

@kwwii Are you fine with this change? I changed the color to the same as before but I don't know if this change was by intention. The Problem was that the trash bin item was not visible.