### PR TITLE
wait for the nodes to be really available

### DIFF
--- a/crowbar_framework/app/assets/javascripts/upgrader.js
+++ b/crowbar_framework/app/assets/javascripts/upgrader.js
@@ -59,7 +59,7 @@ $(document).ready(function() {
               } else {
                 $(".alert-danger").addClass("hidden");
               }
-            } else {
+            } else if (data.ready) {
               $(".alert-danger").addClass("hidden");
               $(".alert-success").removeClass("hidden");
               $(".btn-group .processing").addClass("hidden");

--- a/crowbar_framework/app/controllers/installer/upgrades_controller.rb
+++ b/crowbar_framework/app/controllers/installer/upgrades_controller.rb
@@ -267,9 +267,10 @@ module Installer
       respond_to do |format|
         format.json do
           render json: {
-            total: view_context.total_nodes_count,
+            total: view_context.all_non_admin_nodes.count,
             left: view_context.upgrading_nodes_count,
             failed: view_context.failed_nodes_count,
+            ready: view_context.nodes_ready?,
             error: I18n.t(
               "installer.upgrades.nodes_status.failed",
               nodes: NodeObject.find("state:problem").map(&:name).join(", ")

--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -16,8 +16,8 @@
 #
 
 module NodesHelper
-  def total_nodes_count
-    NodeObject.find("NOT admin_node:true").count
+  def all_non_admin_nodes
+    NodeObject.find("NOT admin_node:true")
   end
 
   def upgrading_nodes_count
@@ -26,6 +26,10 @@ module NodesHelper
 
   def failed_nodes_count
     NodeObject.find("state:problem").count
+  end
+
+  def nodes_ready?
+    all_non_admin_nodes.select { |n| n.status != "ready" }.empty?
   end
 
   def nodes_by_role(role)

--- a/crowbar_framework/app/views/installer/upgrades/finishing.html.haml
+++ b/crowbar_framework/app/views/installer/upgrades/finishing.html.haml
@@ -31,7 +31,7 @@
             .col-lg-4.text-center.text-success
               %h2
                 %strong{ data: { total: "" } }
-                  = total_nodes_count
+                  = all_non_admin_nodes_count
               %p
                 = t(".total_nodes")
 


### PR DESCRIPTION
after the upgrade of the nodes has finished, the nodes are still
in boot process.
A quick upgrader who switches to the barclamps view right after
the "Go to your Barclamps now" button is available and applies
keystone will get a flash message saying:
  "Role keystone-server can't be used for suse"

I am not sure if that really helps though, maybe even another check is necessary here to be really sure we can hit the apply button. this was just my initial idea to query the node status. any ideas?