### PR TITLE
Avoid duplicating network definitions in multiple locations

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -239,22 +239,25 @@ module BarclampLibrary
       end
 
       class Network
-        attr_reader :name, :address, :mtu, :broadcast, :netmask,
-          :subnet, :router, :vlan, :use_vlan,
-          :add_bridge, :conduit
+        attr_reader :name, :address, :broadcast, :netmask,
+          :subnet, :router, :router_pref, :mtu, :vlan, :use_vlan,
+          :add_bridge, :add_ovs_bridge, :bridge_name, :conduit
         def initialize(node, net, data)
           @node = node
           @name = net
           @address = data["address"]
-          @mtu = (data["mtu"] || 1500).to_i
           @broadcast = data["broadcast"]
           @netmask = data["netmask"]
           @subnet = data["subnet"]
           @router = data["router"]
-          @vlan = data["vlan"]
+          @router_pref = data["router_pref"].to_i
+          @mtu = (data["mtu"] || 1500).to_i
+          @vlan = data["vlan"].to_i
           @use_vlan = data["use_vlan"]
           @conduit = data["conduit"]
           @add_bridge = data["add_bridge"]
+          @add_ovs_bridge = data["add_ovs_bridge"]
+          @bridge_name = data["bridge_name"]
           # let's resolve this only if needed
           @interface = nil
           @interface_list = nil

--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -28,12 +28,15 @@ module BarclampLibrary
 
       def self.list_networks(node)
         answer = []
-        node[:crowbar][:network].each do |net, data|
-          # network is not valid if we don't have the full definition
-          next unless node[:network][:networks].key?(net)
-          network_def = node[:network][:networks][net].to_hash.merge(data.to_hash)
-          answer << Network.new(node, net, network_def)
-        end unless node[:crowbar].nil? || node[:crowbar][:network].nil? || node[:network][:networks].nil?
+        unless node[:crowbar].nil? || node[:crowbar][:network].nil? ||
+            node[:network][:networks].nil?
+          node[:crowbar][:network].each do |net, data|
+            # network is not valid if we don't have the full definition
+            next unless node[:network][:networks].key?(net)
+            network_def = node[:network][:networks][net].to_hash.merge(data.to_hash)
+            answer << Network.new(node, net, network_def)
+          end
+        end
         answer
       end
 
@@ -240,9 +243,14 @@ module BarclampLibrary
       end
 
       class Network
-        attr_reader :name, :address, :broadcast, :netmask,
-          :subnet, :router, :router_pref, :mtu, :vlan, :use_vlan,
-          :add_bridge, :add_ovs_bridge, :bridge_name, :conduit
+        attr_reader :name
+        attr_reader :address, :broadcast, :netmask, :subnet
+        attr_reader :router, :router_pref
+        attr_reader :mtu
+        attr_reader :vlan, :use_vlan
+        attr_reader :add_bridge, :add_ovs_bridge, :bridge_name
+        attr_reader :conduit
+
         def initialize(node, net, data)
           @node = node
           @name = net

--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -234,7 +234,7 @@ module BarclampLibrary
       end
 
       class Network
-        attr_reader :name, :address, :mtu, :broadcast, :mac, :netmask,
+        attr_reader :name, :address, :mtu, :broadcast, :netmask,
           :subnet, :router, :vlan, :use_vlan, :interface,
           :interface_list, :add_bridge, :conduit
         def initialize(net, data, rintf, interface_list)
@@ -242,7 +242,6 @@ module BarclampLibrary
           @address = data["address"]
           @mtu = (data["mtu"] || 1500).to_i
           @broadcast = data["broadcast"]
-          @mac = data["mac"]
           @netmask = data["netmask"]
           @subnet = data["subnet"]
           @router = data["router"]

--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -251,9 +251,9 @@ module BarclampLibrary
           @netmask = data["netmask"]
           @subnet = data["subnet"]
           @router = data["router"]
