### PR TITLE
Test if admin node has dns_server role for upgrade

### DIFF
--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -584,6 +584,10 @@ en:
         nodes_not_ready: |
           Some nodes are not ready: %{nodes}.
           Fix the state of nodes before proceeding with the upgrade.
+        admin_missing_dns_server: |
+          The Administration Server does not have the dns-server role while this is mandatory for
+          the upgrade process. Reapply the DNS proposal with this change before proceeding with
+          the upgrade.
       start:
         cancel: 'Abort Upgrade'
         continue: 'Upload and Restore'


### PR DESCRIPTION
The upgrade process will fail if the admin node does not have the
dns_server role applied. Abort upgrade with a warning, if this is
not the case. See also
https://bugzilla.suse.com/show_bug.cgi?id=978060

(cherry picked from commit 3e9955ff99ed4bc2be38b89c16d28ce3145402ad)