### PR TITLE
[3.0] Check if we can ssh to nodes before trying to apply proposal (bsc#968436)

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -103,7 +103,10 @@ class CrowbarService < ServiceObject
 
   def dump_openstack_database
     db_nodes = []
-    NodeObject.find("state:crowbar_upgrade").each do |node|
+    upgrade_nodes = NodeObject.find("state:crowbar_upgrade")
+    check_if_nodes_are_available upgrade_nodes
+
+    upgrade_nodes.each do |node|
 
       # In this step, we need to run action only for database nodes, others will have dummy run.
       step = "done_openstack_shutdown"

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -282,6 +282,7 @@ en:
       template_missing: 'Template for %{name} does not exist'
       unknown_error: 'An unknown error occured'
       database_missing: 'Database service is not running on any node.'
+      nodes_not_available: 'Problems while connecting to nodes %{names}. Check if the nodes are running and reachable before you continue with the upgrade.'
     attributes:
       node:
         name: 'Full Name'


### PR DESCRIPTION
When a node went offline during upgrade, the process will fail and partially
commited proposal moves nodes to wrong state. Better check if the nodes
are accessible before applying upgrade related actions.

(cherry picked from commit c9d522008937d5ded7baf63d2c6fd48fb1c01dd4)