### PR TITLE
Revert "Set CROWBAR_THREADS to 10 to allow concurrent access (bsc#952…

### DIFF
--- a/chef/cookbooks/crowbar/files/default/crowbar.service
+++ b/chef/cookbooks/crowbar/files/default/crowbar.service
@@ -14,7 +14,7 @@ TimeoutStopSec=10
 WorkingDirectory=/opt/dell/crowbar_framework
 
 Environment="CROWBAR_ENV=production"
-Environment="CROWBAR_THREADS=10"
+Environment="CROWBAR_THREADS=1"
 Environment="CROWBAR_WORKERS=5"
 Environment="CROWBAR_LISTEN=127.0.0.1"
 Environment="CROWBAR_PORT=3000"

--- a/chef/cookbooks/crowbar/templates/default/sysconfig.crowbar.erb
+++ b/chef/cookbooks/crowbar/templates/default/sysconfig.crowbar.erb
@@ -11,10 +11,10 @@ CROWBAR_ENV="production"
 ## Path:            Crowbar
 ## Description:     Maximum number of threads
 ## Type:            integer
-## Default:         10
+## Default:         1
 ## ServiceRestart:  crowbar
 # Sets the maximum number of threads used by the web server.
-CROWBAR_THREADS="10"
+CROWBAR_THREADS="1"
 
 ## Path:            Crowbar
 ## Description:     Maximum number of worker processes

--- a/configs/crowbar.service
+++ b/configs/crowbar.service
@@ -14,7 +14,7 @@ TimeoutStopSec=10
 WorkingDirectory=/opt/dell/crowbar_framework
 
 Environment="CROWBAR_ENV=production"
-Environment="CROWBAR_THREADS=10"
+Environment="CROWBAR_THREADS=1"
 Environment="CROWBAR_WORKERS=5"
 Environment="CROWBAR_LISTEN=127.0.0.1"
 Environment="CROWBAR_PORT=3000"

--- a/crowbar_framework/config/puma.rb
+++ b/crowbar_framework/config/puma.rb
@@ -1,7 +1,7 @@
 ROOT = File.expand_path("../../", __FILE__)
 ENVIRONMENT = ENV["CROWBAR_ENV"] || "production"
 
-THREADS = ENV["CROWBAR_THREADS"] || 10
+THREADS = ENV["CROWBAR_THREADS"] || 1
 WORKERS = ENV["CROWBAR_WORKERS"] || 5
 
 LISTEN = ENV["CROWBAR_LISTEN"] || "127.0.0.1"
@@ -34,7 +34,7 @@ bind "tcp://#{LISTEN}:#{PORT}"
 on_worker_boot do
   ::ActiveSupport.on_load(:active_record) do
     config = Rails.application.config.database_configuration[Rails.env]
-    config["pool"] = ENV["CROWBAR_THREADS"] || 10
+    config["pool"] = ENV["CROWBAR_THREADS"] || 1
 
     ::ActiveRecord::Base.establish_connection(config)
   end


### PR DESCRIPTION
…171)"

Apparently the threads make triggering of the sql transactions
deadlocks much more likely. Since PUMA doesn't do real threads
but user space threading, I don't think this is a good idea anyway..

This reverts commit fc31aaa9782e179a3c66fd0d7476a2b66290f0c8.