### PR TITLE
add helper for node repo target platform and enable failed repolist for repochecks

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -34,6 +34,19 @@ module Api
       }
     end
 
+    def target_platform(options = {})
+      platform_exception = options.fetch(:platform_exception, nil)
+
+      case Api::Crowbar.new.version
+      when "4.0"
+        if platform_exception == :ceph
+          ::Crowbar::Product.ses_platform
+        else
+          NodeObject.admin_node.target_platform
+        end
+      end
+    end
+
     protected
 
     def crowbar_upgrade_status

--- a/crowbar_framework/lib/crowbar/repository.rb
+++ b/crowbar_framework/lib/crowbar/repository.rb
@@ -183,7 +183,11 @@ module Crowbar
 
       private
 
-      def provided_with_enabled(feature, platform = nil, arch = nil, check_enabled = true, repos = {})
+      def provided_with_enabled(feature,
+                                platform = nil,
+                                arch = nil,
+                                check_enabled = true,
+                                repos = {})
         answer = false
 
         if platform.nil?


### PR DESCRIPTION
this will be used by ceph and ha to make sure that the system
repositories, alongside the addon repositories are available
and enabled during the upgrade