### PR TITLE
crowbar: Remove from Backup link from installer

### DIFF
--- a/crowbar_framework/app/views/installer/index.html.haml
+++ b/crowbar_framework/app/views/installer/index.html.haml
@@ -6,21 +6,21 @@
           = t(".header")
 
       .panel-body.text-center
-        .col-lg-4
+        .col-lg-6
           %h2
             = link_to installer_path do
               = icon_tag :cloud, nil, class: "fa-5x"
               %p
                 = t(".install")
 
-        .col-lg-4
+        -#.col-lg-4
           %h2
             = link_to backups_path do
               = icon_tag :archive, nil, class: "fa-5x"
               %p
                 = t(".restore")
 
-        .col-lg-4
+        .col-lg-6
           %h2
             = link_to upgrade_path do
               = icon_tag :cloud_upload, nil, class: "fa-5x"


### PR DESCRIPTION
This just doesn't work, let's fix it later.