### PR TITLE
provisioner: Fix alternatives when upgrading to SLES 12 SP1

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
@@ -108,6 +108,18 @@
         </source>
       </script>
 <% end -%>
+      <script>
+        <chrooted config:type="boolean">true</chrooted>
+        <debug config:type="boolean">true</debug>
+        <filename>fix_alternatives</filename>
+        <source>
+          <![CDATA[
+          # python-related alternatives are not updated, even though the binary
+          # names changed (2.6 to 2.7); fix that
+          yes '' | update-alternatives --force --all
+          ]]>
+        </source>
+      </script>
     </chroot-scripts>
     <init-scripts config:type="list">
       <!-- /bugfix bnc#886238: https://bugzilla.novell.com/show_bug.cgi?id=886238 -->


### PR DESCRIPTION
We can have broken alternatives when upgrading for python-related
packages: the reason is that the alternatives are registered for the
2.6 scripts but never removed since the packages are not uninstalled
but simply updated (and on update, we register the 2.7 scripts for the
alternatives).

It's technically a bug in the python packages, but I doubt it'll get
fixed.

For instance, after upgrade, we have this alternative:
 testr -> /usr/bin/testr-2.6
And what happens:
 - python-os-testr was installed on SLES 11 SP3 and created this
   alternative;
 - on the upgrade, the scriptlet that would remove the alternative is
   not run because the package is not removed (just updated);
 - the updated package created a new alternative (/usr/bin/testr-2.7)
   but doesn't remove the old outdated alternative
 - the link group for testr is in automatic mode, but nothing triggers a
   check whether it's still valid, so testr still points to testr-2.6.

The manual of update-alternatives says that we can run
  yes '' | update-alternatives --force --all
to fix all broken alternatives. So let's do that!