### PR TITLE
Allow subsequent restores after failure during upgrade (bsc#967848)

### DIFF
--- a/crowbar_framework/app/assets/javascripts/upgrader.js
+++ b/crowbar_framework/app/assets/javascripts/upgrader.js
@@ -19,7 +19,7 @@ $(document).ready(function() {
               $("[data-step]").addClass("hidden");
               $(".alert-success").removeClass("hidden");
             } else if (data.failed) {
-              $(".alert-danger").removeClass("hidden");
+              window.location = Routes.start_upgrade_path();
             }
           },
           error: function() {

--- a/crowbar_framework/app/controllers/installer/upgrades_controller.rb
+++ b/crowbar_framework/app/controllers/installer/upgrades_controller.rb
@@ -228,6 +228,7 @@ module Installer
         flash[:info] = t("installer.upgrades.restore.multiple_restore")
         true
       else
+        Crowbar::Backup::Restore.purge
         @backup.restore(background: true, from_upgrade: true)
       end
     end

--- a/crowbar_framework/app/controllers/installer/upgrades_controller.rb
+++ b/crowbar_framework/app/controllers/installer/upgrades_controller.rb
@@ -182,9 +182,14 @@ module Installer
     end
 
     def restore_status
+      @status = Crowbar::Backup::Restore.status
+
       respond_to do |format|
         format.json do
-          render json: Crowbar::Backup::Restore.status
+          if @status[:failed]
+            flash[:alert] = t("installer.upgrades.restore.failed")
+          end
+          render json: @status
         end
         format.html do
           redirect_to install_upgrade_url

--- a/crowbar_framework/app/views/installer/upgrades/restore.html.haml
+++ b/crowbar_framework/app/views/installer/upgrades/restore.html.haml
@@ -29,11 +29,6 @@
                     t("installer.upgrades.restore.#{step}"),
                     class: "fa-fw fa-spinner"
 
-              .alert.alert-danger.hidden
-                = icon_tag "exclamation",
-                  t(".failed"),
-                  class: "fa-fw"
-
               .alert.alert-success.hidden
                 = icon_tag "check",
                   t(".success"),

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -586,8 +586,9 @@ en:
         header: 'Restore'
         success: 'Restoration successful.'
         failed: |
-          'Restoration failed. Please check the logs at /var/log/crowbar/production.log and
-          /var/log/crowbar/install.log'
+          Restoration failed. Please check the logs at /var/log/crowbar/production.log and
+          /var/log/crowbar/install.log. Please repeat the 'Upload and Restore' process after
+          the conflict is resolved.
         schema_migration_failed: 'Schema migration for %{bc_name} failed'
         restore_button: 'Restore'
         multiple_restore: 'Restore process is already running'

--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -91,6 +91,13 @@ module Crowbar
           install_dir_path.join("crowbar-restore-ok")
         end
 
+        def purge
+          [:restore_steps, :failed, :success].each do |p|
+            send("#{p}_path").delete if send("#{p}_path").exist?
+          end
+          Crowbar::Installer.failed_path.delete if Crowbar::Installer.failed_path.exist?
+        end
+
         protected
 
         def steps_done

--- a/crowbar_framework/lib/crowbar/installer.rb
+++ b/crowbar_framework/lib/crowbar/installer.rb
@@ -68,16 +68,28 @@ module Crowbar
         }
       end
 
+      def failed_path
+        lib_path.join("crowbar-install-failed")
+      end
+
+      def success_path
+        lib_path.join("crowbar-installed-ok")
+      end
+
+      def installing_path
+        lib_path.join("crowbar_installing")
+      end
+
       def failed?
-        lib_path.join("crowbar-install-failed").exist?
+        failed_path.exist?
       end
 
       def successful?
-        lib_path.join("crowbar-installed-ok").exist?
+        success_path.exist?
       end
 
       def installing?
-        lib_path.join("crowbar_installing").exist?
+        installing_path.exist?
       end
 
       def initial_chef_client?


### PR DESCRIPTION
Instead of a `Retrigger restore` button it was discussed and suggested by @kwwii to simply redirect to the start upgrade page and repeat the process after the conflict is resolved.
After the redirect an error message with details how to solve the conflict is displayed.

**DEPENDS ON** https://github.com/crowbar/crowbar-core/pull/361 where the backup is deleted from the filesystem...