### PR TITLE
Ironic network

### DIFF
--- a/chef/data_bags/crowbar/migrate/network/101_add_ironic_network.rb
+++ b/chef/data_bags/crowbar/migrate/network/101_add_ironic_network.rb
@@ -1,0 +1,14 @@
+def upgrade(ta, td, a, d)
+  unless a["networks"].key? "ironic"
+    a["networks"]["ironic"] = ta["networks"]["ironic"]
+  end
+  # the "intf3" conduit mappings are not added as there's no easy way to
+  # auto-assign physical interfaces properly.
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  # there's no easy way to ensure that "ironic" and "intf3" entries were not
+  # added by the user so it's safer to not delete anything
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-network.json
+++ b/chef/data_bags/crowbar/template-network.json
@@ -87,6 +87,9 @@
             },
             "intf2": {
               "if_list": [ "1g1", "1g2" ]
+            },
+            "intf3": {
+              "if_list": [ "1g1", "1g2" ]
             }
           }
         },
@@ -101,6 +104,26 @@
             },
             "intf2": {
               "if_list": [ "?1g1" ]
+            },
+            "intf3": {
+              "if_list": [ "?1g2" ]
+            }
+          }
+        },
+        {
+          "pattern": "single/.*/.*ironic.*",
+          "conduit_list": {
+            "intf0": {
+              "if_list": [ "?1g1" ]
+            },
+            "intf1": {
+              "if_list": [ "?1g1" ]
+            },
+            "intf2": {
+              "if_list": [ "?1g1" ]
+            },
+            "intf3": {
+              "if_list": [ "?1g2" ]
             }
           }
         },
@@ -114,6 +137,9 @@
               "if_list": [ "?1g1" ]
             },
             "intf2": {
+              "if_list": [ "?1g1" ]
+            },
+            "intf3": {
               "if_list": [ "?1g1" ]
             }
           }
@@ -129,6 +155,9 @@
             },
             "intf2": {
               "if_list": [ "1g1" ]
+            },
+            "intf3": {
+              "if_list": [ "1g1" ]
             }
           }
         },
@@ -142,6 +171,9 @@
               "if_list": [ "?1g1" ]
             },
             "intf2": {
+              "if_list": [ "?1g1" ]
+            },
+            "intf3": {
               "if_list": [ "?1g1" ]
             }
           }
@@ -242,6 +274,23 @@
             "host": { "start": "192.168.130.10", "end": "192.168.130.254"}
           }
         },
+        "ironic": {
+          "conduit": "intf3",
+          "vlan": 100,
+          "use_vlan": false,
+          "add_bridge": false,
+          "add_ovs_bridge": false,
+          "bridge_name": "br-ironic",
+          "subnet": "192.168.127.0",
+          "netmask": "255.255.255.0",
+          "broadcast": "192.168.127.255",
+          "router": "192.168.127.1",
+          "router_pref": 50,
+          "ranges": {
+            "admin": { "start": "192.168.127.10", "end": "192.168.127.11" },
+            "dhcp": { "start": "192.168.127.21", "end": "192.168.127.254" }
+          }
+        },
         "admin": {
           "conduit": "intf0",
           "vlan": 100,
@@ -267,7 +316,7 @@
     "network": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "network": [ "readying", "ready", "applying" ]
       },

--- a/crowbar_framework/config/locales/network/en.yml
+++ b/crowbar_framework/config/locales/network/en.yml
@@ -54,6 +54,7 @@ en:
       public: 'Public'
       private: 'Private'
       storage: 'Storage'
+      ironic: 'Ironic'
     controller:
       virtual: 'Virtual'
 


### PR DESCRIPTION
This change introduces an additional "Ironic" network type to Crowbar. It is a dedicated network to handle network booting of baremetal nodes.