-          @router_pref = data["router_pref"].to_i
+          @router_pref = data["router_pref"].nil? ? nil : data["router_pref"].to_i
           @mtu = (data["mtu"] || 1500).to_i
-          @vlan = data["vlan"].to_i
+          @vlan = data["vlan"].nil? ? nil : data["vlan"].to_i
           @use_vlan = data["use_vlan"]
           @conduit = data["conduit"]
           @add_bridge = data["add_bridge"]

--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -39,7 +39,7 @@ module BarclampLibrary
       def self.get_network_by_type(node, type)
         unless node[:crowbar][:network].nil?
           [type, "admin"].uniq.each do |usage|
-            if found = node[:crowbar][:network].find { |net, data| data[:usage] == usage }
+            if found = node[:crowbar][:network].find { |net, data| net == usage }
               net, data = found
               intf, interface_list, tm = Barclamp::Inventory.lookup_interface_info(node, data["conduit"])
               return Network.new(net, data, intf, interface_list)
@@ -235,7 +235,7 @@ module BarclampLibrary
 
       class Network
         attr_reader :name, :address, :mtu, :broadcast, :mac, :netmask,
-          :subnet, :router, :usage, :vlan, :use_vlan, :interface,
+          :subnet, :router, :vlan, :use_vlan, :interface,
           :interface_list, :add_bridge, :conduit
         def initialize(net, data, rintf, interface_list)
           @name = net
@@ -246,7 +246,6 @@ module BarclampLibrary
           @netmask = data["netmask"]
           @subnet = data["subnet"]
           @router = data["router"]
-          @usage = data["usage"]
           @vlan = data["vlan"]
           @use_vlan = data["use_vlan"]
           @conduit = data["conduit"]

--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -44,11 +44,12 @@ module BarclampLibrary
               # network is not valid if we don't have the full definition
               node[:network][:networks].key?(net) && net == usage
             end
-            unless found.nil?
-              net, data = found
-              network_def = node[:network][:networks][net].to_hash.merge(data.to_hash)
-              return Network.new(node, net, network_def)
-            end
+
+            next if found.nil?
+
+            net, data = found
+            network_def = node[:network][:networks][net].to_hash.merge(data.to_hash)
+            return Network.new(node, net, network_def)
           end
           return nil
         end
@@ -276,7 +277,7 @@ module BarclampLibrary
         protected
 
         def resolve_interface_info
-          intf, @interface_list, tm = Barclamp::Inventory.lookup_interface_info(@node, @conduit)
+          intf, @interface_list, _tm = Barclamp::Inventory.lookup_interface_info(@node, @conduit)
           @interface = @use_vlan ? "#{intf}.#{@vlan}" : intf
         end
       end

--- a/chef/cookbooks/barclamp/libraries/nethelper.rb
+++ b/chef/cookbooks/barclamp/libraries/nethelper.rb
@@ -11,8 +11,10 @@ class Chef
       }.select{ |a|a.kind_of? type }
     end
     def address(net="admin",type=::IP)
+      network_def = Chef::Recipe::Barclamp::Inventory.get_network_by_type(self, net)
+
       self.addresses(net,type).first ||
-        (::IP.coerce("#{self[:crowbar][:network][net][:address]}/#{self[:crowbar][:network][net][:netmask]}") rescue nil) ||
+        (::IP.coerce("#{network_def.address}/#{network_def.netmask}") unless network_def.nil?) ||
         ::IP.coerce(self[:ipaddress])
     end
     def interfaces(net="admin")

--- a/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
+++ b/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
@@ -30,15 +30,19 @@ end
 bmc_user     = node[:ipmi][:bmc_user]
 bmc_password = node[:ipmi][:bmc_password]
 use_dhcp     = node[:ipmi][:use_dhcp]
