### PR TITLE
Add user notification about wiping attached disks during Allocate Node(bsc#845602)

### DIFF
--- a/crowbar_framework/app/views/nodes/_form.html.haml
+++ b/crowbar_framework/app/views/nodes/_form.html.haml
@@ -9,7 +9,7 @@
           %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".save") }
 
           - unless @node.allocated? or @node.admin?
-            %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".allocate") }
+            %input.btn.btn-default{ type: "submit", name: "submit", value: t(".allocate"), data: { confirm: t(".confirm_allocate"), title: t(".allocate_tooltip") } }
 
     .panel-body
       - if @node.allocated?
@@ -127,4 +127,4 @@
         %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".save") }
 
         - unless @node.allocated? or @node.admin?
-          %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".allocate") }
+          %input.btn.btn-default{ type: "submit", name: "submit", value: t(".allocate"), data: { confirm: t(".confirm_allocate"), title: t(".allocate_tooltip") } }

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -441,6 +441,8 @@ en:
       identify: 'Identify'
     form:
       allocate: 'Allocate'
+      confirm_allocate: 'Allocating the node will format all the disks attached to this node, including shared disks. Do you want to proceed and allocate this node?'
+      allocate_tooltip: 'Allocate this node according to the parameters in this form'
       repo_hint: 'To find out why a platform is disabled, check the <a href="%{url}">status of repositories</a>.'
       save: 'Save'
       raid: 'RAID'


### PR DESCRIPTION
Workaround fix for https://bugzilla.suse.com/show_bug.cgi?id=845602
Adds notification to user that the shared disks will be wiped during allocate (hardware and OS installation) of a discovered node.
Link to the UI Screenshot with the popup: 
![screenshot_20160229_153628](https://cloud.githubusercontent.com/assets/13483069/13490378/74ae8ff8-e12c-11e5-8303-05dfc71550ef.png)
