### PR TITLE
Delete pacemaker resources after stopping.

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -31,6 +31,11 @@ when "openstack_shutdown"
 
   include_recipe "crowbar::stop-services-before-upgrade"
 
+  execute "delete pacemaker resources in non-DB cluster" do
+    command "cibadmin -E -f"
+    only_if { ::File.exist?("/usr/sbin/cibadmin") }
+  end
+
   # Stop DRBD and corosync.
   # (Note that this node is not running database)
   service "drbd" do
@@ -104,6 +109,11 @@ when "db_shutdown"
       done
     EOF
     only_if { ::File.exist?("/usr/sbin/crm") }
+  end
+
+  execute "delete pacemaker resources in DB cluster" do
+    command "cibadmin -E -f"
+    only_if { ::File.exist?("/usr/sbin/cibadmin") }
   end
 
   # Stop the database and corosync


### PR DESCRIPTION
They could be re-created once the barclamps are applied again.


1. Maybe it will not be needed, let's see...
2. Maybe some cibadmin command could do it better: cibadmin -E ?