-bmc_address  = node["crowbar"]["network"]["bmc"]["address"] rescue "0.0.0.0"
-bmc_netmask  = node["crowbar"]["network"]["bmc"]["netmask"] rescue "0.0.0.0"
-bmc_router   = node["crowbar"]["network"]["bmc"]["router"] rescue "0.0.0.0"
-bmc_use_vlan = node["crowbar"]["network"]["bmc"]["use_vlan"] rescue false
-bmc_vlan     = if bmc_use_vlan
-                 node["crowbar"]["network"]["bmc"]["vlan"].to_s
-               else
-                 "off"
-               end
+
+bmc_network = Barclamp::Inventory.get_network_by_type(node, "bmc")
+if bmc_network.nil?
+  bmc_address = "0.0.0.0"
+  bmc_netmask = "0.0.0.0"
+  bmc_router  = "0.0.0.0"
+  bmc_vlan    = "off"
+else
+  bmc_address = bmc_network.address
+  bmc_netmask = bmc_network.netmask
+  bmc_router  = bmc_network.router
+  bmc_vlan    = bmc_network.use_vlan ? bmc_network.vlan : "off"
+end
 
 if node["crowbar_wall"]["status"]["ipmi"]["user_set"].nil?
   node.set["crowbar_wall"]["status"]["ipmi"]["user_set"] = false

--- a/chef/cookbooks/network/recipes/switch_config.rb
+++ b/chef/cookbooks/network/recipes/switch_config.rb
@@ -35,14 +35,14 @@ def setup_interface(switch_config, a_node, conduit, switch_name, interface_id )
     interfaces = a_switch_config["interfaces"]
 
     # Find the conduit associated with the interface
-    a_node["crowbar"]["network"].each do |network_name, network|
-      next if network["conduit"] != conduit
-      vlan = network["vlan"]
-      unique_vlans[vlan] = network_name
+    Barclamp::Inventory.list_networks(a_node) do |network|
+      next if network.conduit != conduit
+      vlan = network.vlan
+      unique_vlans[vlan] = network.name
 
       interfaces[interface_id] = {} if interfaces[interface_id].nil?
       vlans_for_interface = interfaces[interface_id]
-      vlans_for_interface[vlan] = network["use_vlan"]
+      vlans_for_interface[vlan] = network.use_vlan
     end
 end
 

--- a/chef/cookbooks/nfs-server/recipes/default.rb
+++ b/chef/cookbooks/nfs-server/recipes/default.rb
@@ -76,12 +76,14 @@ execute "nfs-export" do
   action :nothing
 end
 
+admin_net = Barclamp::Inventory.get_network_by_type(node, "admin")
+
 template "/etc/exports" do
   source "exports.erb"
   group "root"
   owner "root"
   mode 0644
-  variables(admin_subnet: node["network"]["networks"]["admin"]["subnet"],
-            admin_netmask: node["network"]["networks"]["admin"]["netmask"])
+  variables(admin_subnet: admin_net.subnet,
+            admin_netmask: admin_net.netmask)
   notifies :run, "execute[nfs-export]", :delayed
 end

--- a/chef/cookbooks/ntp/recipes/default.rb
+++ b/chef/cookbooks/ntp/recipes/default.rb
@@ -23,7 +23,9 @@ else
 end
 ntp_servers = []
 servers.each do |n|
-  ntp_servers.push n[:crowbar][:network][:admin][:address] if n.name != node.name
+  next if n.name == node.name
+  n_admin_net = Barclamp::Inventory.get_network_by_type(n, "admin")
+  ntp_servers.push n_admin_net.address
 end
 if node["roles"].include?("ntp-server")
   ntp_servers += node[:ntp][:external_servers]

--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -16,8 +16,8 @@
 
 # Set up the OS images as well
 # Common to all OSes
-admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-admin_broadcast = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").broadcast
+admin_net = Barclamp::Inventory.get_network_by_type(node, "admin")
+admin_ip = admin_net.address
 domain_name = node[:dns].nil? ? node[:domain] : (node[:dns][:domain] || node[:domain])
 web_port = node[:provisioner][:web_port]
 provisioner_web="http://#{admin_ip}:#{web_port}"
