### PR TITLE
[3.0] Claim RAID disks when node is ready, not earlier

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -190,8 +190,9 @@ class CrowbarService < ServiceObject
         return [404, "Node not found"]
       end
 
-      if state == "readying"
-        transition_to_readying inst, name, state, node
+      if state == "ready" && !node.admin?
+        # we need to claim raids when we already have ohai data, i.e. after first chef-client run
+        process_raid_claims node
       end
 
       if %w(hardware-installing hardware-updating update).include? state
@@ -569,12 +570,6 @@ class CrowbarService < ServiceObject
   end
 
   protected
-
-  def transition_to_readying(inst, name, state, node = nil)
-    only_unless_admin node do
-      process_raid_claims node
-    end
-  end
 
   def process_raid_claims(node)
     unless node.raid_type == "single"

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1433,7 +1433,7 @@ class NodeObject < ChefObject
     if device
       crowbar_wall[:claimed_disks] ||= {}
 
-      unless disk_owner(device) == owner
+      if owner.empty? || disk_owner(device) != owner
         return false
       end
 


### PR DESCRIPTION
We need to wait for the first chef-client run to gather ohai data

(cherry picked from commit 365dab2fda629fe6754867984f46f1776028bf0c)

This is actually forward-port from tex branch...
