### PR TITLE
Do not stop openvswitch-switch before upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/stop-services-before-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/stop-services-before-upgrade.rb
@@ -39,7 +39,6 @@ bash "stop OpenStack services" do
   code <<-EOF
     for i in /etc/init.d/openstack-* \
              /etc/init.d/rabbitmq-server \
-             /etc/init.d/openvswitch-switch \
              /etc/init.d/ovs-usurp-config-* \
              /etc/init.d/hawk;
     do


### PR DESCRIPTION
Stopping openvswitch  before upgrade causes the nodes to become unreachable and upgrade gets stuck. This patch helps to avoid it. 