### PR TITLE
barclamp: Do not generate parents list for non-vlan ifaces

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -327,6 +327,7 @@ class ::Nic
   # They do not return useful information for bonds and bridges.
   # Get this nic's parents based on ifindex -> iflink matching.
   def parents
+    return [] unless is_a?(::Nic::Vlan)
     return [] if self.ifindex == self.iflink
     self.class.__nics.select do |n|
       (n.ifindex == self.iflink) && ! (n == self)


### PR DESCRIPTION
It could potentially lead to the infinite loop

This is technically not needed when we have https://github.com/crowbar/crowbar-core/pull/525, but might still have a logical sense, as the function already suggests it should not be used for other kind of interfaces