### PR TITLE
delete old backup when uploading the same one again

### DIFF
--- a/crowbar_framework/app/controllers/installer/upgrades_controller.rb
+++ b/crowbar_framework/app/controllers/installer/upgrades_controller.rb
@@ -64,6 +64,10 @@ module Installer
 
       if request.post?
         respond_to do |format|
+          # make sure to remove any existing backup with the same name
+          old_backup = Backup.find(name: params[:file].original_filename.remove(".tar.gz"))
+          old_backup.destroy if old_backup
+
           @backup = Backup.new(params.permit(:file))
 
           if save_and_restore


### PR DESCRIPTION
the backup data always needs to be wiped, e.g. in case of an upgrade
when the first restore failed and the user tries to upload the backup
again there will be an error that the backup already exists, which is
bad