### PR TITLE
Treat NICs with unknown speed as 1g interfaces (bsc#975473)

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -140,7 +140,8 @@ module BarclampLibrary
         count_map = {}
         sorted_ifs.each do |intf|
           speeds = if_list[intf]["speeds"]
-          speeds = ["1g"] unless speeds   #legacy object support
+          # Assume "1g" if ohai didn't return anything
+          speeds = ["1g"] unless speeds && !speeds.empty?
           speeds.each do |speed|
             count = count_map[speed] || 1
             if_remap["#{speed}#{count}"] = intf


### PR DESCRIPTION
If ohai can't figure out the supported speed(s) of a NIC (e.g. it currently
lacks support for 40G interfaces), treat it as "normal" 1g interfaces.
This is a workaround to make such interface at least somehow usable.

partially fixes: https://bugzilla.suse.com/show_bug.cgi?id=975473