### PR TITLE
Add backend calls for 'shutdown of services' step

### DIFF
--- a/crowbar_framework/app/views/setups/show.html.haml
+++ b/crowbar_framework/app/views/setups/show.html.haml
@@ -37,8 +37,8 @@
           %h4 Data Backup
         .panel-body
           %p Now is the time to backup all the other data in your system.
-          %p Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam at porttitor sem. Aliquam erat volutpat. Donec placerat nisl magna, et faucibus arcu condimentum sed.Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-          %button.btn.btn-success.center-block{:type => "button"} Continue Upgrade Process
+          %p You can find dump of your OpenStack database at node XXX, file YYY
+          = button_to "Continue Upgrade Process", finalize_setup_path, class: "btn btn-success center-block", method: :get
 %section
   .container
     %p Step 7:

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -146,6 +146,7 @@ Rails.application.routes.draw do
     collection do
       get :stop
       get :nodes
+      get :finalize
     end
   end
 


### PR DESCRIPTION
So, this is obviously wrong from UI perspective, handling of error from `dump_database` is not correct ... (  but maybe that could be solved in the final UI?)

At least the right calls to API are there.. 