### PR TITLE
network: Don't modify ifs mash when setting node attributes

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -437,7 +437,7 @@ node.set["crowbar_wall"]["network"] ||= Mash.new
 saved_ifs = Mash.new
 ifs.each {|k,v|
   addrs = v["addresses"].map{ |a|a.to_s }.sort
-  saved_ifs[k]=v
+  saved_ifs[k] = v.dup
   saved_ifs[k]["addresses"] = addrs
 }
 Chef::Log.info("Saving interfaces to crowbar_wall: #{saved_ifs.inspect}")

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -106,7 +106,7 @@ ovs_bridge_created = false
 ::Kernel.system("killall -w -q -r '^dhclient'")
 
 # Silly little helper for sorting Crowbar networks.
-# Netowrks that use vlans and bridges will be handled later
+# Networks that use vlans and bridges will be handled later
 def net_weight(net)
   res = 0
   if node["crowbar"]["network"][net]["use_vlan"] then res += 1 end


### PR DESCRIPTION
We need to duplicate the mash because we're changing an attribute of the
variable we set to this mash -- which means, when there's no dup, that
we change the mash too.

Here, it's actually really not intended because it means we move from
IP::IP4 objects to strings. Noone noticed because the rest of the code
can live with both, but it's not intended.

Solves part of https://bugzilla.suse.com/show_bug.cgi?id=967489 (but by
luck): the order of the IP addresses for the interface is not a sorted
one, but the order in which networks are defined. It turns out that
admin is defined before bastion, so it works.