### PR TITLE
provisioner: Do not set product key for Hyper-V install (bsc#964250)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -359,12 +359,19 @@ if not nodes.nil? and not nodes.empty?
           else
             raise "Unsupported version of Windows Server / Hyper-V Server"
           end
+          if os =~ /^hyperv/
+            # hyper-v server doesn't need one, and having one might actually
+            # result in broken installation
+            license_key = ""
+          else
+            license_key = mnode[:license_key] || ""
+          end
           template "#{os_dir_win}/unattend/unattended.xml" do
             mode 0644
             owner "root"
             group "root"
             source "unattended.xml.erb"
-            variables(license_key: mnode[:license_key] || "",
+            variables(license_key: license_key,
                       os_name: os,
                       image_name: image_name,
                       admin_ip: admin_ip,


### PR DESCRIPTION
The installer fails because it doesn't recognize the product key, but we
don't need one for Hyper-V.

https://bugzilla.suse.com/show_bug.cgi?id=964250