### PR TITLE
crowbar: Switch sqlite database to use write-ahead logging

### DIFF
--- a/crowbar_framework/config/database.yml
+++ b/crowbar_framework/config/database.yml
@@ -19,6 +19,7 @@ default: &default
   adapter: sqlite3
   pool: 5
   timeout: 5000
+  options: "PRAGMA journal_mode=WAL;"
 
 development:
   <<: *default


### PR DESCRIPTION
Write-ahead logging seems to be more efficient, and apparently makes the
following SQLite3::BusyException much less frequent:
```
E, [2016-01-29T09:50:45.167185 #27521] ERROR -- : SQLite3::BusyException: database is locked: begin transaction
F, [2016-01-29T09:50:45.168484 #27521] FATAL -- :
ActiveRecord::StatementInvalid (SQLite3::BusyException: database is locked: begin transaction):
  config/initializers/sqlite_transaction_monkey_patch.rb:27:in `block in begin_db_transaction'
  config/initializers/sqlite_transaction_monkey_patch.rb:27:in `begin_db_transaction'
```
For more details, see https://www.sqlite.org/wal.html