### PR TITLE
run migrations before initializing the database (and afterwards)

### DIFF
--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -681,6 +681,7 @@ en:
       restore: 'Restore'
       restore_warning: 'By pressing OK, you will start the restore of the system. Are you sure?'
       restore_database_failed: 'Failed to restore database'
+      migrate_database_failed: 'Failed to migrate database'
       blockui_message: 'Restoring from backup. Please wait...'
       upload_image: 'Upload Backup Image'
       create_image: 'Create Backup Image'


### PR DESCRIPTION
also the SQLite3Exception came from the migrator, not the initializer
add some more error handling in case the database initializer fails