### PR TITLE
upgrade: add API for admin repocheck

### DIFF
--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -52,6 +52,12 @@ class Api::CrowbarController < ApiController
     }
   end
 
+  api :GET, "/api/crowbar/repocheck", "Sanity check for Crowbar server repositories"
+  api_version "2.0"
+  def repocheck
+    render json: @crowbar.repocheck
+  end
+
   protected
 
   def set_crowbar

--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -55,7 +55,15 @@ class Api::CrowbarController < ApiController
   api :GET, "/api/crowbar/repocheck", "Sanity check for Crowbar server repositories"
   api_version "2.0"
   def repocheck
-    render json: @crowbar.repocheck
+    check = @crowbar.repocheck
+
+    if @crowbar.errors.any?
+      render json: {
+        error: @crowbar.errors.full_messages.first
+      }, status: :service_unavailable
+    else
+      render json: check
+    end
   end
 
   protected

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -92,14 +92,28 @@ module Api
 
     def repocheck
       # FIXME: once we start working on 7 to 8 upgrade we have to adapt the sles version
-      {
-        os: {
-          available: repo_version_available?("SLES", "12.2")
-        },
-        cloud: {
-          available: repo_version_available?("suse-openstack-cloud", "8")
+      zypper_stream = Hash.from_xml(
+        `sudo /usr/bin/zypper-retry --xmlout products`
+      )["stream"]
+
+      {}.tap do |ret|
+        if zypper_stream["message"] =~ /^System management is locked/
+          errors.add(
+            :base,
+            I18n.t("api.crowbar.zypper_locked", zypper_locked_message: zypper_stream["message"])
+          )
+          return ret
+        end
+
+        products = zypper_stream["product_list"]["product"]
+
+        ret[:os] = {
+          available: repo_version_available?(products, "SLES", "12.2")
         }
-      }
+        ret[:cloud] = {
+          available: repo_version_available?(products, "suse-openstack-cloud", "8")
+        }
+      end
     end
 
     protected
@@ -138,11 +152,7 @@ module Api
       false
     end
 
-    def repo_version_available?(product, version)
-      products = Hash.from_xml(
-        `zypper --xmlout products`
-      )["stream"]["product_list"]["product"]
-
+    def repo_version_available?(products, product, version)
       products.any? do |p|
         p["version"] == version && p["name"] == product
       end

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -90,6 +90,18 @@ module Api
       end
     end
 
+    def repocheck
+      # FIXME: once we start working on 7 to 8 upgrade we have to adapt the sles version
+      {
+        os: {
+          available: repo_version_available?("SLES", "12.2")
+        },
+        cloud: {
+          available: repo_version_available?("suse-openstack-cloud", "8")
+        }
+      }
+    end
+
     protected
 
     def lib_path
@@ -124,6 +136,16 @@ module Api
       true
     rescue NameError
       false
+    end
+
+    def repo_version_available?(product, version)
+      products = Hash.from_xml(
+        `zypper --xmlout products`
+      )["stream"]["product_list"]["product"]
+
+      products.any? do |p|
+        p["version"] == version && p["name"] == product
+      end
     end
   end
 end

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -771,6 +771,7 @@ en:
       destroy_failed: 'Failed to destroy %{component}'
     crowbar:
       upgrade_ongoing: 'Upgrade is already ongoing. Please wait.'
+      zypper_locked: '%{zypper_locked_message}'
 
   # Global
   overview: 'Overview'

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -767,6 +767,8 @@ en:
       cache_error: 'Failed to cache sanity checks'
 
   api:
+    error:
+      destroy_failed: 'Failed to destroy %{component}'
     crowbar:
       upgrade_ongoing: 'Upgrade is already ongoing. Please wait.'
 
@@ -878,7 +880,3 @@ en:
     poweron: 'Power On'
     pending: 'Pending'
     building: 'Building'
-
-  api:
-    error:
-      destroy_failed: 'Failed to destroy %{component}'

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -250,6 +250,7 @@ Rails.application.routes.draw do
       get :upgrade
       post :upgrade
       get :maintenance
+      get :repocheck
 
       resources :backups,
         only: [:index, :show, :create, :destroy] do

--- a/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
@@ -25,6 +25,13 @@ describe Api::CrowbarController, type: :request do
         )
       ).to_json
     end
+    let!(:crowbar_repocheck) do
+      JSON.parse(
+        File.read(
+          "spec/fixtures/crowbar_repocheck.json"
+        )
+      ).to_json
+    end
 
     it "shows the crowbar object" do
       get "/api/crowbar", {}, headers
@@ -71,6 +78,16 @@ describe Api::CrowbarController, type: :request do
       get "/api/crowbar/maintenance", {}, headers
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq(crowbar_maintenance)
+    end
+
+    it "checks the crowbar repositories" do
+      allow_any_instance_of(Api::Crowbar).to(
+        receive(:repocheck).and_return(crowbar_repocheck)
+      )
+
+      get "/api/crowbar/repocheck", {}, headers
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq(crowbar_repocheck)
     end
   end
 end

--- a/crowbar_framework/spec/fixtures/crowbar_repocheck.json
+++ b/crowbar_framework/spec/fixtures/crowbar_repocheck.json
@@ -1,0 +1,8 @@
+{
+  "os":{
+    "available":true
+  },
+  "cloud":{
+    "available":true
+  }
+}

