### PR TITLE
crowbar: Stop rebuilding node run_list depending on the node state

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -292,11 +292,6 @@ class CrowbarService < ServiceObject
         end
       end
 
-      # The node is going to call chef-client on return or as a side-effect of the process queue.
-      node = NodeObject.find_node_by_name(name)
-      node.rebuild_run_list
-      node.save
-
       # We have a node that has become ready, test to see if there are queued proposals to commit
       process_queue if state == "ready"
     end

--- a/crowbar_framework/app/models/deployer_service.rb
+++ b/crowbar_framework/app/models/deployer_service.rb
@@ -132,12 +132,10 @@ class DeployerService < ServiceObject
     #
     if state == "hardware-installing"
       # build a list of current and pending roles to check against
-      roles = []
-      node.crowbar["crowbar"]["pending"].each do |k, v|
-        roles << v
-      end unless node.crowbar["crowbar"]["pending"].nil?
-      roles << node.run_list_to_roles
-      roles.flatten!
+      roles = node.roles.dup
+      unless node.crowbar["crowbar"]["pending"].nil?
+        roles.concat(node.crowbar["crowbar"]["pending"].values)
+      end
 
       # Walk map to categorize the node.  Choose first one from the bios map that matches.
       role = RoleObject.find_role_by_name "deployer-config-#{inst}"

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -731,14 +731,15 @@ class NodeObject < ChefObject
     crowbar["run_list_map"].delete_if { |k, v| v["priority"] == -1001 }
 
     # Sort map (by priority, then name)
-    vals = crowbar["run_list_map"].sort do |a, b|
+    sorted_run_list_map = crowbar["run_list_map"].sort do |a, b|
       [a[1]["priority"], a[0]] <=> [b[1]["priority"], b[0]]
     end
-    Rails.logger.debug("rebuilt run_list will be #{vals.inspect}")
+
+    Rails.logger.debug("rebuilt run_list will be #{sorted_run_list_map.inspect}")
 
     # Rebuild list
     crowbar_run_list.run_list_items.clear
-    vals.each do |item|
+    sorted_run_list_map.each do |item|
       crowbar_run_list.run_list_items << "role[#{item[0]}]"
     end
   end

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -709,11 +709,7 @@ class NodeObject < ChefObject
     # FIXME: Crowbar 4.0: we keep states parameter for compatibility reason; it
     # should be removed in Crowbar 5.0
     crowbar["run_list_map"] ||= {}
-    val = { "priority" => priority }
-    crowbar["run_list_map"][rolename] = val
-    Rails.logger.debug("crowbar[run_list_map][#{rolename}] = #{val.inspect}")
-    Rails.logger.debug("current state is #{self.crowbar['state']}")
-
+    crowbar["run_list_map"][rolename] = { "priority" => priority }
     rebuild_run_list
   end
 

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1005,8 +1005,6 @@ class ServiceObject
     # For Role ordering
     runlist_priority_map = new_deployment["element_run_list_order"] || { }
     local_chef_order = chef_order()
-    role_map = new_deployment["element_states"]
-    role_map = {} unless role_map
 
     # deployment["element_order"] tells us which order the various
     # roles should be applied, and deployment["elements"] tells us
@@ -1243,7 +1241,7 @@ class ServiceObject
         next if node.role? item
         priority = runlist_priority_map[item] || local_chef_order
         @logger.debug("AR: Adding role #{item} to #{node.name} with priority #{priority}")
-        node.add_to_run_list(item, priority, role_map[item])
+        node.add_to_run_list(item, priority)
         save_it = true
       end
 
@@ -1256,7 +1254,7 @@ class ServiceObject
         unless node.role?(role.name)
           priority = runlist_priority_map[role.name] || local_chef_order
           @logger.debug("AR: Adding role #{role.name} to #{node.name} with priority #{priority}")
-          node.add_to_run_list(role.name, priority, role_map[role.name])
+          node.add_to_run_list(role.name, priority)
           save_it = true
         end
       else
@@ -1416,8 +1414,6 @@ class ServiceObject
 
     runlist_priority_map = prop["deployment"][barclamp]["element_run_list_order"] rescue {}
     runlist_priority_map ||= {}
-    role_map = prop["deployment"][barclamp]["element_states"] rescue {}
-    role_map = {} unless role_map
 
     local_chef_order = runlist_priority_map[newrole] || BarclampCatalog.chef_order(barclamp)
 
@@ -1441,7 +1437,7 @@ class ServiceObject
 
     save_it = false
     unless node.role?(newrole)
-      node.add_to_run_list(newrole, local_chef_order, role_map[newrole])
+      node.add_to_run_list(newrole, local_chef_order)
       save_it = true
     end
 


### PR DESCRIPTION
Whether a role should be handled as part of a chef run will now be
decided in the role recipes.

The benefit of this is that the roles will always be assigned to the
node, even if the roles are not used due to the state. This fixes
several issues, including the fact that the search results for nodes are
not reliable when a node is in some state that is not "readying",
"applying" or "ready".

Depends on ~~https://github.com/crowbar/crowbar-core/pull/514, https://github.com/crowbar/crowbar-ha/pull/121, https://github.com/crowbar/crowbar-ceph/pull/56, https://github.com/crowbar/crowbar-openstack/pull/419~~