### PR TITLE
On restore check for existing proposals with by name

### DIFF
--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -168,7 +168,8 @@ module Crowbar
                 bc_name, prop = filename.split("-")
                 prop.gsub!(/.json$/, "")
                 proposal = Proposal.where(
-                  barclamp: bc_name
+                  barclamp: bc_name,
+                  name: prop
                 ).first_or_initialize(
                   barclamp: bc_name,
                   name: prop


### PR DESCRIPTION
Otherwise it's not possible to restore mulitple proposals of barclamps that
allow multiple instances (e.g. pacemaker)