### PR TITLE
Fix data type for "version" in Backup

### DIFF
--- a/crowbar_framework/app/models/backup.rb
+++ b/crowbar_framework/app/models/backup.rb
@@ -83,7 +83,10 @@ class Backup < ActiveRecord::Base
       return false
     end
 
-    upgrade if upgrade?
+    if upgrade? && !upgrade
+      return false
+    end
+
     if background
       Crowbar::Backup::Restore.new(self).restore_background
     else
@@ -100,7 +103,9 @@ class Backup < ActiveRecord::Base
     if upgrade.supported?
       upgrade.upgrade
     else
-      errors.add(:base, I18n.t("backups.index.upgrade_not_supported"))
+      errors.add(:base, I18n.t("backups.index.upgrade_not_supported",
+                               backup_version: version,
+                               system_version: ENV["CROWBAR_VERSION"]))
       return false
     end
   end

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -720,7 +720,7 @@ en:
       invalid_filename_exists: 'Invalid filename, backup already exists.'
       invalid_backup: 'Cannot restore from invalid backup'
       missing_backup: 'Backup does not exist'
-      upgrade_not_supported: 'Upgrade not supported'
+      upgrade_not_supported: 'Upgrade from %{backup_version} to %{system_version} not supported'
       multiple_restore: 'Restore process is already running'
       version_conflict: 'Cannot restore from different Crowbar version'
     validation:

--- a/crowbar_framework/db/migrate/20160223200120_change_backup_version_type.rb
+++ b/crowbar_framework/db/migrate/20160223200120_change_backup_version_type.rb
@@ -1,0 +1,9 @@
+class ChangeBackupVersionType < ActiveRecord::Migration
+  def up
+    change_column :backups, :version, :string
+  end
+
+  def down
+    change_column :backups, :version, :float
+  end
+end


### PR DESCRIPTION
We're treating version as a string since 3e3bc1fa33de7f83f77adcd88b8f2a23011bfd0e.