### PR TITLE
Abort if cstruct can not be loaded

### DIFF
--- a/chef/cookbooks/ohai/recipes/default.rb
+++ b/chef/cookbooks/ohai/recipes/default.rb
@@ -76,6 +76,12 @@ unless node[:platform_family] == "windows"
       # we need to reset the paths if we can't load cstruct
       Gem.clear_paths
     end
+
+    begin
+      require "cstruct"
+    rescue LoadError
+      Chef::Log.fatal("Unable to load cstruct module - install of #{pkg} failed?")
+    end
   end
 end
 


### PR DESCRIPTION
Apparently under some circumstances installation of cstruct fails
(maybe has something to do with invalid repositories being listed)
and then the rest goes berserk. Abort early instead.