### PR TITLE
Add development gems for benchmarking

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -59,6 +59,8 @@ unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
     gem "brakeman", "~> 2.6.3"
     gem "rspec-rails", "~> 3.3.0"
     gem "byebug", "~> 8.2.2"
+    gem "derailed_benchmarks", "~> 1.3.0"
+    gem "stackprof", "~> 0.2.8"
   end
 
   group :test do


### PR DESCRIPTION
See [schneems/derailed_benchmarks](https://github.com/schneems/derailed_benchmarks) for more information.

This gems helps us the find performance issues in long term it would be also nice to have a basic benchmarking in the gating.