### PR TITLE
[3.0] crowbar: Do not use non-existing attributes in bulk edit (bsc#989994)

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -139,26 +139,6 @@ class NodesController < ApplicationController
               dirty = true
             end
 
-            if view_context.crowbar_options[:show].include?(:bios) and not [node.bios_set, "not_set"].include? node_attributes["bios"]
-              node.bios_set = node_attributes["bios"]
-              dirty = true
-            end
-
-            if view_context.crowbar_options[:show].include?(:raid) and not [node.raid_set, "not_set"].include? node_attributes["raid"]
-              node.raid_set = node_attributes["raid"]
-              dirty = true
-            end
-
-            unless node.group == node_attributes["group"]
-              unless node_attributes["group"].blank? or node_attributes["group"] =~ /^[a-zA-Z][a-zA-Z0-9._:-]+$/
-                report[:group_error] = true
-                raise I18n.t("nodes.list.group_error", failed: node.name)
-              end
-
-              node.group = node_attributes["group"]
-              dirty = true
-            end
-
             if dirty
               node.save
               report[:success].push node_name


### PR DESCRIPTION
We removed some attributes from the bulk edit page, but the controller
was still using them. This resulted in the bulk edit page resetting the
groups of the nodes.

Bug was introduced in https://github.com/crowbar/crowbar-core/pull/353 /
e4d575e8.

https://bugzilla.suse.com/show_bug.cgi?id=989994
(cherry picked from commit 35b696d263d6d82f6be2dad9494b6a842b5e7587)

Backport of https://github.com/crowbar/crowbar-core/pull/557