### PR TITLE
Do not install openvswitch-kmp-default package for SLES12SP2

### DIFF
--- a/chef/cookbooks/network/attributes/default.rb
+++ b/chef/cookbooks/network/attributes/default.rb
@@ -23,8 +23,8 @@ when "suse"
     "openvswitch",
     "openvswitch-switch"
   ]
-  # openSUSE uses the module shipped with upstream kernel
-  if node[:platform] == "suse"
+  # openSUSE and SLES12SP2 use the module shipped with upstream kernel
+  if node[:platform] == "suse" && node[:platform_version].to_f < 12.2
     default[:network][:ovs_pkgs].push("openvswitch-kmp-default")
   end
   # SLES11 uses a different service name for openvswitch


### PR DESCRIPTION
Supposedly it should work well directly with SP2 kernel. See also https://build.suse.de/package/view_file/SUSE:SLE-12-SP2:GA/openvswitch/openvswitch.changes?expand=1