### PR TITLE
provisioner: Force server-identifier option for dhcp subnet (bsc#967489)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/dhcp_update.rb
+++ b/chef/cookbooks/provisioner/recipes/dhcp_update.rb
@@ -30,8 +30,11 @@ dhcp_subnet admin_net["subnet"] do
   network admin_net
   pools ["dhcp","host"]
   pool_options pool_opts
-  options ["option domain-name \"#{domain_name}\"",
-            "option domain-name-servers #{admin_ip}",
-            "default-lease-time #{lease_time}",
-            "max-lease-time #{lease_time}"]
+  options [
+    "server-identifier #{admin_ip}",
+    "option domain-name \"#{domain_name}\"",
+    "option domain-name-servers #{admin_ip}",
+    "default-lease-time #{lease_time}",
+    "max-lease-time #{lease_time}"
+  ]
 end


### PR DESCRIPTION
This way, we don't rely on dhcpd guessing the right IP address to use,
which might be wrong in case multiple addresses are set on the
interface.

https://bugzilla.suse.com/show_bug.cgi?id=967489