### PR TITLE
Display more details on machines index

### DIFF
--- a/crowbar_framework/app/controllers/machines_controller.rb
+++ b/crowbar_framework/app/controllers/machines_controller.rb
@@ -52,7 +52,9 @@ class MachinesController < BarclampController
     @nodes = NodeObject.find_all_nodes.map do |node|
       {
         name: node.name,
-        alias: node.alias
+        alias: node.alias,
+        group: node.group,
+        status: node.status
       }
     end
 


### PR DESCRIPTION
This pull request is required to be able to display the status and the group of a node within the crowbar client. The pull requests for the client implementation is in progress.