### PR TITLE
crowbar: Fix node runlist sorting to be predictable

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -736,8 +736,10 @@ class NodeObject < ChefObject
     # Ruby 1.8 vs. 1.9 compatibility. Select returns Hash in 1.9 instead of
     # an array, so map it back to [key, val] pairs.
     map = map.to_a if map.is_a?(Hash)
-    # Sort map
-    vals = map.sort { |a,b| a[1]["priority"] <=> b[1]["priority"] }
+    # Sort map (by priority, then name)
+    vals = map.sort do |a, b|
+      [a[1]["priority"], a[0]] <=> [b[1]["priority"], b[0]]
+    end
     Rails.logger.debug("rebuilt run_list will be #{vals.inspect}")
 
     # Rebuild list


### PR DESCRIPTION
If two roles have the same priority, there was nothing that was
guaranteeing a fixed order. So sort by priority and then name.

This bug could result in issues for HA clusters where one member of the
cluster runs one role while others are running another role with the
same priority -- triggering timeouts on the sync marks.

cc @aspiers; this should fix https://ci.suse.de/job/openstack-mkcloud/15117/console