### PR TITLE
Disable haml rubocops for now

### DIFF
--- a/.hound.haml.yml
+++ b/.hound.haml.yml
@@ -1,5 +1,6 @@
 linters:
   LineLength:
     max: 150
-  UnnecessaryInterpolation:
+
+  RuboCop:
     enabled: false


### PR DESCRIPTION
Hound's haml linter does not support to change the default rubocop
config. This means that we will have always false positives e.g. single
quotes instead of double quotes.

See: https://github.com/houndci/hound/issues/1121