### PR TITLE
Protect admin server against discovered nodes with missing ohai data

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -210,6 +210,11 @@ nodes.each do |n|
       !cluster_zone[:hosts].key?(base_name_no_net) &&
       Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").nil?
     address = n[:ipaddress]
+    if address.nil?
+      # no ohai can result in this
+      Chef::Log.warn("#{n[:hostname]} in discovered state has no IP address (missing ohai data?); not adding to DNS zone")
+      next
+    end
     time = n[:ohai_time]
     use_temporary = true
 

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -16,7 +16,7 @@
 def find_node_boot_mac_addresses(node, admin_data_net)
   # If we don't have an admin IP allocated yet using node.macaddress is
   # our best guess for the boot macaddress
-  return [node.macaddress] if admin_data_net.nil? || admin_data_net.interface_list.nil?
+  return [node[:macaddress]] if admin_data_net.nil? || admin_data_net.interface_list.nil?
   result = []
   admin_interfaces = admin_data_net.interface_list
   admin_interfaces.each do |interface|


### PR DESCRIPTION
It seems there's a bug somewhere that can cause a node to not have ohai data. And this can result in breaking the chef run on the admin server, which is really bad.

So protect against this.