@@ -203,8 +203,8 @@ if node[:platform_family] == "suse"
     variables(docroot: tftproot,
               port: web_port,
               admin_ip: admin_ip,
-              admin_subnet: node["network"]["networks"]["admin"]["subnet"],
-              admin_netmask: node["network"]["networks"]["admin"]["netmask"],
+              admin_subnet: admin_net.subnet,
+              admin_netmask: admin_net.netmask,
               logfile: "/var/log/apache2/provisioner-access_log",
               errorlog: "/var/log/apache2/provisioner-error_log")
     notifies :reload, resources(service: "apache2")
@@ -545,7 +545,7 @@ node[:provisioner][:supported_oses].each do |os, arches|
         group "root"
         source "crowbar_register.erb"
         variables(admin_ip: admin_ip,
-                  admin_broadcast: admin_broadcast,
+                  admin_broadcast: admin_net.broadcast,
                   web_port: web_port,
                   ntp_servers_ips: ntp_servers_ips,
                   os: os,

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -119,6 +119,7 @@ if not nodes.nil? and not nodes.empty?
     # needed for dhcp
     admin_data_net = Chef::Recipe::Barclamp::Inventory.get_network_by_type(mnode, "admin")
     admin_mac_addresses = find_node_boot_mac_addresses(mnode, admin_data_net)
+    admin_ip_address = admin_data_net.nil? ? mnode[:ipaddress] : admin_data_net.address
 
     case
     when (new_group == "delete")
@@ -164,7 +165,7 @@ if not nodes.nil? and not nodes.empty?
         dhcp_host "#{mnode.name}-#{i}" do
           hostname mnode.name
           if admin_mac_addresses.include?(mac_list[i])
-            ipaddress admin_data_net.address
+            ipaddress admin_ip_address
           end
           macaddress mac_list[i]
           action :add
@@ -197,11 +198,7 @@ if not nodes.nil? and not nodes.empty?
           hostname mnode.name
           macaddress mac_list[i]
           if admin_mac_addresses.include?(mac_list[i])
-            if admin_data_net.nil?
-              ipaddress mnode[:ipaddress]
-            else
-              ipaddress admin_data_net.address
-            end
+            ipaddress admin_ip_address
             options [
               'if exists dhcp-parameter-request-list {
     # Always send the PXELINUX options (specified in hexadecimal)

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -200,7 +200,7 @@ if not nodes.nil? and not nodes.empty?
             if admin_data_net.nil?
               ipaddress mnode[:ipaddress]
             else
-              ipaddress admin_data_net.address unless admin_data_net.nil?
+              ipaddress admin_data_net.address
             end
             options [
               'if exists dhcp-parameter-request-list {

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -197,7 +197,11 @@ if not nodes.nil? and not nodes.empty?
           hostname mnode.name
           macaddress mac_list[i]
           if admin_mac_addresses.include?(mac_list[i])
-            ipaddress admin_data_net.address unless admin_data_net.nil?
+            if admin_data_net.nil?
+              ipaddress mnode[:ipaddress]
+            else
+              ipaddress admin_data_net.address unless admin_data_net.nil?
+            end
             options [
               'if exists dhcp-parameter-request-list {
     # Always send the PXELINUX options (specified in hexadecimal)

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -232,6 +232,8 @@ if not nodes.nil? and not nodes.empty?
           os = node[:provisioner][:default_os]
         end
 
+        node_ip = Barclamp::Inventory.get_network_by_type(mnode, "admin").address
+
         append << node[:provisioner][:available_oses][os][arch][:append_line]
 
         node_cfg_dir = "#{tftproot}/nodes/#{mnode[:fqdn]}"
@@ -338,7 +340,7 @@ if not nodes.nil? and not nodes.empty?
                       boot_device: (mnode[:crowbar_wall][:boot_device] rescue nil),
                       raid_type: (mnode[:crowbar_wall][:raid_type] || "single"),
                       raid_disks: (mnode[:crowbar_wall][:raid_disks] || []),
-                      node_ip: mnode[:crowbar][:network][:admin][:address],
+                      node_ip: node_ip,
                       node_fqdn: mnode[:fqdn],
                       node_hostname: mnode[:hostname],
                       platform: target_platform_distro,

--- a/crowbar_framework/app/controllers/network_controller.rb
+++ b/crowbar_framework/app/controllers/network_controller.rb
@@ -269,7 +269,7 @@ class NetworkController < BarclampController
 
   def node_vlans(node)
     nv = {}
-    vlans = node.networks.each do |vlan, vdetails|
+    node.networks.each do |vlan, vdetails|
       nv[vlan] = { address: vdetails["address"], active: vdetails["use_vlan"] }
     end
     nv

--- a/crowbar_framework/app/controllers/network_controller.rb
+++ b/crowbar_framework/app/controllers/network_controller.rb
@@ -269,7 +269,7 @@ class NetworkController < BarclampController
 
   def node_vlans(node)
     nv = {}
-    vlans = node["crowbar"]["network"].each do |vlan, vdetails|
+    vlans = node.networks.each do |vlan, vdetails|
       nv[vlan] = { address: vdetails["address"], active: vdetails["use_vlan"] }
     end
     nv

--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -463,8 +463,8 @@ class NodesController < ApplicationController
       if !["discovering", "discovered"].include?(@node.state)
         intf_if_map = @node.build_node_map
         # build network information (this may need to move into the object)
-        @node.networks.each do |intf, data|
-          if data["usage"] == "bmc"
+        @node.networks.each do |name, data|
+          if name == "bmc"
             ifname = "bmc"
             address = @node["crowbar_wall"]["ipmi"]["address"] rescue nil
           else
@@ -477,8 +477,8 @@ class NodesController < ApplicationController
             address = data["address"]
           end
           if address
-            network[data["usage"]] = {} if network[data["usage"]].nil?
-            network[data["usage"]][ifname] = address
+            network[name] = {} if network[name].nil?
+            network[name][ifname] = address
           end
         end
         @network = network.sort

--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -477,7 +477,7 @@ class NodesController < ApplicationController
             address = data["address"]
           end
           if address
-            network[name] = {} if network[name].nil?
+            network[name] ||= {}
             network[name][ifname] = address
           end
         end

--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -121,8 +121,9 @@ class NetworkService < ServiceObject
     return [404, "No Address Available"] if !found
 
     if type == :node
-      # Save the information.
-      node.crowbar["crowbar"]["network"][network] = net_info
+      # Save the information (only what we override from the network definition).
+      node.crowbar["crowbar"]["network"][network] ||= {}
+      node.crowbar["crowbar"]["network"][network]["address"] = net_info["address"]
       node.save
     end
 
@@ -381,8 +382,8 @@ class NetworkService < ServiceObject
     ensure
     end
 
-    # Save the information.
-    node.crowbar["crowbar"]["network"][network] = net_info
+    # Save the information (only what we override from the network definition).
+    node.crowbar["crowbar"]["network"][network] ||= {}
     node.save
 
     @logger.info("Network enable_interface: Assigned: #{name} #{network}")

--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -62,7 +62,7 @@ class NetworkService < ServiceObject
     begin
       lock = acquire_ip_lock
       db = Chef::DataBag.load("crowbar/#{network}_network") rescue nil
-      net_info = build_net_info(network, name, db)
+      net_info = build_net_info(network, db)
 
       rangeH = db["network"]["ranges"][range]
       rangeH = db["network"]["ranges"]["host"] if rangeH.nil?
@@ -375,7 +375,7 @@ class NetworkService < ServiceObject
 
     net_info={}
     begin # Rescue block
-      net_info = build_net_info(network, name)
+      net_info = build_net_info(network)
     rescue Exception => e
       @logger.error("Error finding address: #{e.message}")
     ensure
@@ -389,7 +389,7 @@ class NetworkService < ServiceObject
     [200, net_info]
   end
 
-  def build_net_info(network, name, db = nil)
+  def build_net_info(network, db = nil)
     unless db
       db = Chef::DataBag.load("crowbar/#{network}_network") rescue nil
     end
@@ -398,8 +398,6 @@ class NetworkService < ServiceObject
     db["network"].each { |k,v|
       net_info[k] = v unless v.nil?
     }
-    net_info["usage"]= network
-    net_info["node"] = name
     net_info
   end
 end

--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -279,7 +279,10 @@ class NetworkService < ServiceObject
   def transition(inst, name, state)
     @logger.debug("Network transition: entering: #{name} for #{state}")
 
-    if ["installed", "readying"].include? state
+    # we need one state before "installed" (and after allocation) because we
+    # need the node to have the admin network fully defined for
+    # provisioner-server recipes to be functional for that node
+    if ["hardware-installing", "installed", "readying"].include? state
       db = Proposal.where(barclamp: @bc_name, name: inst).first
       role = RoleObject.find_role_by_name "#{@bc_name}-config-#{inst}"
 

--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -215,12 +215,10 @@ class NetworkService < ServiceObject
 
     if type == :node
       # Save the information.
-      newhash = {}
-      node.crowbar["crowbar"]["network"].each do |k, v|
-        newhash[k] = v unless k == network
+      if node.crowbar["crowbar"]["network"].key? network
+        node.crowbar["crowbar"]["network"].delete network
+        node.save
       end
-      node.crowbar["crowbar"]["network"] = newhash
-      node.save
     end
     @logger.info("Network deallocate_ip: removed: #{name} #{network}")
     [200, nil]

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -835,8 +835,8 @@ class NodeObject < ChefObject
 
   def get_network_by_type(type)
     return nil if @role.nil?
-    networks.each do |intf, data|
-      return data if data["usage"] == type
+    networks.each do |name, data|
+      return data if name == type
     end
     nil
   end

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -831,7 +831,7 @@ class NodeObject < ChefObject
 
   def networks
     networks = {}
-    self.crowbar["crowbar"]["network"].each do |name, data|
+    crowbar["crowbar"]["network"].each do |name, data|
       # note that node might not be part of network proposal yet (for instance:
       # if discovered, and IP got allocated by user)
       next if @node["network"]["networks"].nil? || !@node["network"]["networks"].key?(name)
@@ -842,11 +842,11 @@ class NodeObject < ChefObject
 
   def get_network_by_type(type)
     return nil if @role.nil?
-    return nil unless self.crowbar["crowbar"]["network"].key?(type)
+    return nil unless crowbar["crowbar"]["network"].key?(type)
     # note that node might not be part of network proposal yet (for instance:
     # if discovered, and IP got allocated by user)
     return nil if @node["network"]["networks"].nil? || !@node["network"]["networks"].key?(type)
-    @node["network"]["networks"][type].to_hash.merge(self.crowbar["crowbar"]["network"][type].to_hash)
+    @node["network"]["networks"][type].to_hash.merge(crowbar["crowbar"]["network"][type].to_hash)
   end
 
   #

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -849,6 +849,12 @@ class NodeObject < ChefObject
     @node["network"]["networks"][type].to_hash.merge(crowbar["crowbar"]["network"][type].to_hash)
   end
 
+  def set_network_attribute(network, attribute, value)
+    # let's assume the caller knows what it's doing and not check if that
+    # network is enabled for that node
+    crowbar["crowbar"]["network"][network][attribute] = value
+  end
+
   #
   # This is from the crowbar role assigned to the admin node at install time.
   # It is not a node.role parameter


### PR DESCRIPTION
This makes dealing with the network config more difficult, as some bits might get outdated.

Instead, we centralize the definitions in the network role, and have proper API for accessing this easily.

This goes with https://github.com/crowbar/crowbar-ha/pull/119, https://github.com/crowbar/crowbar-hyperv/pull/25 and https://github.com/crowbar/crowbar-openstack/pull/415.