### PR TITLE
fix autoload of crowbar libs

### DIFF
--- a/crowbar_framework/lib/crowbar.rb
+++ b/crowbar_framework/lib/crowbar.rb
@@ -20,11 +20,11 @@ module Crowbar
     File.expand_path("../crowbar/backup", __FILE__)
 
   autoload :Installer,
-    File.expand_path("../installer.rb", __FILE__)
+    File.expand_path("../crowbar/installer", __FILE__)
 
   autoload :Migrate,
-    File.expand_path("../migrate.rb", __FILE__)
+    File.expand_path("../crowbar/migrate", __FILE__)
 
   autoload :Upgrade,
-    File.expand_path("../upgrade.rb", __FILE__)
+    File.expand_path("../crowbar/upgrade", __FILE__)
 end


### PR DESCRIPTION
this hasn't been noticed yet as we are loading all libs in application.rb anyways

@vuntz @aspiers shall we fix it here or shall we drop it completely following up on the discussion on the autoloading?