### PR TITLE
only run remote chef client once per node

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1271,6 +1271,8 @@ class ServiceObject
     pre_cached_nodes = {}
 
     # Each batch is a list of nodes that can be done in parallel.
+    # only run remote chef-clent on a node once
+    batches.uniq!
     batches.each do |nodes|
       @logger.debug "Applying batch: #{nodes.inspect}"
 


### PR DESCRIPTION
when applying the provisioner proposal, where base and server are
on the admin node, the list of nodes says:
`[["admin.crowbar.com"], ["admin.crowbar.com"]]`
which actually triggers two chef client runs in parallel on the admin