### PR TITLE
workaround bootloader installed to wrong disk (bsc#985422)

### DIFF
--- a/updates/control.sh
+++ b/updates/control.sh
@@ -201,7 +201,7 @@ nuke_everything() {
         # write new unique MBR signature
         # This initializes a random 32bit Disk signature used to
         # distinguish disks, which helps installing boot loader properly
-        echo w | fdisk /dev/$name
+        parted --script /dev/$name mktable msdos
     done < <(tac /proc/partitions)
 }
 


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=985422

There seems to have been a behaviour change of fdisk
in that it does not write out a newly created partition table
if there are no other changes
so we switch to parted to create the partition table unique ID instead
