### PR TITLE
dont use dots for public-IP DNS names

### DIFF
--- a/chef/cookbooks/utils/libraries/helpers.rb
+++ b/chef/cookbooks/utils/libraries/helpers.rb
@@ -40,12 +40,12 @@ module CrowbarHelper
 
       # Specify default as the configured public name
       public_name = CrowbarPacemakerHelper.cluster_haproxy_vpublic_name(node)
-      public_fqdn = "public.#{cluster_vhostname}.#{node[:domain]}"
+      public_fqdn = "public-#{cluster_vhostname}.#{node[:domain]}"
       public_net_db = Chef::DataBagItem.load("crowbar", "public_network").raw_data
       public_ip = public_net_db["allocated_by_name"]["#{cluster_vhostname}.#{node[:domain]}"]["address"]
     else
       public_name = node[:crowbar][:public_name]
-      public_fqdn = "public."+node[:fqdn]
+      public_fqdn = "public-" + node[:fqdn]
       public_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "public").address
     end
 


### PR DESCRIPTION
dots make it much harder to use wildcard SSL certs,
because those can only have a \* at the beginning
and dont support _._.domain
