### PR TITLE
crowbar: Add unused bootstrap parameter to ServiceObject.active_update

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1673,7 +1673,7 @@ class ServiceObject
   # Proposal is a json structure (not a ProposalObject)
   # Use to create or update an active instance
   #
-  def active_update(proposal, inst, in_queue)
+  def active_update(proposal, inst, in_queue, bootstrap = false)
     begin
       role = ServiceObject.proposal_to_role(proposal, @bc_name)
       apply_role(role, inst, in_queue)


### PR DESCRIPTION
This is an API change that we need for later cleaning up the bootstrap
process.

Context: https://github.com/crowbar/crowbar-core/pull/516