### PR TITLE
sqlite2postgres: postgres wants explicit info how to convert/cast

### DIFF
--- a/crowbar_framework/db/migrate/20160223200120_change_backup_version_type.rb
+++ b/crowbar_framework/db/migrate/20160223200120_change_backup_version_type.rb
@@ -4,6 +4,11 @@ class ChangeBackupVersionType < ActiveRecord::Migration
   end
 
   def down
-    change_column :backups, :version, :float
+    type = if Rails.configuration.database_configuration[Rails.env]["adapter"] == "postgresql"
+      "float USING version::double precision"
+    else
+      :float
+    end
+    change_column :backups, :version, type
   end
 end


### PR DESCRIPTION
this can unfortunately not be done in another migration on top as
the PG::DatatypeMismatch error happens already within the migration
but it shouldn't be a problem as it is cloud 7 only

~~NOTE: this can only be merged after the final switch to postgres~~ with the if else this statement is not valid anymore

### Related PRs:
* https://github.com/crowbar/crowbar-core/pull/571
* https://github.com/crowbar/crowbar-init/pull/16