### PR TITLE
Revert runlist reduction for crowbar_upgrade

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -727,12 +727,10 @@ class NodeObject < ChefObject
     crowbar["run_list_map"] = {} if crowbar["run_list_map"].nil?
 
     # Cull by state
-    node_state = crowbar["state"]
     map = crowbar["run_list_map"].select do |k, v|
-      v["states"].include?(node_state) ||
-        # When node is in upgrade state, allow only upgrade specific recipes
-        (v["states"].include?("all") && node_state != "crowbar_upgrade")
+      v["states"].include?("all") || v["states"].include?(crowbar["state"])
     end
+
     # Ruby 1.8 vs. 1.9 compatibility. Select returns Hash in 1.9 instead of
     # an array, so map it back to [key, val] pairs.
     map = map.to_a if map.is_a?(Hash)


### PR DESCRIPTION
introduced by https://github.com/jsuchome/crowbar-core/commit/03f83fc3744449a51916bd07dcd7c5bfb706657a

We need to make sure that all the Proposal Roles (-config-default) (especially those
of the core barclamps) stay assigned to the nodes during the upgrade process.
Otherwise chef-client on the admin server (e.g. provisioner::update_nodes) will fail.

(This is same as https://github.com/crowbar/barclamp-crowbar/pull/1368 for tex)