### PR TITLE
[3.0] dont run 'ip' on windows

### DIFF
--- a/chef/cookbooks/bmc-nat/recipes/client.rb
+++ b/chef/cookbooks/bmc-nat/recipes/client.rb
@@ -16,6 +16,7 @@
 # Note : This script runs on both the admin and compute nodes.
 # It intentionally ignores the bios->enable node data flag.
 
+return if node[:platform_family] == "windows"
 nets = node[:crowbar][:network] || return
 nets[:bmc] && nets[:admin] || return
 bmc_subnet    = nets[:bmc][:subnet]


### PR DESCRIPTION
I think we dont really need these routes anyway
and this breaks chef on windows in the QA clouds
because they use bmc-nat mode

(backport of #388 )