### PR TITLE
provisioner: Fix chef crash on admin server when forgetting nodes

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -16,7 +16,7 @@
 def find_node_boot_mac_addresses(node, admin_data_net)
   # If we don't have an admin IP allocated yet using node.macaddress is
   # our best guess for the boot macaddress
-  return [node.macaddress] if admin_data_net.nil?
+  return [node.macaddress] if admin_data_net.nil? || admin_data_net.interface_list.nil?
   result = []
   admin_interfaces = admin_data_net.interface_list
   admin_interfaces.each do |interface|


### PR DESCRIPTION
I've seen that several times, but each time I didn't have time to debug
and this change was "good enough". It's still somehow correct because if
you read the code path that sets the interface list, it can be nil when
a conduit cannot be resolved, for instance.

Of course, now that I'm trying to reproduce, I'm not able to...

cc @rhafer