### PR TITLE
restore: call chef-client directly

### DIFF
--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -205,7 +205,13 @@ module Crowbar
         end
 
         Rails.logger.info("Re-running chef-client locally to apply changes from imported proposals")
-        system("sudo", "-i", "/opt/dell/bin/single_chef_client.sh")
+        system(
+          "sudo",
+          "-i",
+          "/usr/bin/chef-client",
+          "-L",
+          "#{ENV["CROWBAR_LOG_DIR"]}/chef-client/#{NodeObject.admin_node.name}.log"
+        )
       end
 
       def restore_files(source, destination)


### PR DESCRIPTION
single_chef_client.sh runs in the background, and though comes back
immediately. It is better to wait here and not go in the background.
The benefit here is that we can be sure that all necessary changes
after restore are applied, and the user can continue to use the cloud
immediately after restore.
This also helps unbreaking our CI where testsetup needs the chef-server
really quickly after restore is done.