### PR TITLE
Improve how we sort interfaces when there's no interface map

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -69,7 +69,13 @@ module BarclampLibrary
         answer = map.sort{|a,b|
           aindex = Barclamp::Inventory.bus_index(bus_order, a[1]["path"])
           bindex = Barclamp::Inventory.bus_index(bus_order, b[1]["path"])
-          aindex == bindex ? a[0] <=> b[0] : aindex <=> bindex
+          if aindex != bindex
+            aindex <=> bindex
+          elsif a[1]["path"] != b[1]["path"]
+            a[1]["path"] <=> b[1]["path"]
+          else
+            a[0] <=> b[0]
+          end
         }
         answer.map! { |x| x[0] }
       end

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -927,7 +927,13 @@ class NodeObject < ChefObject
     answer = map.sort{|a,b|
       aindex = bus_index(bus_order, a[1]["path"])
       bindex = bus_index(bus_order, b[1]["path"])
-      aindex == bindex ? a[0] <=> b[0] : aindex <=> bindex
+      if aindex != bindex
+        aindex <=> bindex
+      elsif a[1]["path"] != b[1]["path"]
+        a[1]["path"] <=> b[1]["path"]
+      else
+        a[0] <=> b[0]
+      end
     }
     answer.map! { |x| x[0] }
   end


### PR DESCRIPTION
When there's no interface map, we sort interfaces by their name. Which
is kind of okay-ish, except that on first boot, the names are assigned
in a first-come first-serve basis. Which might not match the
expectation.

So instead, when there's no interface map, sort by bus order and
fallback on the name.

cc @rhafer 

Maybe something for the next version, though?