### PR TITLE
Block the UI when restoring _not_ from upgrade

### DIFF
--- a/crowbar_framework/app/assets/javascripts/application.js
+++ b/crowbar_framework/app/assets/javascripts/application.js
@@ -1,5 +1,22 @@
 //= require_self
 
+function setBlockUI(events, selector) {
+  selector.live(events, function(event) {
+    $.blockUI({
+      css: {
+        border: 'none',
+        padding: '15px',
+        backgroundColor: '#000',
+        '-webkit-border-radius': '10px',
+        '-moz-border-radius': '10px',
+        opacity: .5,
+        color: '#fff'
+      },
+      message: $(event.target).data('blockui')
+    });
+  });
+}
+
 jQuery(document).ready(function($) {
   $('textarea.editor').each(function() {
     var cm = CodeMirror.fromTextArea(this, {
@@ -78,20 +95,8 @@ jQuery(document).ready(function($) {
     ]
   });
 
-  $('[data-blockui]').live('submit', function(event) {
-    $.blockUI({
-      css: {
-        border: 'none',
-        padding: '15px',
-        backgroundColor: '#000',
-        '-webkit-border-radius': '10px',
-        '-moz-border-radius': '10px',
-        opacity: .5,
-        color: '#fff'
-      },
-      message: $(event.target).data('blockui')
-    });
-  });
+  setBlockUI('submit', $('[data-blockui]'));
+  setBlockUI('click', $('body.backups [data-blockui]'));
 
   $('[data-checkall]').live('change', function(event) {
     var checker = $(event.target).data('checkall');

--- a/crowbar_framework/app/controllers/backups_controller.rb
+++ b/crowbar_framework/app/controllers/backups_controller.rb
@@ -63,7 +63,7 @@ class BackupsController < ApplicationController
   # /utils/backup/restore   POST   Trigger a restore
   def restore
     respond_to do |format|
-      if @backup.restore
+      if @backup.restore(background: false)
         format.json { head :ok }
         format.html { redirect_to backups_path }
       else

--- a/crowbar_framework/app/controllers/installer/upgrades_controller.rb
+++ b/crowbar_framework/app/controllers/installer/upgrades_controller.rb
@@ -69,7 +69,7 @@ module Installer
           url = repos_upgrade_url
         else
           @backup = Backup.all.first
-          @backup.restore
+          @backup.restore(background: true)
         end
 
         respond_to do |format|

--- a/crowbar_framework/app/helpers/backups_helper.rb
+++ b/crowbar_framework/app/helpers/backups_helper.rb
@@ -39,7 +39,7 @@ module BackupsHelper
       restore_backup_path(backup.id),
       method: :post,
       class: "btn btn-success",
-      data: { confirm: t(".restore_warning") }
+      data: { confirm: t(".restore_warning"), blockui: t(".blockui_message") }
     )
   end
 

--- a/crowbar_framework/app/models/backup.rb
+++ b/crowbar_framework/app/models/backup.rb
@@ -71,9 +71,14 @@ class Backup < ActiveRecord::Base
     @data ||= extract
   end
 
-  def restore
+  def restore(options = {})
+    background = options.fetch(:background, false)
     upgrade if upgrade?
-    Crowbar::Backup::Restore.new(self).restore
+    if background
+      Crowbar::Backup::Restore.new(self).restore_background
+    else
+      Crowbar::Backup::Restore.new(self).restore
+    end
   end
 
   def upgrade?

--- a/crowbar_framework/app/views/installer/index.html.haml
+++ b/crowbar_framework/app/views/installer/index.html.haml
@@ -15,7 +15,7 @@
 
         .col-lg-4
           %h2
-            = link_to "#" do
+            = link_to backups_path do
               = icon_tag :archive, nil, class: "fa-5x"
               %p
                 = t(".restore")

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -686,6 +686,7 @@ en:
       openstack: 'OpenStack'
       restore: 'Restore'
       restore_warning: 'By pressing OK, you will start the restore of the system. Are you sure?'
+      blockui_message: 'Restoring from backup. Please wait...'
       upload_image: 'Upload Backup Image'
       create_image: 'Create Backup Image'
       download_image: 'Click to download image'

--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -41,7 +41,7 @@ module Crowbar
           send(component)
           if any_errors?
             cleanup
-            @backup.errors.add(:restore, @status)
+            @backup.errors.add(:restore, error_messages.join(" - "))
             Thread.exit if @thread
             return false
           end
@@ -122,7 +122,15 @@ module Crowbar
       end
 
       def any_errors?
-        !@status.select { |k, v| v[:status] != :ok }.empty?
+        !errors.empty?
+      end
+
+      def errors
+        @status.select { |k, v| v[:status] != :ok }
+      end
+
+      def error_messages
+        errors.values.map { |e| e[:msg] }
       end
 
       def set_step(step)

--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -41,8 +41,9 @@ module Crowbar
           send(component)
           if any_errors?
             cleanup
+            @backup.errors.add(:restore, @status)
             Thread.exit if @thread
-            return @status
+            return false
           end
           # set_failed is called directly after the fail
           if component == :restore_database && !self.class.failed_path.exist?
@@ -51,6 +52,7 @@ module Crowbar
         end
 
         cleanup
+        true
       end
 
       class << self
@@ -247,7 +249,7 @@ module Crowbar
           set_failed
           @status[:run_installer] = {
             status: :not_acceptable,
-            msg: I18n.t(".installation_failed", scope: "installers.status")
+            msg: I18n.t("installers.status.installation_failed")
           }
         end
 

--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -249,7 +249,7 @@ module Crowbar
           set_failed
           @status[:run_installer] = {
             status: :not_acceptable,
-            msg: I18n.t("installers.status.installation_failed")
+            msg: I18n.t("installer.installers.status.installation_failed")
           }
         end
 


### PR DESCRIPTION
as the restore now happens in the background (see https://github.com/crowbar/crowbar-core/pull/269), a restore from /utils/backup comes back immediately, which is not really wanted.

![restore_ongoing](https://cloud.githubusercontent.com/assets/5364817/12911281/98faba8a-cf11-11e5-93ca-d60faee3d2c8.png)
![restore_failed](https://cloud.githubusercontent.com/assets/5364817/12911283/9b656fae-cf11-11e5-9a9b-152d37878cb4.png)


btw. if we would have restored in the background here as well, the UI would have to be adapted to show the progress, maybe even create a new view (that we also link to from the installer startpage) to show progress. This is the easy solution now due to the remaining open tasks.