### PR TITLE
Retry transactions when SQLite3 is busy

### DIFF
--- a/crowbar_framework/config/initializers/sqlite_transaction_monkey_patch.rb
+++ b/crowbar_framework/config/initializers/sqlite_transaction_monkey_patch.rb
@@ -24,7 +24,16 @@ module ActiveRecord
   module ConnectionAdapters
     class SQLite3Adapter < AbstractAdapter
       def begin_db_transaction
-        log("begin transaction",nil) { @connection.transaction(:immediate) }
+        log("begin transaction", nil) do
+          5.times do
+            begin
+              @connection.transaction(:immediate)
+              break
+            rescue SQLite3::BusyException => e
+              logger.info "begin transaction fails #{e}"
+            end
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
After Balazs patch, all transactions are IMMEDIATE, adquiring
both read and write locks.  From time to time we can see
transactions that try to get both locks for more that the timeout.

This patch retry 5 times the transaction before giving up.

Fixes bsc#963738