### PR TITLE
crowbar-hack: be sure that UEFI is there.

### DIFF
--- a/chef/cookbooks/crowbar-hacks/recipes/default.rb
+++ b/chef/cookbooks/crowbar-hacks/recipes/default.rb
@@ -76,7 +76,7 @@ if states.include?(node[:state])
   end
 end
 
-if node["uefi"]
+if node["uefi"] && File.exist?("/sys/firmware/efi")
   node["uefi"]["boot"]["order"].each do |order|
     entry = node["uefi"]["entries"][order]
     next if entry[:active]

--- a/chef/cookbooks/crowbar-hacks/recipes/default.rb
+++ b/chef/cookbooks/crowbar-hacks/recipes/default.rb
@@ -76,26 +76,35 @@ if states.include?(node[:state])
   end
 end
 
-if node["uefi"] && File.exist?("/sys/firmware/efi")
-  node["uefi"]["boot"]["order"].each do |order|
-    entry = node["uefi"]["entries"][order]
-    next if entry[:active]
+ruby_block "uefi_boot_order_config" do
+  block do
+    if node["uefi"] && File.exist?("/sys/firmware/efi")
+      node["uefi"]["boot"]["order"].each do |order|
+        entry = node["uefi"]["entries"][order]
+        next if entry[:active]
 
-    Chef::Log.info("Activating UEFI boot entry #{sprintf("%x", order)}: #{entry["title"]}")
-    ::Kernel.system("efibootmgr -a -b #{sprintf('%x', order)}")
+        Chef::Log.info("Activating UEFI boot entry "\
+                       "#{sprintf("%x", order)}: #{entry["title"]}")
+        ::Kernel.system("efibootmgr --active --bootnum #{format("%x", order)}")
+      end
+
+      neworder = node["uefi"]["boot"]["order"].partition do |order|
+        node["uefi"]["entries"][order]["device"] =~ /[\/)]MAC\(/i rescue false
+      end.flatten
+
+      if neworder != node["uefi"]["boot"]["order"]
+        Chef::Log.info("Change UEFI Boot Order: "\
+                       "#{node[:provisioner_state]} "\
+                       "#{node["uefi"]["boot"]["order"].inspect} "\
+                       "=> #{neworder.inspect}")
+        ::Kernel.system("efibootmgr --bootorder #{neworder.map { |e| format("%x", e) }.join(",")}")
+
+        node["uefi"]["boot"]["order_old"] = node["uefi"]["boot"]["order"]
+        node["uefi"]["boot"]["order"] = neworder
+
+        node.save
+      end
+    end
   end
-
-  neworder = node["uefi"]["boot"]["order"].partition do |order|
-    node["uefi"]["entries"][order]["device"] =~ /[\/)]MAC\(/i rescue false
-  end.flatten
-
-  if neworder != node["uefi"]["boot"]["order"]
-    Chef::Log.info("Change UEFI Boot Order: #{node[:provisioner_state]} #{node["uefi"]["boot"]["order"].inspect} => #{neworder.inspect}")
-    ::Kernel.system("efibootmgr -o #{neworder.map{ |e| sprintf("%x", e) }.join(",")}")
-
-    node["uefi"]["boot"]["order_old"] = node["uefi"]["boot"]["order"]
-    node["uefi"]["boot"]["order"] = neworder
-
-    node.save
-  end
+  action :create
 end


### PR DESCRIPTION
Fix bnc#976048

Execute the UEFI boot order configuration inside a ruby_block, to
be sure that Ohai provides all the information during the compilation
stage.

(cherry picked from commit 4a86b66)
(cherry picked from commit 99f9888)