### PR TITLE
3.0 | Hide windows licence properly (bsc#954911)

### DIFF
--- a/crowbar_framework/app/assets/javascripts/application.js
+++ b/crowbar_framework/app/assets/javascripts/application.js
@@ -240,11 +240,11 @@ jQuery(document).ready(function($) {
   $('[data-listsearch]').listSearch();
   $('[data-ledupdate]').ledUpdate();
   $('[data-show-for-clusters-only="true"]').hideShowClusterConf();
+  $('[data-hidetext]').hideShowText();
 
   $('#proposal_attributes, #proposal_deployment').changedState();
   $('#nodelist').nodeList();
   $('input[type=password]').hideShowPassword();
-  $('[data-hidetext]').hideShowText();
 
   setInterval(
     function() {

--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -151,7 +151,7 @@ module NodesHelper
 
         if CrowbarService.require_license_key? @node.target_platform
           value = if @node.license_key
-            content_tag(:span, @node.license_key, "data-hidetext" => "pull-right")
+            hidetext_tag(@node.license_key, class: "pull-right")
           else
             value_for(nil, t("model.attributes.node.license_key_not_set"))
           end

--- a/crowbar_framework/app/helpers/tag_helper.rb
+++ b/crowbar_framework/app/helpers/tag_helper.rb
@@ -42,6 +42,20 @@ module TagHelper
     end
   end
 
+  def hidetext_tag(text, options = {})
+    placeholder = "&#149;" * text.length
+
+    content_tag(
+      :span,
+      placeholder.html_safe,
+      data: {
+        hidetext: true,
+        hidetext_secret: text,
+        hidetext_class: options.delete(:class)
+      }
+    )
+  end
+
   def tooltip_tag(text, options = {})
     options[:data] = {
       tooltip: true,

--- a/crowbar_framework/vendor/assets/javascripts/jquery/hideShowText.js
+++ b/crowbar_framework/vendor/assets/javascripts/jquery/hideShowText.js
@@ -20,15 +20,13 @@
 ;(function($) {
   function HideShowText(el, options) {
     this.$el = $(el);
-     
+
     this.defaults = {
-      hidden: false,
-      secret: '',
-      target: 'hidetext-secret',
-      classes: this.$el.data('hidetext'),
+      secretTarget: 'hidetext-secret',
+      classTarget: 'hidetext-class',
       firstToggle: true
     };
-     
+
     this.options = $.extend(
       this.defaults,
       options
@@ -36,52 +34,89 @@
 
     this.init();
   }
-   
+
   HideShowText.prototype.init = function() {
     var self = this;
-    
-    this.$el.data(this.options.target, this.$el.text());
-    self.createSecretString();
-    self.toggleText();
-     
-    this.$el.on('click', 'div.toggle-text', function(e) {
+    var secret;
+    var placeholder;
+
+    if (self.$el.data(self.options.secretTarget) === undefined) {
+      secret = self.$el.text();
+      placeholder = self.createSecret(secret);
+    } else {
+      secret = self.$el.data(self.options.secretTarget);
+      placeholder = self.createSecret(secret);
+    }
+
+    self.$el.data(
+      self.options.secretTarget,
+      secret
+    );
+
+    self.writeContent(
+      placeholder
+    );
+
+    self.$el.on('click', 'div.toggle-text', function(e) {
       e.preventDefault();
       self.toggleText();
     });
   };
 
-  HideShowText.prototype.createSecretString = function() {
-    for (var i = 0; i < this.$el.text().length; i++)  {
-      this.options.secret += "&#149;";
-    }
-  }
-   
   HideShowText.prototype.toggleText = function() {
-    if (this.options.firstToggle) {
-      this.$el.text("");
-      this.$el.append("<span class=\"hidetext-text\">" + this.options.secret + "</span> <div class=\"toggle-text toggle-text-show " + this.options.classes + "\">&nbsp;</div>");
-      this.options.firstToggle = false;
-      this.options.hidden = true;
-    } else {
-      var text;
+    var self = this;
 
-      if (this.options.hidden) {
-        text = this.$el.data(this.options.target);
-        this.options.hidden = false;
-      } else {
-        text = this.options.secret;
-        this.options.hidden = true;
-      }
+    var inner = self.$el
+      .find('.hidetext-text')
+      .text();
 
-      this.$el
-        .children('.hidetext-text')
-          .html(text)
-        .end()
-        .children('.toggle-text')
-          .toggleClass('toggle-text-show toggle-text-hide');
-    }
+    var outer = self.$el
+      .data(self.options.secretTarget);
+
+    self.$el
+      .data(self.options.secretTarget, inner)
+      .children('.hidetext-text')
+        .html(outer)
+      .end()
+      .children('.toggle-text')
+        .toggleClass('toggle-text-show toggle-text-hide');
   };
-   
+
+  HideShowText.prototype.createSecret = function(secret) {
+    var self = this;
+    var placeholder = '';
+
+    for (var i = 0; i < secret.length; i++)  {
+      placeholder += "&#149;";
+    }
+
+    return placeholder;
+  };
+
+  HideShowText.prototype.writeContent = function(secret) {
+    var self = this;
+
+    self.$el
+      .text("")
+      .append(
+        [
+          '<span class="hidetext-text">',
+            '{0}',
+          '</span>',
+          '<div class="toggle-text toggle-text-show {1}">',
+            '&nbsp;',
+          '</div>'
+        ].join(
+          ''
+        ).format(
+          secret,
+          self.$el.data(
+            self.options.classTarget
+          )
+        )
+      );
+  };
+
   $.fn.hideShowText = function(options) {
     return this.each(function() {
       new HideShowText(this, options);


### PR DESCRIPTION
I have refactored the hideShowText jQuery plugin to respect serverside
hidden rendered passwords and license keys. With the old code you can
always see the license for a short amount of time. Now the hidden text
gets already rendered on the serverside.

https://bugzilla.suse.com/show_bug.cgi?id=954911
(cherry picked from commit e1a8d4867a737f204f2bf375b6cc605ec59b30f2)