### PR TITLE
workaround random mksquashfs race bsc#962397

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -259,6 +259,7 @@ if not nodes.nil? and not nodes.empty?
         when os =~ /^(open)?suse/
           append << "install=#{install_url} autoyast=#{node_url}/autoyast.xml"
           append << "ifcfg=dhcp4 netwait=60"
+          append << "squash=0" # workaround bsc#962397
           append << "autoupgrade=1" if mnode[:state] == "os-upgrading"
 
           target_platform_distro = os.gsub(/-.*$/, "")


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=962397
The instsys we use with autoyast
downloads some RPMs from HTTP and converts these to squashfs
using mksquashfs. Since that uses multiple cores,
it seems that there sometimes is a race
that produces corrupt filesystems and thus breaks the install.

we only started using more than 1 core recently in
https://github.com/SUSE-Cloud/automation/commit/0ff56c95bbc932f2b89a