### PR TITLE
backup: cleanup with higher permissions

### DIFF
--- a/crowbar_framework/app/models/backup.rb
+++ b/crowbar_framework/app/models/backup.rb
@@ -110,7 +110,14 @@ class Backup < ActiveRecord::Base
   end
 
   def cleanup
-    @data.rmtree if @data
+    return unless @data
+
+    system(
+      "sudo",
+      "rm",
+      "-rf",
+      @data.to_s
+    )
     @data = nil
   end
 

--- a/crowbar_framework/app/models/backup.rb
+++ b/crowbar_framework/app/models/backup.rb
@@ -110,7 +110,7 @@ class Backup < ActiveRecord::Base
   end
 
   def cleanup
-    return unless @data || @data.to_s =~ /\A#{Rails.root.join("tmp").to_s}/
+    return unless @data || @data.to_s =~ /\A#{Dir.tmpdir}/
 
     system(
       "sudo",

--- a/crowbar_framework/app/models/backup.rb
+++ b/crowbar_framework/app/models/backup.rb
@@ -110,7 +110,7 @@ class Backup < ActiveRecord::Base
   end
 
   def cleanup
-    return unless @data
+    return unless @data || @data.to_s =~ /\A#{Rails.root.join("tmp").to_s}/
 
     system(
       "sudo",

--- a/crowbar_framework/config/initializers/tmpdir.rb
+++ b/crowbar_framework/config/initializers/tmpdir.rb
@@ -19,7 +19,7 @@ class Dir
   class << self
     def mktmpdir_with_rails_context(prefix_suffix = nil, tmp_dir = nil, *rest)
       # set tmp dir to application tmp dir
-      tmp_dir = Rails.root.join("tmp").to_s if tmp_dir.nil?
+      tmp_dir = tmpdir_with_rails_context if tmp_dir.nil?
       # determine the caller
       call = caller_locations(1, 1).first.label
       # set caller prefix to the directory name
@@ -31,5 +31,15 @@ class Dir
     end
 
     alias_method_chain :mktmpdir, :rails_context
+
+    def tmpdir_with_rails_context(systemdir = false)
+      if systemdir
+        tmpdir_without_rails_context
+      else
+        Rails.root.join("tmp").to_s
+      end
+    end
+
+    alias_method_chain :tmpdir, :rails_context
   end
 end


### PR DESCRIPTION
as there are files belonging to root in the rails tmp dir they
need to be removed with higher permissions

from the backup/restore CI:
```
Errno::EACCES (Permission denied @ dir_initialize - /opt/dell/crowbar_framework/tmp/create_archive-20160314-14811-fyefs2/crowbar/root/.ssh):
  app/models/backup.rb:110:in `cleanup'
  app/controllers/backups_controller.rb:58:in `create'
```