### PR TITLE
Fix looking for unknown aliases

### DIFF
--- a/crowbar_framework/app/models/batch/base.rb
+++ b/crowbar_framework/app/models/batch/base.rb
@@ -18,7 +18,7 @@
 
 module Batch
   class Base < Tableless
-    ALIAS_REGEXP = /"(@@[^ @]+@@)"/
+    ALIAS_REGEXP = /(@@[^ @]+@@)/
     ALIAS_TEMPLATE = "@@%s@@".freeze
 
     attr_accessor(


### PR DESCRIPTION
We were looking for quotes around the alias, while when we expand the
alias, we don't require quotes.

This is a followup PR for
https://github.com/crowbar/crowbar-core/pull/349 which solved this issue
for the old CLI tools.