### PR TITLE
Revert "only skip verify_authenticity_token on json requests"

### DIFF
--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -76,7 +76,8 @@ class ApplicationController < ActionController::Base
 
   protect_from_forgery with: :exception
 
-  skip_before_action :verify_authenticity_token, if: :json_request?
+  # TODO: Disable it only for API calls
+  skip_before_action :verify_authenticity_token
 
   def self.set_layout(template = "application")
     layout proc { |controller|
@@ -119,10 +120,6 @@ class ApplicationController < ActionController::Base
   # private stuff below.
 
   private
-
-  def json_request?
-    request.format.json?
-  end
 
   def flash_and_log_exception(e)
     flash[:alert] = e.message


### PR DESCRIPTION
Reverts crowbar/crowbar-core#455

I have encountered some issues during a manual upgrade. I can't upload the backup without running into `ActionController::InvalidAuthenticityToken (ActionController::InvalidAuthenticityToken)`

This needs to be investigated further, as the authenticity token is not stored in the session, but probably in a cookie.

for now it is better to flip the switch back, and create a card for further manual testing debugging