### PR TITLE
crowbar: Stop running chef a second time on apply if things failed, and in a different way for admin server

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1333,7 +1333,7 @@ class ServiceObject
         unless badones.empty?
           message = "Failed to apply the proposal to: "
           badones.each do |baddie|
-            message = message + "#{pids[baddie[0]]} \n"+ get_log_lines("#{pids[baddie[0]]}")
+            message = message + "#{pids[baddie[0]]}\n" + get_log_lines(pids[baddie[0]])
           end
           update_proposal_status(inst, "failed", message)
           restore_to_ready(applying_nodes)
@@ -1357,7 +1357,7 @@ class ServiceObject
         unless badones.empty?
           message = "Failed to apply the proposal to: "
           badones.each do |baddie|
-            message = message + "#{pids[baddie[0]]} \n "+ get_log_lines("#{pids[baddie[0]]}")
+            message = message + "#{pids[baddie[0]]}\n " + get_log_lines(pids[baddie[0]])
           end
           update_proposal_status(inst, "failed", message)
           restore_to_ready(applying_nodes)

--- a/crowbar_framework/app/models/updater_service.rb
+++ b/crowbar_framework/app/models/updater_service.rb
@@ -74,8 +74,4 @@ class UpdaterService < ServiceObject
    #end
     @logger.debug("Updater apply_role_post_chef_call: exiting")
   end
-
-  def oneshot?
-    true
-  end
 end


### PR DESCRIPTION
This was a horrible workaround for various bugs, mostly in the cookbooks. This shouldn't be needed anymore -- if it still is, then we should fix the real bugs.

Also, for the admin server: This was done in the days where chef had no locking to avoid concurrent runs, since the admin server had some other chef runs started by crowbar (on transitions, for instance). This has been fixed since a long time now, so there's no reason to continue this.