### PR TITLE
Do OS upgrade only for nodes in crowbar_upgrade state (bsc#972527)

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -385,7 +385,9 @@ class CrowbarService < ServiceObject
   end
 
   def prepare_nodes_for_os_upgrade
-    upgrade_nodes = NodeObject.all.reject { |node| node.admin? || node[:platform] == "windows" }
+    upgrade_nodes = NodeObject.all.reject do |node|
+      node.admin? || node[:platform] == "windows" || node.state != "crowbar_upgrade"
+    end
     check_if_nodes_are_available upgrade_nodes
     admin_node = NodeObject.admin_node
     upgrade_nodes_failed = []


### PR DESCRIPTION
Fix to upgrade OS only on nodes marked for upgrade through "crowbar_upgrade" state. Other nodes (in "ready" state are not altered).

Fixes bug: https://bugzilla.suse.com/show_bug.cgi?id=972527

Co-authored by @rhafer