### PR TITLE
crowbar: Fix error when trying to get status of non-existing proposal

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -788,6 +788,7 @@ class BarclampController < ApplicationController
           ).first
         ]
       end
+      result.compact!
 
       result.each do |prop|
         prop_id = "#{prop.barclamp}_#{prop.name}"


### PR DESCRIPTION
```
F, [2016-07-02T10:02:04.196340 #5021:0x000000061d6f90] FATAL -- Failed to iterate over proposal list due to 'undefined method `barclamp' for nil:NilClass'
/opt/dell/crowbar_framework/app/controllers/barclamp_controller.rb:793:in `block in proposal_status'
/opt/dell/crowbar_framework/app/controllers/barclamp_controller.rb:792:in `each'
/opt/dell/crowbar_framework/app/controllers/barclamp_controller.rb:792:in `proposal_status'
```