### PR TITLE
crowbar: On restore, only restore roles that are for proposals and nodes

### DIFF
--- a/chef/data_bags/crowbar/migrate/ipmi/100_merge_roles.rb
+++ b/chef/data_bags/crowbar/migrate/ipmi/100_merge_roles.rb
@@ -6,6 +6,17 @@ def upgrade(ta, td, a, d)
   d["elements"]["ipmi"] = all_elements.uniq
   d["elements"].delete("ipmi-configure")
   d["elements"].delete("ipmi-discover")
+
+  # ipmi roles are on all nodes
+  NodeObject.all.each do |node|
+    node.add_to_run_list("ipmi",
+                         td["element_run_list_order"]["ipmi"],
+                         td["element_states"]["ipmi"])
+    node.delete_from_run_list("ipmi-configure")
+    node.delete_from_run_list("ipmi-discover")
+    node.save
+  end
+
   return a, d
 end
 
@@ -16,5 +27,18 @@ def downgrade(ta, td, a, d)
   d["elements"]["ipmi-configure"] = d["elements"]["ipmi"]
   d["elements"]["ipmi-discover"] = d["elements"]["ipmi"]
   d["elements"].delete("ipmi")
+
+  # ipmi roles are on all nodes
+  NodeObject.all.each do |node|
+    node.add_to_run_list("ipmi-configure",
+                         td["element_run_list_order"]["ipmi-configure"],
+                         td["element_states"]["ipmi-configure"])
+    node.add_to_run_list("ipmi-discover",
+                         td["element_run_list_order"]["ipmi-discover"],
+                         td["element_states"]["ipmi-discover"])
+    node.delete_from_run_list("ipmi")
+    node.save
+  end
+
   return a, d
 end

--- a/chef/data_bags/crowbar/migrate/provisioner/101_remove_bootdisk_finder.rb
+++ b/chef/data_bags/crowbar/migrate/provisioner/101_remove_bootdisk_finder.rb
@@ -2,6 +2,13 @@ def upgrade(ta, td, a, d)
   d["element_states"] = td["element_states"]
   d["element_order"] = td["element_order"]
   d["elements"].delete("provisioner-bootdisk-finder")
+
+  # provisioner-bootdisk-finder was on all nodes
+  NodeObject.all.each do |node|
+    node.delete_from_run_list("provisioner-bootdisk-finder")
+    node.save
+  end
+
   return a, d
 end
 
@@ -9,5 +16,14 @@ def downgrade(ta, td, a, d)
   d["element_states"] = td["element_states"]
   d["element_order"] = td["element_order"]
   d["elements"]["provisioner-bootdisk-finder"] = d["elements"]["provisioner-base"]
+
+  # provisioner-bootdisk-finder should be on all nodes
+  NodeObject.all.each do |node|
+    node.add_to_run_list("provisioner-bootdisk-finder",
+                         td["element_run_list_order"]["provisioner-bootdisk-finder"],
+                         td["element_states"]["provisioner-bootdisk-finder"])
+    node.save
+  end
+
   return a, d
 end

--- a/crowbar_framework/lib/crowbar/backup/base.rb
+++ b/crowbar_framework/lib/crowbar/backup/base.rb
@@ -100,6 +100,31 @@ module Crowbar
         def export_files
           restore_files.concat(restore_files_after_install).map(&:reverse)
         end
+
+        def filter_chef_node(name)
+          false
+        end
+        alias_method :filter_chef_nodes, :filter_chef_node
+
+        def filter_chef_role(name)
+          # Filter roles which are not crowbar roles (proposal + node roles)
+          # as they are code, not data
+          # The regexp for node roles is not great, but we know we have a _
+          # due to the domain, so it should be good enough
+          name !~ /(.+-config-.+)|(^crowbar-.+_.+)/
+        end
+        alias_method :filter_chef_roles, :filter_chef_role
+
+        def filter_chef_client(name)
+          # Filter client "crowbar" as we need the new one on restore anyway
+          name =~ /^crowbar$/
+        end
+        alias_method :filter_chef_clients, :filter_chef_client
+
+        def filter_chef_databag(db, name)
+          false
+        end
+        alias_method :filter_chef_databags, :filter_chef_databag
       end
     end
   end

--- a/crowbar_framework/lib/crowbar/backup/base.rb
+++ b/crowbar_framework/lib/crowbar/backup/base.rb
@@ -122,7 +122,9 @@ module Crowbar
         alias_method :filter_chef_clients, :filter_chef_client
 
         def filter_chef_databag(db, name)
-          false
+          # Filter items in crowbar data bag that are not network databag items
+          return false if db != "crowbar"
+          name !~ /.+_network$/
         end
         alias_method :filter_chef_databags, :filter_chef_databag
       end

--- a/crowbar_framework/lib/crowbar/backup/export.rb
+++ b/crowbar_framework/lib/crowbar/backup/export.rb
@@ -70,7 +70,8 @@ module Crowbar
           bag_dir.mkpath
 
           ::Chef::DataBag.load(name).each do |item, item_url|
-            next if item.match(/\Atemplate-.*/)
+            next if self.class.filter_chef_databag(name, item)
+
             logger.debug "Backing up databag #{name}/#{item}"
 
             record = ::Chef::DataBagItem.load(

--- a/crowbar_framework/lib/crowbar/backup/export.rb
+++ b/crowbar_framework/lib/crowbar/backup/export.rb
@@ -183,6 +183,8 @@ module Crowbar
         data_dir.mkpath
 
         klass.list.each do |name, url|
+          next if self.class.send("filter_chef_#{component}".to_sym, name)
+
           logger.debug "Backing up #{component} #{name}"
 
           record = klass.load(name)

--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -191,6 +191,10 @@ module Crowbar
               file = Pathname.new(file)
               # skip client "crowbar"
               next if type == :clients && file.basename.to_s =~ /^crowbar.json$/
+              # skip roles which are not crowbar roles (proposal + node roles)
+              # the regexp for node roles is not great, but we know we have a _
+              # due to the domain, so it should be good enough
+              next if type == :roles && file.basename.to_s !~ /(.+-config-.+)|(^crowbar-.+_.+)/
               next unless file.extname == ".json"
 
               record = JSON.load(file.read)

--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -195,8 +195,8 @@ module Crowbar
               if type == :databags
                 db = file.parent.basename.to_s
                 next if Crowbar::Backup::Base.send("filter_chef_#{type}".to_sym, db, name)
-              else
-                next if Crowbar::Backup::Base.send("filter_chef_#{type}".to_sym, name)
+              elsif Crowbar::Backup::Base.send("filter_chef_#{type}".to_sym, name)
+                next
               end
 
               record = JSON.load(file.read)


### PR DESCRIPTION
We do not want to restore roles such as provisioner-base, as the role
should be considered as code and not data, and it might be outdated in
the backup.