### PR TITLE
Remove the vhost config file of nova dashboard before upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/stop-services-before-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/stop-services-before-upgrade.rb
@@ -74,3 +74,11 @@ end
     only_if { File.exist? "/var/log/rabbitmq/#{logfile}" }
   end
 end
+
+# The vhost file for the dashboard causes apache to fail to start when reapplying
+# the horzion barclamp. Apache is started before that file is refresh. After
+# the config file refresh only a reload is done, which doesn't do anything
+# when the service is not running.
+file "/etc/apache2/vhosts.d/openstack-dashboard.conf" do
+  action :delete
+end


### PR DESCRIPTION
The config file doesn't work with apache 2.4 anymore and cause
the service to fail to start when reapplying the horzion barclamp.