### PR TITLE
[stable/3.0] Remove target_platform and default_os valus from admin node

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -47,6 +47,15 @@ module Api
       end
 
       if upgrade_script_path.exist?
+
+        # admin node will have different OS after the upgrade
+        admin_node = NodeObject.admin_node
+        admin_node["target_platform"] = ""
+        if admin_node["provisioner"] && admin_node["provisioner"]["default_os"]
+          admin_node["provisioner"].delete "default_os"
+        end
+        admin_node.save
+
         pid = spawn("sudo #{upgrade_script_path}")
         Process.detach(pid)
         Rails.logger.info("#{upgrade_script_path} executed with pid: #{pid}")

--- a/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe Api::CrowbarController, type: :request do
   context "with a successful crowbar API request" do
+    let(:admin_node) { NodeObject.find_node_by_name("admin") }
     let(:headers) { { ACCEPT: "application/vnd.crowbar.v2.0+json" } }
     let(:pid) { rand(20000..30000) }
     let!(:crowbar_upgrade_status) do
@@ -62,6 +63,7 @@ describe Api::CrowbarController, type: :request do
         receive_message_chain(:upgrade_script_path, :exist?).
         and_return(true)
       )
+      allow(NodeObject).to receive(:admin_node).and_return(admin_node)
 
       post "/api/crowbar/upgrade", {}, headers
       expect(response).to have_http_status(:ok)

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 describe Api::Crowbar do
   let(:pid) { rand(20000..30000) }
+  let(:admin_node) { NodeObject.find_node_by_name("admin") }
   let!(:crowbar_upgrade_status) do
     JSON.parse(
       File.read(
@@ -59,6 +60,7 @@ describe Api::Crowbar do
         receive_message_chain(:upgrade_script_path, :exist?).
         and_return(true)
       )
+      allow(NodeObject).to receive(:admin_node).and_return(admin_node)
 
       expect(subject.upgrade!).to be true
     end


### PR DESCRIPTION
We need it to be filled by new values after the OS upgrade.

`admin_node["provisioner"]["default_os"]` is used to set the new OS for nodes after the server is upgraded
