### PR TITLE
dont require nscd

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -403,6 +403,7 @@ execute "reload nscd after dns config change" do
   command "nscd -i hosts"
   action :nothing
   subscribes :run, "template[/etc/bind/db.#{node[:dns][:domain]}]"
+  only_if { File.exist?("/var/run/nscd/nscd.pid") }
 end
 
 node.set[:dns][:zones]=zones


### PR DESCRIPTION
install-suse-cloud was failing
when nscd was not installed or not running.
And since there is nothing needing it,
we make this part optional

note: also affects Cloud5, so needs backport.