### PR TITLE
Return run_list_to_roles method, to prevent empty roles list.

### DIFF
--- a/crowbar_framework/app/models/deployer_service.rb
+++ b/crowbar_framework/app/models/deployer_service.rb
@@ -82,6 +82,8 @@ class DeployerService < ServiceObject
       unless node.crowbar["crowbar"]["pending"].nil?
         roles.concat(node.crowbar["crowbar"]["pending"].values)
       end
+      roles << node.run_list_to_roles
+      roles.flatten!
 
       # Walk map to categorize the node.  Choose first one from the bios map that matches.
       role = RoleObject.find_role_by_name "#{@bc_name}-config-#{inst}"
@@ -99,9 +101,11 @@ class DeployerService < ServiceObject
         break if done
       end
 
-      os_map = role.default_attributes["deployer"]["os_map"]
-      node.crowbar["crowbar"]["hardware"]["os"] = os_map[0]["install_os"]
-      node.save
+      unless node.crowbar["crowbar"]["hardware"].nil?
+        os_map = role.default_attributes["deployer"]["os_map"]
+        node.crowbar["crowbar"]["hardware"]["os"] = os_map[0]["install_os"]
+        node.save
+      end
     end
 
     # The discovery image needs to have clients cleared.

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -759,6 +759,16 @@ class NodeObject < ChefObject
     old_run_list != crowbar_run_list.run_list_items
   end
 
+  def run_list_to_roles
+    crowbar["run_list_map"] = {} if crowbar["run_list_map"].nil?
+    a = crowbar["run_list_map"].select { |k, v| v["priority"] != -1001 }
+    if a.is_a?(Hash)
+      a.keys
+    else
+      a.collect! { |x| x[0] }
+    end
+  end
+
   def crowbar
     @role.default_attributes
   end


### PR DESCRIPTION
This function was removed before, but now we are hitting the error that the roles list of a node is sometimes empty during transition to hardware-installing.

UPDATE: this is the error we're trying to fix:
```
D, [2016-08-08T07:02:08.344171 #11272:0x007f248dcd5d08] DEBUG -- Deployer transition: entering: d52-54-77-77-77-05.vc2.cloud.suse.de for hardware-installing
F, [2016-08-08T07:02:08.393637 #11272:0x007f248dcd5d08] FATAL -- json/transition for deployer:default failed: undefined method `[]=' for nil:NilClass
F, [2016-08-08T07:02:08.393966 #11272:0x007f248dcd5d08] FATAL -- /opt/dell/crowbar_framework/app/models/deployer_service.rb:103:in `transition'
...
```
This reverts parts of https://github.com/crowbar/crowbar-core/pull/515. @nicolasbock @MaximilianMeister , you've reviewed original PR, could you also take a look here?