### PR TITLE
crowbar: Do not use @logger in forks where it's not available anymore

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1588,14 +1588,22 @@ class ServiceObject
   private
 
   def wait_for_chef_clients(node_name, options = {})
-    options = if options.fetch(:logger)
+    use_logger = options.fetch(:logger, nil)
+    options = if use_logger
       {logger: @logger}
     else
       {}
     end
-    @logger.debug("wait_for_chef_clients: Waiting for already running chef-clients on #{node_name}.")
+    if use_logger
+      @logger.debug("wait_for_chef_clients: Waiting for already running chef-clients on #{node_name}.")
+    end
     unless RemoteNode.chef_ready?(node_name, 1200, 10, options)
-      @logger.error("Waiting for already running chef-clients on #{node_name} failed.")
+      msg = "Waiting for already running chef-clients on #{node_name} failed."
+      if use_logger
+        @logger.error(msg)
+      else
+        puts(msg)
+      end
       exit(1)
     end
   end


### PR DESCRIPTION
This is what is causing these lines in the logs:
  log writing failed. closed stream