### PR TITLE
Set proper permissions on the bind configuration directory

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -40,7 +40,12 @@ when "rhel", "suse"
   bindgroup = "named"
 end
 
-directory "/etc/bind"
+directory "/etc/bind" do
+  owner "root"
+  group bindgroup
+  mode 0770
+  action :create
+end
 
 unless node[:dns][:master]
   directory "/etc/bind/slave" do


### PR DESCRIPTION
This avoids the warning "named: working directory is not writeable"