### PR TITLE
crowbar: Stop uploading proposal templates as chef data bags

### DIFF
--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -256,8 +256,19 @@ class NetworkService < ServiceObject
       db = Chef::DataBag.load("crowbar/#{k}_network") rescue nil
       if db.nil?
         @logger.debug("Network: creating #{k} in the network")
+
+        # ensure that crowbar data bag exists
+        databag_name = "crowbar"
+        begin
+          Chef::DataBag.load(databag_name)
+        rescue Net::HTTPServerException
+          crowbar_bag = Chef::DataBag.new
+          crowbar_bag.name databag_name
+          crowbar_bag.save
+        end
+
         db = Chef::DataBagItem.new
-        db.data_bag "crowbar"
+        db.data_bag databag_name
         db["id"] = "#{k}_network"
         db["network"] = net
         db["allocated"] = {}

--- a/crowbar_framework/lib/crowbar/chef/upload.rb
+++ b/crowbar_framework/lib/crowbar/chef/upload.rb
@@ -28,7 +28,6 @@ module Crowbar
 
       def all
         cookbooks
-        data_bags
         roles
       end
 
@@ -69,46 +68,6 @@ module Crowbar
         true
       end
 
-      def data_bags
-        loader = ::Chef::Knife::Core::ObjectLoader.new(::Chef::DataBagItem, logger)
-        data_bags = loader.find_all_object_dirs(chef_data_bags_path) || []
-        data_bags.each do |data_bag|
-          begin
-            logger.info("Creating data_bag #{data_bag}...")
-            api.post_rest("data", name: data_bag)
-          rescue Net::HTTPServerException => e
-            if e.response.code == "409"
-              logger.info("Data_bag #{data_bag} already exists")
-            else
-              logger.error("Creating data_bag #{data_bag} failed (#{e.response.code})")
-              return false
-            end
-          end
-
-          data_bag_items = loader.find_all_objects(chef_data_bags_path.join(data_bag))
-          data_bag_item_paths = normalize_data_bag_item_paths(data_bag_items) || []
-          data_bag_item_paths.each do |data_bag_item_path|
-            # Workaround for a strange chef behavior
-            relative_path = chef_data_bags_path.relative_path_from(Pathname.new(Dir.pwd))
-            data_bag_item = loader.load_from(relative_path, data_bag, data_bag_item_path)
-            bag = ::Chef::DataBagItem.new
-            bag.data_bag(data_bag)
-            bag.raw_data = data_bag_item
-            logger.info("Uploading data_bag item #{data_bag_item_path}...")
-
-            begin
-              return false unless bag.save
-            rescue Net::HTTPServerException => e
-              logger.error(
-                "Uploading data_bag item #{data_bag_item_path} failed (#{e.response.code})"
-              )
-              return false
-            end
-          end
-        end
-        true
-      end
-
       def roles
         loader = ::Chef::Knife::Core::ObjectLoader.new(::Chef::Role, logger)
         chef_roles_path.each_child do |file|
@@ -139,10 +98,6 @@ module Crowbar
 
       def chef_cookbooks_path
         chef_data_path.join("cookbooks")
-      end
-
-      def chef_data_bags_path
-        chef_data_path.join("data_bags")
       end
 
       def chef_roles_path

--- a/crowbar_framework/spec/lib/crowbar/chef/upload_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/chef/upload_spec.rb
@@ -123,35 +123,6 @@ describe Crowbar::Chef::Upload do
     end
   end
 
-  context "databag" do
-    it "uploads successfully" do
-      stub_databag_positive
-      expect(subject.data_bags).to be true
-    end
-
-    it "fails to upload databag item" do
-      stub_databag_negative
-      expect(subject.data_bags).to be false
-    end
-
-    context "fails to be created" do
-      it "when it already exists on the server" do
-        stub_databag_negative
-        expect(subject.data_bags).to be false
-      end
-
-      it "when it raises a Net::HTTPServerException" do
-        stub_databag_negative
-        allow_any_instance_of(OfflineChef).to(
-          receive(:post_rest).with(
-            "data", name: "crowbar"
-          ).and_raise(Net::HTTPServerException)
-        )
-        expect(subject.data_bags).to be false
-      end
-    end
-  end
-
   context "role" do
     it "uploads successfully" do
       stub_role_positive


### PR DESCRIPTION
We should not need them: the templates are only ever used when creating
proposals, and the rails app has direct access to the json file.

This should go with https://github.com/crowbar/crowbar/pull/2230