### PR TITLE
Prepare a directory structure where user is supposed to put his rpm.

### DIFF
--- a/chef/cookbooks/suse-manager-client/files/default/README
+++ b/chef/cookbooks/suse-manager-client/files/default/README
@@ -1,0 +1,2 @@
+Copy the rhn-org-trusted-ssl-cert-VERSION-RELEASE.noarch.rpm package you downloaded
+from your SUSE Manager server to this directory as ssl-cert.rpm.


### PR DESCRIPTION
Current documentation says:

_Download the package rhn-org-trusted-ssl-cert-VERSION-RELEASE.noarch.rpm from https://susemanager.example.com/pub/. VERSION and RELEASE may vary, ask the administrator of the SUSE Manager for the correct values. susemanager.example.com needs to be replaced by the address of your SUSE Manager server. Copy the file you downloaded to /opt/dell/chef/cookbooks/suse-manager-client/files/default/ssl-cert.rpm on the Administration Server. The package contains the SUSE Manager's CA SSL Public Certificate. The certificate installation has not been automated on purpose, because downloading the certificate manually enables you to check it before copying it._

However, the directory does not even exist. Also, suggested call of `/opt/dell/bin/barclamp_install.rb --rpm suse-manager-client` won't work as the new file is not packaged. We could have fake `ssl-cert.rpm` (with the content of this README file), but I'd rather propose to update the documentation for a simpler call of `knife cookbook upload core -o ...`