### PR TITLE
[stable/3.0] backport #470

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
@@ -115,8 +115,10 @@
         <source>
           <![CDATA[
           # python-related alternatives are not updated, even though the binary
-          # names changed (2.6 to 2.7); fix that
-          yes '' | update-alternatives --force --all
+          # names changed (2.6 to 2.7); find all broken links and fix/update them
+          for i in $(find /etc/alternatives -type l ! -readable -printf "%f\n") ; do
+              update-alternatives --auto "$i"
+          done
           ]]>
         </source>
       </script>

--- a/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
@@ -108,6 +108,18 @@
         </source>
       </script>
 <% end -%>
+      <script>
+        <chrooted config:type="boolean">true</chrooted>
+        <debug config:type="boolean">true</debug>
+        <filename>fix_alternatives</filename>
+        <source>
+          <![CDATA[
+          # python-related alternatives are not updated, even though the binary
+          # names changed (2.6 to 2.7); fix that
+          yes '' | update-alternatives --force --all
+          ]]>
+        </source>
+      </script>
     </chroot-scripts>
     <init-scripts config:type="list">
       <!-- /bugfix bnc#886238: https://bugzilla.novell.com/show_bug.cgi?id=886238 -->


### PR DESCRIPTION
https://github.com/crowbar/crowbar-core/pull/470 is not merged yet, so I opened the backport already to trigger upgrade gating for 5to6