### PR TITLE
set maintenance mode or stop corosync/pacemaker on update

### DIFF
--- a/chef/cookbooks/updater/metadata.rb
+++ b/chef/cookbooks/updater/metadata.rb
@@ -22,5 +22,6 @@ long_description ""
 version "0.0.1"
 
 depends "utils"
+depends "crowbar-pacemaker"
 
 recipe "updater", "System Package Updater"


### PR DESCRIPTION
As per all the docs by pacemaker, the services should be stopped for a software update of the cluster stack.  If other packages are being updated but not the cluster stack, then it's enough to set maintenance mode.

**FIXME: however if the update is happening on a remote node, then the `crm` command is unavailable so we need to set maintenance mode another way.** **UPDATE:** something like https://github.com/crowbar/crowbar-ha/pull/187 might fix this.

Depends on ~~crowbar/crowbar-ha#183~~