### PR TITLE
apply_role: log only when needed and at the right place

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1313,9 +1313,6 @@ class ServiceObject
         non_admin_nodes << node_name
       end
 
-      @logger.debug("AR: Calling chef-client for #{role.name} on non-admin nodes #{non_admin_nodes.join(" ")}")
-      @logger.debug("AR: Calling chef-client for #{role.name} on admin nodes #{admin_list.join(" ")}")
-
       #
       # XXX: We used to do this twice - do we really need twice???
       # Yes! We do!  The system has some transient issues that are hidden
@@ -1324,6 +1321,9 @@ class ServiceObject
       #
       pids = {}
       unless non_admin_nodes.empty?
+        @logger.debug(
+          "AR: Calling chef-client for #{role.name} on non-admin nodes #{non_admin_nodes.join(" ")}"
+        )
         non_admin_nodes.each do |node|
           pre_cached_nodes[node] ||= NodeObject.find_node_by_name(node)
           nobj = pre_cached_nodes[node]
@@ -1363,6 +1363,9 @@ class ServiceObject
       end
 
       unless admin_list.empty?
+        @logger.debug(
+          "AR: Calling chef-client for #{role.name} on admin nodes #{admin_list.join(" ")}"
+        )
         admin_list.each do |node|
           filename = "#{ENV['CROWBAR_LOG_DIR']}/chef-client/#{node}.log"
           pid = run_remote_chef_client(node, Rails.root.join("..", "bin", "single_chef_client.sh").expand_path.to_s, filename)


### PR DESCRIPTION
* log message is misleading when node list is empty
* like this it is easier to see where (on which node) chef-client failed