### PR TITLE
Fix when node roles are empty

### DIFF
--- a/crowbar_framework/app/models/deployer_service.rb
+++ b/crowbar_framework/app/models/deployer_service.rb
@@ -77,7 +77,8 @@ class DeployerService < ServiceObject
     if state == "hardware-installing"
       node = NodeObject.find_node_by_name(name)
       # build a list of current and pending roles to check against
-      roles = node.roles.dup
+      roles = []
+      roles = node.roles.dup if node.roles
       unless node.crowbar["crowbar"]["pending"].nil?
         roles.concat(node.crowbar["crowbar"]["pending"].values)
       end


### PR DESCRIPTION
We found that sometimes node roles are empty in the hardware-installing
phase. This leads to an error that prevents the nodes to be properly
installed and remain just discovered forever.