--- a/crowbar_framework/spec/fixtures/crowbar_repocheck_zypper.xml
+++ b/crowbar_framework/spec/fixtures/crowbar_repocheck_zypper.xml
@@ -1,0 +1,17 @@
+<?xml version='1.0'?>
+<stream>
+<message type="info">Loading repository data...</message>
+<message type="info">Reading installed packages...</message>
+<product-list>
+<product name="SLES" version="12.2" release="0" epoch="0" arch="x86_64" vendor="SUSE LLC &lt;https://www.suse.com/&gt;" summary="SUSE Linux Enterprise Server 12 SP2 RC2" repo="sles12sp2" productline="" registerrelease="" shortname="SLES12-SP2" flavor="POOL" isbase="false" installed="false"><endoflife time_t="1730332800" text="2024-10-31T01:00:00+01"/><registerflavor/><description>SUSE Linux Enterprise offers a comprehensive
+        suite of products built on a single code base.
+        The platform addresses business needs from
+        the smallest thin-client devices to the world&apos;s
+        most powerful high-performance computing
+        and mainframe servers. SUSE Linux Enterprise
+        offers common management tools and technology
+        certifications across the platform, and
+        each product is enterprise-class.</description></product>
+<product name="suse-openstack-cloud" version="7" release="0" epoch="0" arch="x86_64" vendor="SUSE LINUX GmbH, Nuernberg, Germany" summary="SUSE OpenStack Cloud 7" repo="@System" productline="suse-openstack-cloud" registerrelease="" shortname="SOC7" flavor="cd" isbase="false" installed="true"><endoflife time_t="1556150400" text="2019-04-25T02:00:00+02"/><registerflavor>extension</registerflavor><description>SUSE OpenStack Cloud 7</description></product>
+</product-list>
+</stream>

--- a/crowbar_framework/spec/fixtures/crowbar_repocheck_zypper_locked.xml
+++ b/crowbar_framework/spec/fixtures/crowbar_repocheck_zypper_locked.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0'?>
+<stream>
+<message type="error">System management is locked by the application with pid 18904 (zypper).
+Close this application before trying again.</message>
+</stream>

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -23,6 +23,16 @@ describe Api::Crowbar do
       )
     )
   end
+  let!(:crowbar_repocheck_zypper) do
+    File.read(
+      "spec/fixtures/crowbar_repocheck_zypper.xml"
+    ).to_s
+  end
+  let!(:crowbar_repocheck_zypper_locked) do
+    File.read(
+      "spec/fixtures/crowbar_repocheck_zypper_locked.xml"
+    ).to_s
+  end
 
   before(:each) do
     allow_any_instance_of(Kernel).to(
@@ -120,6 +130,11 @@ describe Api::Crowbar do
       allow_any_instance_of(Api::Crowbar).to(
         receive(:repo_version_available?).and_return(true)
       )
+      allow_any_instance_of(Kernel).to(
+        receive(:`).with(
+          "sudo /usr/bin/zypper-retry --xmlout products"
+        ).and_return(crowbar_repocheck_zypper)
+      )
 
       expect(subject.repocheck.deep_stringify_keys).to eq(crowbar_repocheck)
     end
@@ -130,8 +145,31 @@ describe Api::Crowbar do
       allow_any_instance_of(Api::Crowbar).to(
         receive(:repo_version_available?).and_return(false)
       )
+      allow_any_instance_of(Kernel).to(
+        receive(:`).with(
+          "sudo /usr/bin/zypper-retry --xmlout products"
+        ).and_return(crowbar_repocheck_zypper)
+      )
 
       expect(subject.repocheck.deep_stringify_keys).to_not eq(crowbar_repocheck)
+    end
+  end
+
+  context "with a locked zypper" do
+    it "shows an error message that zypper is locked" do
+      allow_any_instance_of(Api::Crowbar).to(
+        receive(:repo_version_available?).and_return(false)
+      )
+      allow_any_instance_of(Kernel).to(
+        receive(:`).with(
+          "sudo /usr/bin/zypper-retry --xmlout products"
+        ).and_return(crowbar_repocheck_zypper_locked)
+      )
+
+      subject.repocheck
+      expect(subject.errors.full_messages.first).to eq(
+        Hash.from_xml(crowbar_repocheck_zypper_locked)["stream"]["message"]
+      )
     end
   end
 end

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -16,6 +16,13 @@ describe Api::Crowbar do
       )
     )
   end
+  let!(:crowbar_repocheck) do
+    JSON.parse(
+      File.read(
+        "spec/fixtures/crowbar_repocheck.json"
+      )
+    )
+  end
 
   before(:each) do
     allow_any_instance_of(Kernel).to(
@@ -105,6 +112,26 @@ describe Api::Crowbar do
   context "with no addons installed" do
     it "lists no addons" do
       expect(subject.addons).to eq([])
+    end
+  end
+
+  context "with repositories in place" do
+    it "lists the available repositories" do
+      allow_any_instance_of(Api::Crowbar).to(
+        receive(:repo_version_available?).and_return(true)
+      )
+
+      expect(subject.repocheck.deep_stringify_keys).to eq(crowbar_repocheck)
+    end
+  end
+
+  context "with repositories not in place" do
+    it "lists the repositories that are not available" do
+      allow_any_instance_of(Api::Crowbar).to(
+        receive(:repo_version_available?).and_return(false)
+      )
+
+      expect(subject.repocheck.deep_stringify_keys).to_not eq(crowbar_repocheck)
     end
   end
 end


### PR DESCRIPTION
this endpoint is to make sure that the cloud and sp2 repos are available
before upgrading the admin server