### PR TITLE
[stable/3.0] dump schema.rb in production

### DIFF
--- a/crowbar_framework/config/environments/production.rb
+++ b/crowbar_framework/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
 
   config.active_record.migration_error = :page_load
-  config.active_record.dump_schema_after_migration = false
+  config.active_record.dump_schema_after_migration = true
 
   config.assets.debug = false
   config.assets.raise_runtime_errors = true


### PR DESCRIPTION
this will be used by YamlDB to import the schema.rb and the data.yml
dump into the new postgresql database during the upgrade from 6 to 7

(cherry picked from commit df655856b06191c807aabdf4d2c5aa12342971fc)