### PR TITLE
Pass the specific error message from chef recipe to crowbar rails app

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-db-dump.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-db-dump.rb
@@ -49,8 +49,12 @@ when "openstack_shutdown"
       available = `df #{path} | tail -n 1 | sed "s/ \\+/ /g" | cut -d " " -f 4`
       db_size = `su - postgres -c 'pg_dumpall | wc -c'`
       if db_size.to_i > available.to_i
-        Chef::Log.fatal("DB size is: #{db_size}, available space on #{path} is #{available}")
-        raise "Not enough space on #{path} for the Database dump!"
+        message = "Not enough space for the Database dump on node #{node.name}!\n" \
+          "Database size is: #{db_size}B, available space on #{path} is only #{available}B."
+        Chef::Log.fatal(message)
+        node["crowbar_wall"]["chef_error"] = message
+        node.save
+        raise message
       end
     end
   end

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -358,6 +358,10 @@ class CrowbarService < ServiceObject
   def apply_role (role, inst, in_queue)
     @logger.debug("Crowbar apply_role: enter")
     answer = super
+    if answer.first != 200
+      @logger.error("Crowbar apply_role: super apply_role finished with error")
+      return answer
+    end
     @logger.debug("Crowbar apply_role: super apply_role finished")
 
     role = role.default_attributes

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -45,9 +45,25 @@ class CrowbarService < ServiceObject
   # Unfortunatelly we need to explicitely look at crowbar-status of the proposal
   # because apply_role from this model ignores errors from superclass's apply_role.
   def commit_and_check_proposal
-    proposal_commit("default", false, false)
+    answer = proposal_commit("default", false, false)
+    # check if error message is saved in one of the nodes
+    if answer.first != 200
+      found_errors = []
+      NodeObject.find("state:crowbar_upgrade").each do |node|
+        error = node["crowbar_wall"]["chef_error"] || ""
+        next if error.empty?
+        found_errors.push error
+        @logger.error("Chef run ended with an error on the node #{name}: #{error}")
+        node["crowbar_wall"]["chef_error"] = ""
+        node.save
+      end
+      unless found_errors.empty?
+        raise found_errors.join("\n")
+      end
+    end
 
     proposal = Proposal.where(barclamp: "crowbar", name: "default").first
+    # there could be different error than one raised from a recipe
     if proposal["deployment"]["crowbar"]["crowbar-status"] == "failed"
       raise proposal["deployment"]["crowbar"]["crowbar-failed"]
     end


### PR DESCRIPTION
This is currently only used by upgrade process, but potentially could offer solution for other cases when we want to report an error from chef recipe.

(Note that this PR contains 2 different solutions for resetting the error flag of node.)