### PR TITLE
[stable/3.0] Change permits to be backwards compatible

### DIFF
--- a/crowbar_framework/app/controllers/backups_controller.rb
+++ b/crowbar_framework/app/controllers/backups_controller.rb
@@ -182,6 +182,6 @@ class BackupsController < ApplicationController
   end
 
   def backup_upload_params
-    params.require(:backup).permit(:file)
+    params.require(:backup).require(:payload).permit(:file)
   end
 end


### PR DESCRIPTION
since we changed from httparty to rest-client, we require a different
parameter structure for file uploads.
to be in line with the update in crowbar-client, and to avoid having
to patch the content section in the client, we adapt the permits on
the server side