### PR TITLE
crowbar: Avoid exporting backups in the backup

### DIFF
--- a/crowbar_framework/config/initializers/yaml_db.rb
+++ b/crowbar_framework/config/initializers/yaml_db.rb
@@ -19,7 +19,7 @@ module SerializationHelper
   class Dump
     def self.tables
       ActiveRecord::Base.connection.tables.reject do |table|
-        ["schema_info", "schema_migrations", "sessions"].include?(table)
+        ["schema_info", "schema_migrations", "sessions", "backups"].include?(table)
       end
     end
   end

--- a/crowbar_framework/lib/crowbar/backup/export.rb
+++ b/crowbar_framework/lib/crowbar/backup/export.rb
@@ -123,7 +123,13 @@ module Crowbar
           else
             # copy files with higher permissions
             dest = data_dir.join(destination).to_s
-            system("sudo", "cp", "-a", source, dest)
+            if source == "/var/lib/crowbar"
+              # avoid doing an export of the existing backups, to avoid growing
+              # size of backups
+              system("sudo", "rsync", "-a", "#{source}/", "--exclude", "backup", dest)
+            else
+              system("sudo", "cp", "-a", source, dest)
+            end
           end
         end
       end


### PR DESCRIPTION
This just makes the size go exponential.
