### PR TITLE
crowbar: Fix queue message when applying a proposal (bsc#989958)

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -517,6 +517,8 @@ class BarclampController < ApplicationController
           "crowbar-deep-merge-template"
         )
       )
+      # See FIXME in ServiceObject.apply_role
+      message = "" if code = 202
 
       respond_to do |format|
         case code

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -953,7 +953,9 @@ class ServiceObject
       # Attempt to queue the proposal.  If delay is empty, then run it.
       deps = proposal_dependencies(role)
       delay, pre_cached_nodes = queue_proposal(inst, element_order, new_elements, deps)
-      return [202, "Queued: waiting for #{delay.join(", ")}"] unless delay.empty?
+      # FIXME: this breaks the convention that we return a string; but really,
+      # we should return a hash everywhere, to avoid this...
+      return [202, delay] unless delay.empty?
 
       @logger.debug "delay empty - running proposal"
     end


### PR DESCRIPTION
There was an attempt to fix the internal API so that
ServiceObject.apply_role always returns [int, str], but this actually
breaks the UI-only path in the controller.

So revert this and document with a FIXME that this should eventually be
fixed by moving everything to [int, hash] where we will have more
freedom.

https://bugzilla.suse.com/show_bug.cgi?id=989958