### PR TITLE
crowbar: Disable check for interface with IPv6 address for our hostname

### DIFF
--- a/crowbar_framework/lib/crowbar/checks/network.rb
+++ b/crowbar_framework/lib/crowbar/checks/network.rb
@@ -59,9 +59,10 @@ module Crowbar
         unless ipv4_configured || ipv4_addrs.empty?
           return false
         end
-        unless ipv6_configured || ipv6_addrs.empty?
-          return false
-        end
+        # we don't really depend on IPv6, so no big deal
+        #unless ipv6_configured || ipv6_addrs.empty?
+        #  return false
+        #end
 
         true
       end


### PR DESCRIPTION
This doesn't matter too much at the moment, as we don't really depend on
IPv6 anywhere, and it's possible that people would have broken DNS
records or broken network config for IPv6 (doc team just hit that, for
instance).

cc @MaximilianMeister 