### PR TITLE
ipmi: Allocate address on bmc network after allocation

### DIFF
--- a/chef/data_bags/crowbar/template-ipmi.json
+++ b/chef/data_bags/crowbar/template-ipmi.json
@@ -32,7 +32,7 @@
         "mode": "full",
         "transitions": true,
         "transition_list": [
-          "discovering", "discovered"
+          "discovering", "discovered", "hardware-installing"
 	]
       } 
     }


### PR DESCRIPTION
Do not allocate an address for discovered nodes (which might not be
used), but only when the node gets allocated (reaching
hardware-installing state).