### PR TITLE
crowbar: Make apply_role a bit more solid

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1341,6 +1341,11 @@ class ServiceObject
 
     update_proposal_status(inst, "success", "")
     [200, {}]
+  rescue StandardError => e
+    @logger.fatal("apply_role: Uncaught exception #{e.message} #{e.backtrace.join("\n")}")
+    message = "Failed to apply the proposal: uncaught exception (#{e.message})"
+    update_proposal_status(inst, "failed", message)
+    [405, message]
   ensure
     apply_locks.each(&:release) if apply_locks.any?
     restore_to_ready(applying_nodes) if applying_nodes.any?

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -919,6 +919,10 @@ class ServiceObject
   def apply_role(role, inst, in_queue, bootstrap = false)
     @logger.debug "apply_role(#{role.name}, #{inst}, #{in_queue}, #{bootstrap})"
 
+    # Variables used in the global ensure
+    apply_locks = []
+    applying_nodes = []
+
     # Part I: Looking up data & checks
     #
     # we look up the role in the database (if there is one), the new one is
@@ -953,9 +957,13 @@ class ServiceObject
       # Attempt to queue the proposal.  If delay is empty, then run it.
       deps = proposal_dependencies(role)
       delay, pre_cached_nodes = queue_proposal(inst, element_order, new_elements, deps)
-      # FIXME: this breaks the convention that we return a string; but really,
-      # we should return a hash everywhere, to avoid this...
-      return [202, delay] unless delay.empty?
+      unless delay.empty?
+        # force not processing the queue further
+        in_queue = true
+        # FIXME: this breaks the convention that we return a string; but really,
+        # we should return a hash everywhere, to avoid this...
+        return [202, delay]
+      end
 
       @logger.debug "delay empty - running proposal"
     end
@@ -968,7 +976,6 @@ class ServiceObject
         @logger.fatal("apply_role: Failed to expand items #{failures.inspect} for role \"#{role_name}\"")
         message = "Failed to apply the proposal: cannot expand list of nodes for role \"#{role_name}\", following items do not exist: #{failures.join(", ")}"
         update_proposal_status(inst, "failed", message)
-        process_queue unless in_queue
         return [405, message]
       end
     end
@@ -1146,10 +1153,7 @@ class ServiceObject
     # save databag with the role removal intention
     proposal.save if save_proposal
 
-    if bootstrap
-      applying_nodes = []
-      apply_locks = []
-    else
+    unless bootstrap
       applying_nodes = batches.flatten.uniq.sort
 
       # Mark nodes as applying; beware that all_nodes do not contain nodes that
@@ -1187,8 +1191,6 @@ class ServiceObject
       rescue Crowbar::Error::LockingFailure => e
         message = "Failed to apply the proposal: #{e.message}"
         update_proposal_status(inst, "failed", message)
-        restore_to_ready(applying_nodes)
-        process_queue unless in_queue
         return [409, message] # 409 is 'Conflict'
       end
 
@@ -1254,8 +1256,6 @@ class ServiceObject
       @logger.fatal("apply_role: Exception #{e.message} #{e.backtrace.join("\n")}")
       message = "Failed to apply the proposal: exception before calling chef (#{e.message})"
       update_proposal_status(inst, "failed", message)
-      restore_to_ready(applying_nodes)
-      process_queue unless in_queue
       return [405, message]
     end
 
@@ -1294,8 +1294,6 @@ class ServiceObject
         message = message + "#{pids[baddie[0]]}\n" + get_log_lines(pids[baddie[0]])
       end
       update_proposal_status(inst, "failed", message)
-      restore_to_ready(applying_nodes)
-      process_queue unless in_queue
       return [405, message]
     end
 
@@ -1309,8 +1307,6 @@ class ServiceObject
       @logger.fatal("apply_role: Exception #{e.message} #{e.backtrace.join("\n")}")
       message = "Failed to apply the proposal: exception after calling chef (#{e.message})"
       update_proposal_status(inst, "failed", message)
-      restore_to_ready(applying_nodes)
-      process_queue unless in_queue
       return [405, message]
     end
 
@@ -1344,11 +1340,11 @@ class ServiceObject
     proposal.save unless roles_to_remove.empty?
 
     update_proposal_status(inst, "success", "")
-    restore_to_ready(applying_nodes)
-    process_queue unless in_queue
     [200, {}]
   ensure
-    apply_locks.each(&:release) if apply_locks
+    apply_locks.each(&:release) if apply_locks.any?
+    restore_to_ready(applying_nodes) if applying_nodes.any?
+    process_queue unless in_queue
   end
 
   def apply_role_pre_chef_call(old_role, role, all_nodes)


### PR DESCRIPTION
We move some code that must always be run before returning in the global
ensure; this helps make sure that code is actually run in all cases.

We also catch all exceptions that aren't caught from this method to set
the status of the proposal to "failed", to avoid people being blocked by
a proposal staying forever in "applying".