### PR TITLE
Leave some upgrade related role for nodes in crowbar_upgrade state. 

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-db-dump.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-db-dump.rb
@@ -30,7 +30,7 @@ return unless node[:platform_family] == "suse"
 upgrade_step = node["crowbar_wall"]["crowbar_upgrade_step"] || "none"
 
 case upgrade_step
-when "openstack_shutdown"
+when "dump_openstack_database"
 
   include_recipe "crowbar::stop-services-before-upgrade"
 

--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -44,6 +44,8 @@ when "openstack_shutdown"
       done
     EOF
   end
+when "done_openstack_shutdown", "wait_for_openstack_shutdown"
+  Chef::Log.debug("Nothing to do on this node, waiting for others to finish their work...")
 else
   Chef::Log.warn("Invalid upgrade step given: #{upgrade_step}")
 end


### PR DESCRIPTION
some upgrade role assigned, so it does not lose its state.

