### PR TITLE
provisioner: Add back missing safety check when deleting grub file

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -145,7 +145,7 @@ if not nodes.nil? and not nodes.empty?
         action :delete
         # Do not backup binary files
         backup false
-      end
+      end unless grubfile.nil?
 
       [grubdir].each do |d|
         directory d do
@@ -181,7 +181,7 @@ if not nodes.nil? and not nodes.empty?
         action :delete
         # Do not backup binary files
         backup false
-      end
+      end unless grubfile.nil?
 
       [grubdir].each do |d|
         directory d do


### PR DESCRIPTION
In some weird cases (deleting a node that is discovering, for instance),
there's no grub file defined.