### PR TITLE
Make rubocop default to same style as HoundCI

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,1 @@
+inherit_from: .hound.ruby.yml


### PR DESCRIPTION
This removes the need to specify `-c .hound.ruby.yml` every time you run `rubocop` from the command-line.

Originally suggested in https://github.com/crowbar/crowbar-core/pull/49#issuecomment-143750159

If this gets merged, I can submit the same change for the other repos.