### PR TITLE
exclude cloud 6 repos after upgrade

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -306,10 +306,8 @@ if node[:platform_family] == "suse" && !node.roles.include?("provisioner-server"
 
       out = `LANG=C zypper --non-interactive repos #{name} 2> /dev/null`
       out.split("\n").each do |line|
-        attribute, value = line.split(":", 2)
+        attribute, value = line.split(":", 2).map(&:strip)
         next if value.nil?
-        attribute.strip!
-        value.strip!
         if attribute == "URI"
           current_url = value
         elsif attribute == "Priority"

--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -311,7 +311,7 @@ if node[:platform_family] == "suse" && !node.roles.include?("provisioner-server"
         if attribute == "URI"
           current_url = value
         elsif attribute == "Priority"
-          current_priority = value
+          current_priority = value.to_i
         end
       end
 

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -299,9 +299,15 @@ if not nodes.nil? and not nodes.empty?
 
           target_platform_distro = os.gsub(/-.*$/, "")
           target_platform_version = os.gsub(/^.*-/, "")
-          repos = Provisioner::Repositories.get_repos(target_platform_distro,
-                                                      target_platform_version,
-                                                      arch)
+          repos = Provisioner::Repositories.get_repos(
+            target_platform_distro,
+            target_platform_version,
+            arch
+          )
+          # FIXME: We are just ignoring old repos after the upgrade here
+          # this needs to be improved for the next upgrade by actively removing
+          # the repositories after the upgrade (and on repo deactivation)
+          repos.reject! { |k, _v| k =~ /Cloud-6/ } if mnode[:state] == "os-upgrading"
           Chef::Log.info("repos: #{repos.inspect}")
 
           if node[:provisioner][:suse]


### PR DESCRIPTION
this is partially related to 

* https://bugzilla.suse.com/show_bug.cgi?id=975384
* https://trello.com/c/1VDjvMFc/1036-bsc-975384-issues-in-crowbar-s-repository-handling
* the upgrade CI (where it fails after the upgrade due to old repos still in the registry)

this extends https://github.com/crowbar/crowbar-core/pull/505 a bit further, which was not the complete fix