### PR TITLE
crowbar, provisioner: Change default FS to btrfs

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -344,7 +344,7 @@ if not nodes.nil? and not nodes.empty?
                       architecture: arch,
                       is_ses: storage_available && !cloud_available,
                       crowbar_join: "#{os_url}/crowbar_join.sh",
-                      default_fs: mnode[:crowbar_wall][:default_fs] || "ext4",
+                      default_fs: mnode[:crowbar_wall][:default_fs] || "btrfs",
                       needs_openvswitch:
                         (mnode[:network] && mnode[:network][:needs_openvswitch]) || false
             )

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -299,7 +299,7 @@ class NodeObject < ChefObject
   end
 
   def default_fs
-    crowbar_wall["default_fs"] || "ext4"
+    crowbar_wall["default_fs"] || "btrfs"
   end
 
   def default_fs=(value)


### PR DESCRIPTION
Let's try btrfs on all nodes to see if we hit any issue with it.

Note that this setting is only used for the SUSE platform family.
