### PR TITLE
Update the target_platform attribute before upgrading the OS

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -307,8 +307,11 @@ class CrowbarService < ServiceObject
 
   def prepare_nodes_for_os_upgrade
     upgrade_nodes = NodeObject.all.reject { |node| node.admin? || node[:platform] == "windows" }
+    admin_node = NodeObject.admin_node
 
     upgrade_nodes.each do |node|
+      node["target_platform"] = admin_node["provisioner"]["default_os"]
+      node.save
       node.set_state("os-upgrading")
     end
 

--- a/crowbar_framework/lib/crowbar/upgrade.rb
+++ b/crowbar_framework/lib/crowbar/upgrade.rb
@@ -100,6 +100,18 @@ module Crowbar
           filecontent_replace(file, "nova_dashboard", "horizon")
         end
       end
+
+      # find admin node and update target_platform
+      nodes_path = knife_path.join("nodes")
+      nodes_path.children.each do |file|
+        json = JSON.load(file.read)
+        next unless json["crowbar"] && json["crowbar"]["admin_node"]
+        json.delete "target_platform"
+        json["provisioner"].delete "default_os"
+        file.open("w") do |node|
+          node.write(JSON.pretty_generate(json))
+        end
+      end
     end
 
     def crowbar_files


### PR DESCRIPTION
The nodes (including the admin node) still have the old target_platform set
(e.g. suse-11.3) change that to the new default OS.