### PR TITLE
crowbar: Fix blockui appearing nearly all the time (bsc#966356)

### DIFF
--- a/crowbar_framework/app/assets/javascripts/application.js
+++ b/crowbar_framework/app/assets/javascripts/application.js
@@ -1,7 +1,7 @@
 //= require_self
 
 function setBlockUI(events, selector) {
-  selector.live(events, function(event) {
+  $(selector).live(events, function(event) {
     $.blockUI({
       css: {
         border: 'none',
@@ -95,9 +95,9 @@ jQuery(document).ready(function($) {
     ]
   });
 
-  setBlockUI('submit', $('[data-blockui]'));
-  setBlockUI('click', $('body.backups, [data-blockui]'));
-  setBlockUI('click', $('installer-upgrades, [data-blockui]'));
+  setBlockUI('submit', '[data-blockui]');
+  setBlockUI('click', 'body.backups, [data-blockui]');
+  setBlockUI('click', 'installer-upgrades, [data-blockui]');
 
   $('[data-checkall]').live('change', function(event) {
     var checker = $(event.target).data('checkall');


### PR DESCRIPTION
The selector evaluation should be done when we call live, not before.

https://bugzilla.suse.com/show_bug.cgi?id=966356