### PR TITLE
batch: Fix looking for unknown aliases

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -44,7 +44,7 @@ require "easy_diff"
 require "chef/mixin/deep_merge"
 require "pp"
 
-ALIAS_REGEXP = /"(@@[^ @]+@@)"/
+ALIAS_REGEXP = /(@@[^ @]+@@)/
 ALIAS_TEMPLATE = "@@%s@@"
 
 INDENT = "   "


### PR DESCRIPTION
We were looking for quotes around the alias, while when we expand the
alias, we don't require quotes. This means that batch files not using
quotes (which is valid) for aliases will raise an exception like

/opt/dell/bin/barclamp_lib.rb:532:in `eval': (<unknown>): found character that cannot start any token while scanning for the next token at line 20 column 9 (Psych::SyntaxError)