### PR TITLE
[stable/3.0] Backport from #383 (bsc#845602)

### DIFF
--- a/crowbar_framework/app/views/nodes/_form.html.haml
+++ b/crowbar_framework/app/views/nodes/_form.html.haml
@@ -9,7 +9,7 @@
           %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".save") }
 
           - unless @node.allocated? or @node.admin?
-            %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".allocate") }
+            %input.btn.btn-default{ type: "submit", name: "submit", value: t(".allocate"), data: { confirm: t(".confirm_allocate"), title: t(".allocate_tooltip") } }
 
     .panel-body
       - if @node.allocated?
@@ -127,4 +127,4 @@
         %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".save") }
 
         - unless @node.allocated? or @node.admin?
-          %input.btn.btn-default{ :type => "submit", :name => "submit", :value => t(".allocate") }
+          %input.btn.btn-default{ type: "submit", name: "submit", value: t(".allocate"), data: { confirm: t(".confirm_allocate"), title: t(".allocate_tooltip") } }

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -450,6 +450,8 @@ en:
       invalid_req: 'Invalid hit request %{req}'
     form:
       allocate: 'Allocate'
+      confirm_allocate: 'Allocating the node will format all the disks attached to this node, including shared disks. Do you want to proceed and allocate this node?'
+      allocate_tooltip: 'Allocate this node according to the parameters in this form'
       repo_hint: 'To find out why a platform is disabled, check the <a href="%{url}">status of repositories</a>.'
       save: 'Save'
       raid: 'RAID'


### PR DESCRIPTION
Workaround fix for https://bugzilla.suse.com/show_bug.cgi?id=845602
Adds notification to user that the shared disks will be wiped during allocate (hardware and OS installation) of a discovered node.

(cherry picked from commit 3fdc66bbd8ad32a42f6d2a2e7f66040ced87b34f)