### PR TITLE
crowbar: Fix typo in log

### DIFF
--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -79,7 +79,7 @@ module Crowbar
           raise "Restore failed"
         end
 
-        Rails.logger.info("Re-runnig chef-client locally to apply changes from imported proposals")
+        Rails.logger.info("Running chef-client locally to apply changes from imported proposals")
         system("sudo", "-i", "/opt/dell/bin/single_chef_client.sh")
 
         true


### PR DESCRIPTION
Also, not sure why we "re-run" instead of simply "run" ;-)