### PR TITLE
provisioner: Fix reboot of discovered node (bsc#988021)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -200,7 +200,7 @@ if not nodes.nil? and not nodes.empty?
             if admin_data_net.nil?
               ipaddress mnode[:ipaddress]
             else
-              ipaddress admin_data_net.address unless admin_data_net.nil?
+              ipaddress admin_data_net.address
             end
             options [
               'if exists dhcp-parameter-request-list {

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -197,7 +197,11 @@ if not nodes.nil? and not nodes.empty?
           hostname mnode.name
           macaddress mac_list[i]
           if admin_mac_addresses.include?(mac_list[i])
-            ipaddress admin_data_net.address unless admin_data_net.nil?
+            if admin_data_net.nil?
+              ipaddress mnode[:ipaddress]
+            else
+              ipaddress admin_data_net.address unless admin_data_net.nil?
+            end
             options [
               'if exists dhcp-parameter-request-list {
     # Always send the PXELINUX options (specified in hexadecimal)


### PR DESCRIPTION
When a node is discovered, but not allocated, it is not assigned an IP
address in the admin network yet. Due to the dhcp template interpreting
"no IP" as "deny booting", this resulted in reboot of discovered nodes
blocking the nodes.

Now in such cases, we simply take the current IP address of the node.

https://bugzilla.suse.com/show_bug.cgi?id=988021

(cherry picked from commit 7711b4c63e1428bf8faeee5179da62878ebded1a)