### PR TITLE
Raise busy timeout.

### DIFF
--- a/crowbar_framework/config/database.yml
+++ b/crowbar_framework/config/database.yml
@@ -17,8 +17,8 @@
 
 default: &default
   adapter: sqlite3
-  pool: 5
-  timeout: 5000
+  pool: 3
+  timeout: 30000
 
 development:
   <<: *default


### PR DESCRIPTION
When qa_crowbarsetup.sh renames the nodes in a loop, we're hitting
the transaction timeout as that takes more than 5s. Raise the limit
for now.