### PR TITLE
upgrade: add back end part of prepare in cloud 6

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -37,17 +37,11 @@ when "crowbar_upgrade"
 
   bash "disable_openstack_services" do
     code <<-EOF
-      for i in /etc/init.d/openstack-* \
-               /etc/init.d/openvswitch-switch \
-               /etc/init.d/ovs-usurp-config-* \
-               /etc/init.d/drbd \
-               /etc/init.d/openais;
+      for i in $(systemctl list-units openstack* --no-legend | cut -d" " -f1) \
+               drbd.service \
+               pacemaker.service;
       do
-        if test -e $i
-        then
-          initscript=`basename $i`
-          chkconfig -d $initscript
-        fi
+        systemctl disable $i
       done
     EOF
   end

--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -27,6 +27,42 @@ return unless node[:platform_family] == "suse"
 upgrade_step = node["crowbar_wall"]["crowbar_upgrade_step"] || "none"
 
 case upgrade_step
+
+when "crowbar_upgrade"
+
+  # Disable openstack services
+  # We don't know which openstack services are enabled on the node and
+  # collecting that information via the attributes provided by chef is
+  # rather complicated. So instead we fall back to a simple bash hack
+
+  bash "disable_openstack_services" do
+    code <<-EOF
+      for i in /etc/init.d/openstack-* \
+               /etc/init.d/openvswitch-switch \
+               /etc/init.d/ovs-usurp-config-* \
+               /etc/init.d/drbd \
+               /etc/init.d/openais;
+      do
+        if test -e $i
+        then
+          initscript=`basename $i`
+          chkconfig -d $initscript
+        fi
+      done
+    EOF
+  end
+
+  # Disable crowbar-join
+  service "crowbar_join" do
+    # do not stop it, it would change node's state
+    action :disable
+  end
+
+  # Disable chef-client
+  service "chef-client" do
+    action [:disable, :stop]
+  end
+
 when "openstack_shutdown"
 
   include_recipe "crowbar::stop-services-before-upgrade"

--- a/crowbar_framework/app/controllers/installer/upgrades_controller.rb
+++ b/crowbar_framework/app/controllers/installer/upgrades_controller.rb
@@ -23,6 +23,25 @@ module Installer
     before_filter :set_progess_values
     before_filter :set_service_object, only: [:services, :backup, :nodes]
 
+    def prepare
+      status = :ok
+
+      begin
+        service_object = CrowbarService.new(Rails.logger)
+
+        service_object.prepare_nodes_for_crowbar_upgrade
+      rescue => e
+        Rails.logger.error e.message
+        status = :unprocessable_entity
+      end
+
+      respond_to do |format|
+        format.html do
+          head :no_content, status: status
+        end
+      end
+    end
+
     def show
       respond_to do |format|
         format.html do

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -580,6 +580,10 @@ en:
         backup: 'Data Backup'
         nodes: 'Upgrading Nodes OS'
         finishing: 'Finishing Upgrade'
+      prepare:
+        nodes_not_ready: |
+          Some nodes are not ready: %{nodes}.
+          Fix the state of nodes before proceeding with the upgrade.
       start:
         cancel: 'Abort Upgrade'
         continue: 'Upload and Restore'

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -164,6 +164,7 @@ Rails.application.routes.draw do
       only: [:show],
       controller: "installer/upgrades" do
       member do
+        post :prepare
         get :start
         post :start
         get :restore


### PR DESCRIPTION
the whole backend part of the prepare step needed to be forward ported
from cloud 5

cc @jsuchome 

this would replace https://github.com/SUSE-Cloud/automation/pull/912