### PR TITLE
Modal implementation for warning allocate node

### DIFF
--- a/crowbar_framework/app/views/nodes/_form.html.haml
+++ b/crowbar_framework/app/views/nodes/_form.html.haml
@@ -9,7 +9,7 @@
           %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".save") }
 
           - unless @node.allocated? or @node.admin?
-            %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".allocate") }
+            %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".allocate"), "data-remote" => true, "data-confirm" => t(".confirm_allocate"), :title => t(".allocate_tooltip") }
 
     .panel-body
       - if @node.allocated?
@@ -127,4 +127,4 @@
         %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".save") }
 
         - unless @node.allocated? or @node.admin?
-          %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".allocate") }
+          %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".allocate"), "data-remote" => true, "data-confirm" => t(".confirm_allocate"), :title => t(".allocate_tooltip") }

--- a/crowbar_framework/app/views/nodes/_form.html.haml
+++ b/crowbar_framework/app/views/nodes/_form.html.haml
@@ -9,7 +9,8 @@
           %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".save") }
 
           - unless @node.allocated? or @node.admin?
-            %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".allocate"), "data-remote" => true, "data-confirm" => t(".confirm_allocate"), :title => t(".allocate_tooltip") }
+            .btn.btn-default{ data: { toggle: "modal", target: "#node_allocate_modal" } }
+              = t(".allocate")
 
     .panel-body
       - if @node.allocated?
@@ -127,4 +128,23 @@
         %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".save") }
 
         - unless @node.allocated? or @node.admin?
-          %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".allocate"), "data-remote" => true, "data-confirm" => t(".confirm_allocate"), :title => t(".allocate_tooltip") }
+          .btn.btn-default{ data: { toggle: "modal", target: "#node_allocate_modal" } }
+            = t(".allocate")
+
+.modal.fade{ id: "node_allocate_modal" }
+  .modal-dialog
+    .modal-content
+      .modal-header
+        .btn.close{ data: {dismiss: "modal" } }
+          &times
+        %h2
+          = t(".allocate_node")
+      = form_for :node, :url => update_node_path(@node.handle), class: "btn btn-danger", "data-remote" => true, :html => { :role => "form", "data-type" => "html", "data-method" => "put" } do |f|
+        .modal-body
+          %h3
+            = t(".confirm_allocate")
+        .modal-footer
+          .row
+            .btn.btn-default{ data: { dismiss: "modal" } }
+              = t("cancel")
+            = f.submit(class: "btn btn-danger", value: t(".allocate"))

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -444,6 +444,8 @@ en:
       identify: 'Identify'
     form:
       allocate: 'Allocate'
+      confirm_allocate: 'WARNING! Allocating the node will wipe all the disks attached to the node including the shared disks. Proceed?'
+      allocate_tooltip: 'Cleanup and Allocate node with the intended role'
       repo_hint: 'To find out why a platform is disabled, check the <a href="%{url}">status of repositories</a>.'
       save: 'Save'
       raid: 'RAID'

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -444,8 +444,8 @@ en:
       identify: 'Identify'
     form:
       allocate: 'Allocate'
+      allocate_node: 'Allocate Node'
       confirm_allocate: 'WARNING! Allocating the node will wipe all the disks attached to the node including the shared disks. Proceed?'
-      allocate_tooltip: 'Cleanup and Allocate node with the intended role'
       repo_hint: 'To find out why a platform is disabled, check the <a href="%{url}">status of repositories</a>.'
       save: 'Save'
       raid: 'RAID'


### PR DESCRIPTION
Modal implementation to warn user on node allocate. This is an alternative to using data-confirm message popups which show a check box allowing the user to disable future popups. The implementation needs to be extended to other warning popups in the crowbar UI. Depends on https://github.com/crowbar/crowbar-core/pull/383
![screenshot_20160302_120839](https://cloud.githubusercontent.com/assets/13483069/13491027/4567b004-e130-11e5-871e-afb248a4d59c.png)
