### PR TITLE
crowbar: Fix system() call when creating backup

### DIFF
--- a/crowbar_framework/app/controllers/logging_controller.rb
+++ b/crowbar_framework/app/controllers/logging_controller.rb
@@ -20,7 +20,7 @@ class LoggingController < BarclampController
     ctime=Time.now.strftime("%Y%m%d-%H%M%S")
     @file = "crowbar-logs-#{ctime}.tar.bz2"
     pid = fork do
-      system("sudo -i /opt/dell/bin/gather_logs.sh #{@file}")
+      system("sudo", "-i", "/opt/dell/bin/gather_logs.sh", @file)
     end
     Process.detach(pid) # reap child process automatically; don't leave running
     redirect_to "/utils?waiting=true&file=#{@file.gsub(/\./,'-DOT-')}"

--- a/crowbar_framework/app/models/backup.rb
+++ b/crowbar_framework/app/models/backup.rb
@@ -135,7 +135,7 @@ class Backup < ActiveRecord::Base
     Crowbar::Backup::Export.new(dir).export
     Dir.chdir(dir) do
       system(
-        "sudo tar czf #{path} *"
+        "sudo", "tar", "czf", path.to_s, "."
       )
     end
 


### PR DESCRIPTION
It was failing when the name of the archive had a space, and... it was
allowing command injection.