### PR TITLE
Raise CROWBAR_THREADS to 10 (bsc#952171)

### DIFF
--- a/chef/cookbooks/crowbar/files/default/crowbar.service
+++ b/chef/cookbooks/crowbar/files/default/crowbar.service
@@ -14,7 +14,7 @@ TimeoutStopSec=10
 WorkingDirectory=/opt/dell/crowbar_framework
 
 Environment="CROWBAR_ENV=production"
-Environment="CROWBAR_THREADS=1"
+Environment="CROWBAR_THREADS=10"
 Environment="CROWBAR_WORKERS=5"
 Environment="CROWBAR_LISTEN=127.0.0.1"
 Environment="CROWBAR_PORT=3000"

--- a/chef/cookbooks/crowbar/templates/default/sysconfig.crowbar.erb
+++ b/chef/cookbooks/crowbar/templates/default/sysconfig.crowbar.erb
@@ -11,10 +11,10 @@ CROWBAR_ENV="production"
 ## Path:            Crowbar
 ## Description:     Maximum number of threads
 ## Type:            integer
-## Default:         1
+## Default:         10
 ## ServiceRestart:  crowbar
 # Sets the maximum number of threads used by the web server.
-CROWBAR_THREADS="1"
+CROWBAR_THREADS="10"
 
 ## Path:            Crowbar
 ## Description:     Maximum number of worker processes

--- a/configs/crowbar.service
+++ b/configs/crowbar.service
@@ -14,7 +14,7 @@ TimeoutStopSec=10
 WorkingDirectory=/opt/dell/crowbar_framework
 
 Environment="CROWBAR_ENV=production"
-Environment="CROWBAR_THREADS=1"
+Environment="CROWBAR_THREADS=10"
 Environment="CROWBAR_WORKERS=5"
 Environment="CROWBAR_LISTEN=127.0.0.1"
 Environment="CROWBAR_PORT=3000"

--- a/crowbar_framework/config/crowbar.env
+++ b/crowbar_framework/config/crowbar.env
@@ -1,5 +1,3 @@
-export RAINBOWS_WORKERS=5
-
 export CROWBAR_VERSION=3.0
 export CROWBAR_LOG_DIR=/var/log/crowbar
 

--- a/crowbar_framework/config/puma.rb
+++ b/crowbar_framework/config/puma.rb
@@ -1,7 +1,7 @@
 ROOT = File.expand_path("../../", __FILE__)
 ENVIRONMENT = ENV["CROWBAR_ENV"] || "production"
 
-THREADS = ENV["CROWBAR_THREADS"] || 1
+THREADS = ENV["CROWBAR_THREADS"] || 10
 WORKERS = ENV["CROWBAR_WORKERS"] || 5
 
 LISTEN = ENV["CROWBAR_LISTEN"] || "127.0.0.1"
@@ -34,7 +34,7 @@ bind "tcp://#{LISTEN}:#{PORT}"
 on_worker_boot do
   ::ActiveSupport.on_load(:active_record) do
     config = Rails.application.config.database_configuration[Rails.env]
-    config["pool"] = ENV["CROWBAR_THREADS"] || 1
+    config["pool"] = ENV["CROWBAR_THREADS"] || 10
 
     ::ActiveRecord::Base.establish_connection(config)
   end


### PR DESCRIPTION
We need to raise the workers because deploying a proposal and accessing
the web ui at the same time is not possible. Also we need to raise the
workers instead of threads due to crowbar is not thread safe.

PS: This is the amount of workers which I found out while try and error.