### PR TITLE
crowbar-init: enable inclusion of sinatra/rails partials

### DIFF
--- a/configs/crowbar-rails.conf.partial
+++ b/configs/crowbar-rails.conf.partial
@@ -1,0 +1,3 @@
+ProxyPass / http://127.0.0.1:3000/ timeout=1500 Keepalive=On
+ProxyPassReverse / http://127.0.0.1:3000/
+SetEnv proxy-initial-not-pooled 1

--- a/configs/crowbar.conf
+++ b/configs/crowbar.conf
@@ -9,7 +9,5 @@
     ErrorDocument 422 /422.html
     ErrorDocument 500 /500.html
 
-    ProxyPass / http://127.0.0.1:3000/ timeout=1500 Keepalive=On
-    ProxyPassReverse / http://127.0.0.1:3000/
-    SetEnv proxy-initial-not-pooled 1
+    Include /etc/apache2/conf.d/crowbar.conf.partial
 </VirtualHost>


### PR DESCRIPTION
when crowbar-init is installed there will be a symlink created in
/etc/apache2/conf.d/crowbar/crowbar.conf which first points to:
https://github.com/crowbar/crowbar-init/blob/master/config/crowbar-sinatra.conf.partial
and once the work from crowbar-init is done this symlink will point to:
https://github.com/MaximilianMeister/crowbar-core/blob/apache/conf-sinatra/configs/crowbar-rails.conf.partial

NOTE:
@rsalevsky is working on the packaging side, and once this is done and tested this PR can be merged