### PR TITLE
Only use bootproto "none" for bond slaves

### DIFF
--- a/chef/cookbooks/network/templates/default/suse-cfg.erb
+++ b/chef/cookbooks/network/templates/default/suse-cfg.erb
@@ -18,7 +18,7 @@ iface=@interfaces[@nic.name]
 -%>
 NAME=<%=quote(@nic.name)%>
 STARTMODE=auto
-<% if iface["slave"] -%>
+<% if iface["slave"] && Nic.bond?(iface["master"])-%>
 BOOTPROTO=none
 <% else -%>
 BOOTPROTO=static


### PR DESCRIPTION
Should be "static" (with no IP Address) for OVS slaves.