### PR TITLE
enable canceling the upgrade

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -69,6 +69,17 @@ class Api::UpgradeController < ApiController
     render json: @upgrade.check
   end
 
+  api :POST, "/api/upgrade/cancel", "Cancel the upgrade process by setting the nodes back to ready"
+  api_version "2.0"
+  def cancel
+    service_object = CrowbarService.new(Rails.logger)
+    service_object.revert_nodes_from_crowbar_upgrade
+
+    head :ok
+  rescue => e
+    render json: { error: e.message }, status: :unprocessable_entity
+  end
+
   protected
 
   def set_upgrade

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -429,17 +429,16 @@ class CrowbarService < ServiceObject
     proposal = ProposalObject.find_proposal("crowbar", "default")
 
     NodeObject.all.each do |node|
-      if node.state == "crowbar_upgrade"
-        # revert nodes to previous state; mark the wall so apply does not change state again
-        node["crowbar_wall"]["crowbar_upgrade_step"] = "revert_to_ready"
-        node.save
-        node.set_state("ready")
-      end
+      next unless node.state == "crowbar_upgrade"
+      # revert nodes to previous state; mark the wall so apply does not change state again
+      node["crowbar_wall"]["crowbar_upgrade_step"] = "revert_to_ready"
+      node.save
+      node.set_state("ready")
     end
 
     # commit current proposal (with the crowbar-upgrade role still assigned to nodes),
     # so the recipe is executed when nodes have 'ready' state
-    self.proposal_commit("default", false, false)
+    proposal_commit("default", false, false)
     # now remove the nodes from upgrade role
     proposal["deployment"]["crowbar"]["elements"]["crowbar-upgrade"] = []
     proposal.save

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -425,6 +425,26 @@ class CrowbarService < ServiceObject
     upgrade_nodes_failed
   end
 
+  def revert_nodes_from_crowbar_upgrade
+    proposal = ProposalObject.find_proposal("crowbar", "default")
+
+    NodeObject.all.each do |node|
+      if node.state == "crowbar_upgrade"
+        # revert nodes to previous state; mark the wall so apply does not change state again
+        node["crowbar_wall"]["crowbar_upgrade_step"] = "revert_to_ready"
+        node.save
+        node.set_state("ready")
+      end
+    end
+
+    # commit current proposal (with the crowbar-upgrade role still assigned to nodes),
+    # so the recipe is executed when nodes have 'ready' state
+    self.proposal_commit("default", false, false)
+    # now remove the nodes from upgrade role
+    proposal["deployment"]["crowbar"]["elements"]["crowbar-upgrade"] = []
+    proposal.save
+  end
+
   def apply_role_pre_chef_call(old_role, role, all_nodes)
     @logger.debug("crowbar apply_role_pre_chef_call: entering #{all_nodes.inspect}")
     all_nodes.each do |n|

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -275,6 +275,7 @@ Rails.application.routes.draw do
       post :services
       get :services
       get :prechecks
+      post :cancel
     end
 
     resources :nodes,

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -54,5 +54,26 @@ describe Api::UpgradeController, type: :request do
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq(upgrade_prechecks)
     end
+
+    it "cancels the upgrade" do
+      allow_any_instance_of(CrowbarService).to receive(
+        :revert_nodes_from_crowbar_upgrade
+      ).and_return(true)
+
+      post "/api/upgrade/cancel", {}, headers
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "fails to cancel the upgrade" do
+      allow_any_instance_of(CrowbarService).to receive(
+        :revert_nodes_from_crowbar_upgrade
+      ).and_raise("an Error")
+
+      post "/api/upgrade/cancel", {}, headers
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.body).to eq(
+        "{\"error\":\"an Error\"}"
+      )
+    end
   end
 end


### PR DESCRIPTION
by adding another api endpoint to reset the nodes to ready
this function has been used in cloud5 as well