### PR TITLE
Always install dmidecode

### DIFF
--- a/chef/cookbooks/ohai/recipes/default.rb
+++ b/chef/cookbooks/ohai/recipes/default.rb
@@ -82,6 +82,11 @@ unless node[:platform_family] == "windows"
     rescue LoadError
       Chef::Log.fatal("Unable to load cstruct module - install of #{pkg} failed?")
     end
+
+    # Install dmidecode - needed for better machine detection and network.json matching
+    if node[:kernel][:machine] =~ /(x86|aarch64)/
+      package("dmidecode").run_action(:install)
+    end
   end
 end
 


### PR DESCRIPTION
ohai and crowbars ohai plugins (and crowbar) depend heavily on the
system name and serial number to be always available, so make sure
this is installed all the time. Currently it is only conincidentally
installed on x86 and missing on aarch64.