### PR TITLE
crowbar: Make "Default Filesystem" option only visible on SUSE platforms

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -516,6 +516,16 @@ class CrowbarService < ServiceObject
     ]
   end
 
+  def self.support_default_fs
+    [
+      "opensuse-42.1",
+      "suse-12.1",
+      "suse-12.0",
+      "suse-11.4",
+      "suse-11.3"
+    ]
+  end
+
   protected
 
   def transition_to_readying(inst, name, state, node = nil)

--- a/crowbar_framework/app/views/nodes/_form.html.haml
+++ b/crowbar_framework/app/views/nodes/_form.html.haml
@@ -26,7 +26,7 @@
       - else
         .form-group
           = f.label :target_platform, t('.target_platform')
-          = select_tag :target_platform, platforms_for_select(@node.target_platform, @node.architecture), :class => "form-control", "data-showit" => [crowbar_service.require_license_platforms.join(","), crowbar_service.support_software_raid.join(",")].join(";"), "data-showit-target" => "#license_key_container;#raid_type,#raid_disks"
+          = select_tag :target_platform, platforms_for_select(@node.target_platform, @node.architecture), :class => "form-control", "data-showit" => [crowbar_service.require_license_platforms.join(","), crowbar_service.support_software_raid.join(","), crowbar_service.support_default_fs.join(",")].join(";"), "data-showit-target" => "#license_key_container;#raid_type,#raid_disks;#default_fs_container"
           %span.help-block
             = raw t(".repo_hint", url: repositories_url)
 
@@ -107,9 +107,11 @@
         %span.help-block
           = t('.intended_role_hint')
 
-      .form-group
-        = f.label :default_fs , t('.default_fs')
-        = select_tag :default_fs, fs_for_select(@node.default_fs), :class => "form-control"
+      - if crowbar_service.support_default_fs.include?(@node.target_platform) or not @node.allocated?
+        .form-group
+          #default_fs_container
+            = f.label :default_fs , t('.default_fs')
+            = select_tag :default_fs, fs_for_select(@node.default_fs), :class => "form-control", :disabled => @node.allocated?
 
       - if have_openstack
         .form-group


### PR DESCRIPTION
This is only respected by the autoyast profile.

Also, disable the select tag if the node is allocated because, well,
it's too late to change in that case.