### PR TITLE
crowbar: Fix visibility of license key input in bulk edit

### DIFF
--- a/crowbar_framework/app/views/nodes/list.html.haml
+++ b/crowbar_framework/app/views/nodes/list.html.haml
@@ -78,7 +78,7 @@
                       = "-"
                 - else
                   %td
-                    = select_tag "node[#{node.handle}][target_platform]", platforms_for_select(node.target_platform, node.architecture), :class => "form-control", "data-showit" => crowbar_service.require_license_platforms.join(","), "data-showit-target" => "input[name=\"node[#{node.name}][license_key]\"]", "data-showit-direct" => "true"
+                    = select_tag "node[#{node.handle}][target_platform]", platforms_for_select(node.target_platform, node.architecture), :class => "form-control", "data-showit" => crowbar_service.require_license_platforms.join(","), "data-showit-target" => "input[name=\"node[#{node.handle}][license_key]\"]", "data-showit-direct" => "true"
                   %td
                     = password_field_tag "node[#{node.handle}][license_key]", node.license_key, :class => "form-control"
                 %td.text-center


### PR DESCRIPTION
We were not referring to the right name for the tag, and therefore the
license key was always visible.