### PR TITLE
crowbar: Remove checks for non-existing node states

### DIFF
--- a/crowbar_framework/app/models/deployer_service.rb
+++ b/crowbar_framework/app/models/deployer_service.rb
@@ -70,14 +70,12 @@ class DeployerService < ServiceObject
     # After installation, there is also no client available
     #
     if [
-      "delete",
       "discovering", "discovered",
       "hardware-installing", "hardware-installed",
       "hardware-updating", "hardware-updated",
-      "reset", "reinstall",
-      "burnin-starting", "burnin-finished",
-      "completing", "completed",
       "installing", "installed",
+      "delete",
+      "reset", "reinstall",
       "update"
     ].member?(state) && !node.admin?
       @logger.debug("Deployer transition: should be deleting a client entry for #{node.name}")

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -497,7 +497,7 @@ class NodeObject < ChefObject
     # if you add new states then you MUST expand the PIE chart on the nodes index page
     subState = !state.nil? ? state.split[0].downcase : ""
     case subState
-    when "ready", "completed"
+    when "ready"
       "ready"     # green
     when "discovered", "wait", "waiting", "user", "hold", "pending", "input"
       "pending"   # flashing yellow


### PR DESCRIPTION
The following states are never set anywhere:
"burnin-starting", "burnin-finished", "completing", "completed"

~~**Note:** this contains https://github.com/crowbar/crowbar-core/pull/365~~