### PR TITLE
Add root_password_hash to provisioner template

### DIFF
--- a/chef/data_bags/crowbar/template-provisioner.json
+++ b/chef/data_bags/crowbar/template-provisioner.json
@@ -5,6 +5,7 @@
     "provisioner": {
       "default_user": "crowbar",
       "default_password_hash": "$1$BDC3UwFr$/VqOWN1Wi6oM0jiMOjaPb.",
+      "root_password_hash": "",
       "access_keys": "",
       "shell_prompt": "USER@HOST:CWD SUFFIX",
       "enable_pxe": true,


### PR DESCRIPTION
This makes it easier to discover the setting when you're looking
for it in the raw mode.