### PR TITLE
Stop dnsmasq to avoid dns queries on admin network during restore and resume later (bsc#966419)

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -360,26 +360,9 @@ admin_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin"
 # the nameserver to just the loopback interface while restoring. That however
 # needs coordination with dnsmasq which might be listening there already.
 if node["crowbar"]["admin_node"] && ::File.exist?("/var/lib/crowbar/install/restore_steps")
-  admin_if = node[:crowbar_wall][:network][:nets][:admin].first
-  bash "block incoming DNS request during install/upgrade" do
-    code <<-EOH
-      iptables -I INPUT -i #{admin_if} -p udp -m udp --dport 53 \
-        -j REJECT -m comment --comment "UPGRADE_DNSBLOCK"
-      iptables -I INPUT -i #{admin_if} -p tcp -m tcp --dport 53 \
-        -j REJECT -m comment --comment "UPGRADE_DNSBLOCK"
-    EOH
-    not_if "iptables -L INPUT | grep -q UPGRADE_DNSBLOCK"
-  end
-elsif node["crowbar"]["admin_node"]
-  admin_if = node[:crowbar_wall][:network][:nets][:admin].first
-  bash "remove upgrade dns block" do
-    code <<-EOH
-      iptables -D INPUT -i #{admin_if} -p udp -m udp --dport 53 \
-        -j REJECT -m comment --comment "UPGRADE_DNSBLOCK"
-      iptables -D INPUT -i #{admin_if} -p tcp -m tcp --dport 53 \
-        -j REJECT -m comment --comment "UPGRADE_DNSBLOCK"
-    EOH
-    only_if "iptables -L INPUT | grep -q UPGRADE_DNSBLOCK"
+  admin_addr = "127.0.0.1"
+  service "dnsmasq" do
+    action [:stop, :disable]
   end
 end
 

--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -356,12 +356,10 @@ admin_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin"
 # When we're restoring the admin node from backup or upgrade data,
 # reject incoming DNS traffic to avoid sending wrong results to running
 # clients.
-# FIXME: A cleaner approach would be to restrict the listener address of
-# the nameserver to just the loopback interface while restoring. That however
-# needs coordination with dnsmasq which might be listening there already.
-if node["crowbar"]["admin_node"] && ::File.exist?("/var/lib/crowbar/install/restore_steps")
+if node["crowbar"]["admin_node"] && ::File.exist?("/var/lib/crowbar/install/disable_dns")
   admin_addr = "127.0.0.1"
-  service "dnsmasq" do
+  service "stop dnsmasq during restore" do
+    service_name "dnsmasq"
     action [:stop, :disable]
   end
 end

--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -57,6 +57,7 @@ unless node[:platform_family] == "windows"
         # invalidate dnsmasq cache if local zone changes
         subscribes :reload, "template[/etc/bind/db.#{node[:dns][:domain]}]"
       end
+      not_if { ::File.exist?("/var/lib/crowbar/install/restore_steps") }
     end
 
     dns_list = dns_list.insert(0, "127.0.0.1").take(3)

--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -57,7 +57,7 @@ unless node[:platform_family] == "windows"
         # invalidate dnsmasq cache if local zone changes
         subscribes :reload, "template[/etc/bind/db.#{node[:dns][:domain]}]"
       end
-      not_if { ::File.exist?("/var/lib/crowbar/install/restore_steps") }
+      not_if { node["crowbar"]["admin_node"] && ::File.exist?("/var/lib/crowbar/install/disable_dns") }
     end
 
     dns_list = dns_list.insert(0, "127.0.0.1").take(3)

--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -38,6 +38,12 @@ module Crowbar
       def restore
         cleanup if self.class.restore_steps_path.exist?
 
+        # restrict dns-server to not answer requests from other nodes to
+        # avoid wrong results to clients.
+        self.class.disable_dns_path.open("w") do |f|
+          f.write "#{Time.zone.now.iso8601}\n #{@backup.path}"
+        end
+
         self.class.steps.each do |component|
           set_step(component)
           send(component)
@@ -80,6 +86,10 @@ module Crowbar
 
         def restore_steps_path
           install_dir_path.join("restore_steps")
+        end
+
+        def disable_dns_path
+          install_dir_path.join("disable_dns")
         end
 
         def install_dir_path
@@ -166,6 +176,7 @@ module Crowbar
 
       def restore_chef
         Rails.logger.debug "Restoring chef backup files"
+
         begin
           [:nodes, :roles, :clients, :databags].each do |type|
             Dir.glob(@data.join("knife", type.to_s, "**", "*")).each do |file|
@@ -216,6 +227,9 @@ module Crowbar
         rescue Net::HTTPServerException
           raise "Restore failed"
         end
+
+        # now that restore is done, dns server can answer requests from other nodes.
+        disable_dns_path.delete if disable_dns_path.exist?
 
         Rails.logger.info("Re-running chef-client locally to apply changes from imported proposals")
         system(


### PR DESCRIPTION
Fixing https://bugzilla.suse.com/show_bug.cgi?id=966419 without iptables rules and instead disable and re-enable dnsmasq service letting only the nameserver listen on 127.0.0.1 during restore. An additional state file "disable_dns" is added since the file "restore_steps" waits for completion of chef-client while enabling dns service can be done immediately after the chef-server is running.