### PR TITLE
dns: Run dns-client role only in readying/ready/applying states

### DIFF
--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -56,7 +56,7 @@ unless node[:platform_family] == "windows"
       # invalidate dnsmasq cache if local zone changes
       subscribes :reload, "template[/etc/bind/db.#{node[:dns][:domain]}]"
     end
-    not_if { node["crowbar"]["admin_node"] && ::File.exist?("/var/lib/crowbar/install/disable_dns") }
+    not_if { node["crowbar"]["admin_node"] && File.exist?("/var/lib/crowbar/install/disable_dns") }
   end
 
   dns_list = dns_list.insert(0, "127.0.0.1").take(3)

--- a/chef/data_bags/crowbar/migrate/dns/100_dns_client_states.rb
+++ b/chef/data_bags/crowbar/migrate/dns/100_dns_client_states.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-dns.json
+++ b/chef/data_bags/crowbar/template-dns.json
@@ -15,10 +15,10 @@
     "dns": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 4,
+      "schema-revision": 100,
       "element_states": {
         "dns-server": [ "readying", "ready", "applying" ],
-        "dns-client": [ "all" ]
+        "dns-client": [ "readying", "ready", "applying" ]
       },
       "elements": {},
       "element_order": [


### PR DESCRIPTION
This is like nearly all other roles.

The change only really impacts the discovery image, but it turns out
that with the discovery image, we use DHCP, so we get the DNS info from
DHCP in that case.

To be super safe, we should merge https://github.com/crowbar/crowbar-core/pull/529 first, but I doubt it matters in reality.