### PR TITLE
Automatically register modules into crowbar

### DIFF
--- a/crowbar_framework/config/boot.rb
+++ b/crowbar_framework/config/boot.rb
@@ -107,3 +107,11 @@ else
   gem "chef", version: "~> 10.32.2"
   require "chef"
 end
+
+includes_path = Pathname.new("/var/lib/crowbar/includes/")
+if includes_path.directory?
+  includes_path.each_child(false) do |file|
+    next unless file.extname == ".rb"
+    require_relative "/var/lib/crowbar/includes/#{file}"
+  end
+end

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -18,7 +18,7 @@
 Rails.application.routes.draw do
   apipie
 
-  route_dirs = [Pathname.new("/var/lib/crowbar/routes.d/"), Rails.root.join("config", "routes.d")]
+  route_dirs = [Pathname.new("/var/lib/crowbar/includes/"), Rails.root.join("config", "routes.d")]
   route_dirs.each do |route_dir|
     next unless route_dir.directory?
     route_dir.children.each do |routes|


### PR DESCRIPTION
This change is required to include modules like crowbar-init into
crowbar without adapting the crowbar source code for this.