### PR TITLE
crowbar: Fix network switch view being broken (bsc#966051)

### DIFF
--- a/crowbar_framework/app/controllers/network_controller.rb
+++ b/crowbar_framework/app/controllers/network_controller.rb
@@ -178,9 +178,11 @@ class NetworkController < BarclampController
         status: {
           "ready" => 0,
           "failed" => 0,
-          "unknown" => 0,
+          "pending" => 0,
           "unready" => 0,
-          "pending" => 0
+          "building" => 0,
+          "crowbar_upgrade" => 0,
+          "unknown" => 0
         }
       } unless @groups.key? node.group
 
@@ -195,9 +197,11 @@ class NetworkController < BarclampController
             status: {
               "ready" => 0,
               "failed" => 0,
-              "unknown" => 0,
+              "pending" => 0,
               "unready" => 0,
-              "pending" => 0
+              "building" => 0,
+              "crowbar_upgrade" => 0,
+              "unknown" => 0
             }
           } unless @switches.key? switch[:switch]
 


### PR DESCRIPTION
The list of known status was outdated in the network controller.

https://bugzilla.suse.com/show_bug.cgi?id=966051