### PR TITLE
crowbar: Add rake task "schema_migrate_status" for migration overview

### DIFF
--- a/crowbar_framework/lib/schema_migration.rb
+++ b/crowbar_framework/lib/schema_migration.rb
@@ -79,6 +79,21 @@ module SchemaMigration
     migrate_object(bc_name, template, all_scripts, attributes, deployment)
   end
 
+  def self.get_barclamp_current_deployment_revison(bc_name)
+    begin
+      template = Proposal.new(barclamp: bc_name)
+    rescue Proposal::TemplateMissing
+      return [nil, nil]
+    end
+
+    proposals = Proposal.where(barclamp: bc_name)
+    latest_schema_revision = template["deployment"][bc_name]["schema-revision"]
+    latest_proposals_revision = proposals.collect do |prop|
+      { name: prop.name, revision: prop["deployment"][bc_name]["schema-revision"] }
+    end
+    [latest_schema_revision, latest_proposals_revision]
+  end
+
   private
 
   def self.data_bags_path

--- a/crowbar_framework/lib/tasks/crowbar.rake
+++ b/crowbar_framework/lib/tasks/crowbar.rake
@@ -37,4 +37,30 @@ namespace :crowbar do
     RAILS_ENV = "production"
     Rake::Task["crowbar:schema_migrate"].invoke(args[:barclamps])
   end
+
+  desc "Show the current proposal migration status"
+  task :schema_migrate_status, [:barclamps] => :environment do |t, args|
+    args.with_defaults(barclamps: nil)
+
+    require "schema_migration"
+    require "barclamp_catalog"
+
+    if args[:barclamps].nil?
+      barclamps = BarclampCatalog.barclamps.keys.join(" ")
+    else
+      barclamps = args[:barclamps]
+    end
+
+    printf "%-20s %-20s %s\n", "*barclamp*", "*latest revision*", "*proposals revision*"
+    barclamps.split.sort.each do |bc_name|
+      latest_schema_revision, latest_proposals_revision = \
+                              SchemaMigration.get_barclamp_current_deployment_revison bc_name
+      unless latest_proposals_revision.nil?
+        proposals_rev = latest_proposals_revision.sort.collect do |prop|
+          "#{prop[:name]}:#{prop[:revision]}"
+        end
+        printf "%-20s %-20s %s\n", bc_name, latest_schema_revision, proposals_rev.join(" ")
+      end
+    end
+  end
 end


### PR DESCRIPTION
To get an overview about the current migration status for the different
proposals, add a new rake task called "schema_migrate_status".
Calling the task with

RAILS_ENV=production rake crowbar:schema_migrate_status

gives a list with the template name, the latest possible revision and a list
of proposals with the currently applied revision. It looks like:

```
*barclamp*           *latest revision*    *proposals revision*
nova                 101                  default:101
keystone             35                   default:35
rabbitmq             11                   default:11
neutron              48                   default:48
```