### PR TITLE
Added support for SLES12SP2 repositories

### DIFF
--- a/crowbar_framework/config/repos-cloud.yml
+++ b/crowbar_framework/config/repos-cloud.yml
@@ -135,3 +135,119 @@ suse-12.1:
       required: "recommended"
       url:
       ask_on_error: false
+suse-12.2:
+  x86_64:
+    sles12-sp2-pool:
+      name: "SLES12-SP2-Pool"
+      required: "mandatory"
+      features: ["os"]
+      repomd:
+        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:GA/SLES/12.2/POOL/x86_64"
+        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+      url:
+      smt_path: "SUSE/Products/SLE-SERVER/12-SP2/x86_64/product"
+      ask_on_error: false
+    sles12-sp2-updates:
+      name: "SLES12-SP2-Updates"
+      required: "mandatory"
+      features: ["os"]
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP2:x86_64/update"
+        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+      url:
+      smt_path: "SUSE/Updates/SLE-SERVER/12-SP2/x86_64/update"
+      ask_on_error: false
+    cloud:
+      name: "Cloud"
+      required: "mandatory"
+      features: ["openstack"]
+      repomd:
+        tag: ["obsproduct://build.suse.de/SUSE:SLE-12-SP2:Update:Products:Cloud7/suse-openstack-cloud/7/cd/x86_64",
+              "obsproduct://build.suse.de/Devel:Cloud:7:Mitaka/suse-openstack-cloud/7/cd/x86_64",
+              "obsproduct://build.suse.de/Devel:Cloud:7:Staging/suse-openstack-cloud/7/cd/x86_64",
+              "obsproduct://build.suse.de/Devel:Cloud:7/suse-openstack-cloud/7/cd/x86_64"]
+        key_md5: ["9a62177e1c6852d48453ed3909956d6b", "6e2920076653964b7de9d6d0421955bb"]
+      url:
+      ask_on_error: false
+    suse-openstack-cloud-7-pool:
+      name: "SUSE-OpenStack-Cloud-7-Pool"
+      required: "mandatory"
+      features: ["openstack"]
+#      repomd:
+#        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:Update:Products:Cloud7/suse-openstack-cloud/7/POOL/x86_64"
+#        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+      url:
+      smt_path: "SUSE/Products/OpenStack-Cloud/7/x86_64/product"
+      ask_on_error: false
+    suse-openstack-cloud-7-updates:
+      name: "SUSE-OpenStack-Cloud-7-Updates"
+      required: "mandatory"
+      features: ["openstack"]
+#      repomd:
+#        tag: "obsrepository://build.suse.de/SUSE:Updates:OpenStack-Cloud:7:x86_64/update"
+#        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+      url:
+      smt_path: "SUSE/Updates/OpenStack-Cloud/7/x86_64/update"
+      ask_on_error: false
+    sle12-sp2-ha-pool:
+      name: "SLE12-SP2-HA-Pool"
+      required: "optional"
+      features: ["ha"]
+      repomd:
+        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:GA/sle-ha/12.2/POOL/x86_64"
+        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+      url:
+      smt_path: "SUSE/Products/SLE-HA/12-SP2/x86_64/product"
+      ask_on_error: false
+    sle12-sp2-ha-updates:
+      name: "SLE12-SP2-HA-Updates"
+      required: "optional"
+      features: ["ha"]
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-HA:12-SP2:x86_64/update"
+        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+      url:
+      smt_path: "SUSE/Updates/SLE-HA/12-SP2/x86_64/update"
+      ask_on_error: false
+    ptf:
+      name: "PTF"
+      required: "recommended"
+      url:
+      ask_on_error: false
+  s390x:
+    sles12-sp2-pool:
+      name: "SLES12-SP2-Pool"
+      required: "optional"
+      features: ["os"]
+      repomd:
+        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:GA/SLES/12.2/POOL/s390x"
+        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+      url:
+      smt_path: "SUSE/Products/SLE-SERVER/12-SP2/s390x/product"
+      ask_on_error: false
+    sles12-sp2-updates:
+      name: "SLES12-SP2-Updates"
+      required: "optional"
+      features: ["os"]
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP2:s390x/update"
+        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+      url:
+      smt_path: "SUSE/Updates/SLE-SERVER/12-SP2/s390x/update"
+      ask_on_error: false
+    cloud:
+      name: "Cloud"
+      required: "mandatory"
+      features: ["openstack"]
+      repomd:
+        tag: ["obsproduct://build.suse.de/SUSE:SLE-12-SP2:Update:Products:Cloud7/suse-openstack-cloud/7/cd/s390x",
+              "obsproduct://build.suse.de/Devel:Cloud:7:Staging/suse-openstack-cloud/7/cd/s390x",
+              "obsproduct://build.suse.de/Devel:Cloud:7/suse-openstack-cloud/7/cd/s390x"]
+        key_md5: ["9a62177e1c6852d48453ed3909956d6b", "6e2920076653964b7de9d6d0421955bb"]
+      url:
+      ask_on_error: false
+    ptf:
+      name: "PTF"
+      required: "recommended"
+      url:
+      ask_on_error: false


### PR DESCRIPTION
I have no idea what to enter as `key_md5` values...

Reply from @vuntz at irc: "keeping the same values as for SP1 should be fine anyway, as these are the IBS keys and they're the same between SP1 & SP2 (and Cloud 7 & Cloud 7"