### PR TITLE
crowbar: Fix strings in installer

### DIFF
--- a/crowbar_framework/lib/crowbar/installer.rb
+++ b/crowbar_framework/lib/crowbar/installer.rb
@@ -24,7 +24,7 @@ module Crowbar
         else
           return {
             status: 501,
-            msg: I18n.t(".installers.show.system_not_supported")
+            msg: I18n.t("installer.installers.show.system_not_supported")
           }
         end
 
@@ -106,9 +106,9 @@ module Crowbar
       def error_msg
         errors = ""
         if failed?
-          errors += I18n.t(".installers.status.installation_failed")
+          errors += I18n.t("installer.installers.status.installation_failed")
         elsif !network_status[:valid]
-          errors += I18n.t(".installers.status.invalid_network")
+          errors += I18n.t("installer.installers.status.invalid_network")
           errors += " "
           errors += network_status[:msg]
         end
@@ -116,11 +116,11 @@ module Crowbar
       end
 
       def success_msg
-        I18n.t(".installers.show.installation_successful") if successful?
+        I18n.t("installer.installers.show.installation_successful") if successful?
       end
 
       def notice_msg
-        I18n.t(".installers.show.reinstall_notice")
+        I18n.t("installer.installers.show.reinstall_notice")
       end
     end
   end


### PR DESCRIPTION
The strings were not found in the library used; I assume it's because
the library is not the controller, so doesn't get the magic prefix.