### PR TITLE
Switch to SES4 repos

### DIFF
--- a/crowbar_framework/config/repos-cloud.yml
+++ b/crowbar_framework/config/repos-cloud.yml
@@ -171,6 +171,26 @@ suse-12.2:
       url:
       smt_path: "SUSE/Updates/SLE-HA/12-SP2/aarch64/update"
       ask_on_error: false
+    suse-enterprise-storage-4-pool:
+      name: "SUSE-Enterprise-Storage-4-Pool"
+      required: "optional"
+      features: ["ceph"]
+      repomd:
+        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:Update:Products:SES4/ses/4/POOL/aarch64"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Products/Storage/4/aarch64/product"
+      ask_on_error: false
+    suse-enterprise-storage-4-updates:
+      name: "SUSE-Enterprise-Storage-4-Updates"
+      required: "optional"
+      features: ["ceph"]
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:Storage:4:aarch64/update"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Updates/Storage/4/aarch64/update"
+      ask_on_error: false
     ptf:
       name: "PTF"
       required: "recommended"
@@ -250,6 +270,25 @@ suse-12.2:
       url:
       smt_path: "SUSE/Updates/SLE-HA/12-SP2/x86_64/update"
       ask_on_error: false
+    suse-enterprise-storage-4-pool:
+      name: "SUSE-Enterprise-Storage-4-Pool"
+      required: "optional"
+      features: ["ceph"]
+      repomd:
+        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:Update:Products:SES4/ses/4/POOL/x86_64"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Products/Storage/4/x86_64/product"
+      ask_on_error: false
+    suse-enterprise-storage-4-updates:
+      name: "SUSE-Enterprise-Storage-4-Updates"
+      required: "optional"
+      features: ["ceph"]
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:Storage:4:x86_64/update"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Updates/Storage/4/x86_64/update"
     ptf:
       name: "PTF"
       required: "recommended"

--- a/crowbar_framework/config/repos-ses.yml
+++ b/crowbar_framework/config/repos-ses.yml
@@ -7,7 +7,7 @@ suse-12.1:
       features: ["os"]
       repomd:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP1:GA/SLES/12.1/POOL/x86_64"
-        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
       url:
       smt_path: "SUSE/Products/SLE-SERVER/12-SP1/x86_64/product"
       ask_on_error: false
@@ -17,7 +17,7 @@ suse-12.1:
       features: ["os"]
       repomd:
         tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP1:x86_64/update"
-        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
       url:
       smt_path: "SUSE/Updates/SLE-SERVER/12-SP1/x86_64/update"
       ask_on_error: false
@@ -27,7 +27,7 @@ suse-12.1:
       features: ["ha"]
       repomd:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP1:GA/sle-ha/12.1/POOL/x86_64"
-        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
       url:
       smt_path: "SUSE/Products/SLE-HA/12-SP1/x86_64/product"
       ask_on_error: false
@@ -37,30 +37,162 @@ suse-12.1:
       features: ["ha"]
       repomd:
         tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-HA:12-SP1:x86_64/update"
-        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
       url:
       smt_path: "SUSE/Updates/SLE-HA/12-SP1/x86_64/update"
       ask_on_error: false
     suse-enterprise-storage-3-pool:
       name: "SUSE-Enterprise-Storage-3-Pool"
-      required: "optional"
+      required: "mandatory"
       features: ["ceph"]
       repomd:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP1:Update:Products:SES3/ses/3/POOL/x86_64"
-        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
       url:
       smt_path: "SUSE/Products/Storage/3/x86_64/product"
       ask_on_error: false
     suse-enterprise-storage-3-updates:
       name: "SUSE-Enterprise-Storage-3-Updates"
-      required: "optional"
+      required: "mandatory"
       features: ["ceph"]
-#      repomd:
-#        tag: "obsrepository://build.suse.de/SUSE:Updates:Storage:2.1:x86_64/update"
-#        key_md5: "9a62177e1c6852d48453ed3909956d6b"
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:Storage:3:x86_64/update"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
       url:
       smt_path: "SUSE/Updates/Storage/3/x86_64/update"
       ask_on_error: false
+    ptf:
+      name: "PTF"
+      required: "recommended"
+      url:
+      ask_on_error: false
+suse-12.2:
+  aarch64:
+    sles12-sp2-pool:
+      name: "SLES12-SP2-Pool"
+      required: "mandatory"
+      features: ["os"]
+      repomd:
+        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:GA/SLES/12.2/POOL/aarch64"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Products/SLE-SERVER/12-SP2/aarch64/product"
+      ask_on_error: false
+    sles12-sp2-updates:
+      name: "SLES12-SP2-Updates"
+      required: "mandatory"
+      features: ["os"]
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP2:aarch64/update"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Updates/SLE-SERVER/12-SP2/aarch64/update"
+      ask_on_error: false
+    sle12-sp2-ha-pool:
+      name: "SLE12-SP2-HA-Pool"
+      required: "optional"
+      features: ["ha"]
+      repomd:
+        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:GA/sle-ha/12.2/POOL/aarch64"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Products/SLE-HA/12-SP2/aarch64/product"
+      ask_on_error: false
+    sle12-sp2-ha-updates:
+      name: "SLE12-SP2-HA-Updates"
+      required: "optional"
+      features: ["ha"]
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-HA:12-SP2:aarch64/update"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Updates/SLE-HA/12-SP2/aarch64/update"
+      ask_on_error: false
+    suse-enterprise-storage-4-pool:
+      name: "SUSE-Enterprise-Storage-4-Pool"
+      required: "mandatory"
+      features: ["ceph"]
+      repomd:
+        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:Update:Products:SES4/ses/4/POOL/aarch64"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Products/Storage/4/aarch64/product"
+      ask_on_error: false
+    suse-enterprise-storage-4-updates:
+      name: "SUSE-Enterprise-Storage-4-Updates"
+      required: "mandatory"
+      features: ["ceph"]
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:Storage:4:aarch64/update"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Updates/Storage/4/aarch64/update"
+      ask_on_error: false
+    ptf:
+      name: "PTF"
+      required: "recommended"
+      url:
+      ask_on_error: false
+  x86_64:
+    sles12-sp2-pool:
+      name: "SLES12-SP2-Pool"
+      required: "mandatory"
+      features: ["os"]
+      repomd:
+        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:GA/SLES/12.2/POOL/x86_64"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Products/SLE-SERVER/12-SP2/x86_64/product"
+      ask_on_error: false
+    sles12-sp2-updates:
+      name: "SLES12-SP2-Updates"
+      required: "mandatory"
+      features: ["os"]
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-SERVER:12-SP2:x86_64/update"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Updates/SLE-SERVER/12-SP2/x86_64/update"
+      ask_on_error: false
+    sle12-sp2-ha-pool:
+      name: "SLE12-SP2-HA-Pool"
+      required: "optional"
+      features: ["ha"]
+      repomd:
+        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:GA/sle-ha/12.2/POOL/x86_64"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Products/SLE-HA/12-SP2/x86_64/product"
+      ask_on_error: false
+    sle12-sp2-ha-updates:
+      name: "SLE12-SP2-HA-Updates"
+      required: "optional"
+      features: ["ha"]
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:SLE-HA:12-SP2:x86_64/update"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Updates/SLE-HA/12-SP2/x86_64/update"
+      ask_on_error: false
+    suse-enterprise-storage-4-pool:
+      name: "SUSE-Enterprise-Storage-4-Pool"
+      required: "mandatory"
+      features: ["ceph"]
+      repomd:
+        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP2:Update:Products:SES4/ses/4/POOL/x86_64"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Products/Storage/4/x86_64/product"
+      ask_on_error: false
+    suse-enterprise-storage-4-updates:
+      name: "SUSE-Enterprise-Storage-4-Updates"
+      required: "mandatory"
+      features: ["ceph"]
+      repomd:
+        tag: "obsrepository://build.suse.de/SUSE:Updates:Storage:4:x86_64/update"
+        fingerprint: "FEAB 5025 39D8 46DB 2C09 61CA 70AF 9E81 39DB 7C82"
+      url:
+      smt_path: "SUSE/Updates/Storage/4/x86_64/update"
     ptf:
       name: "PTF"
       required: "recommended"


### PR DESCRIPTION
Note: the repomd piece is commented out, so it won't actually check the
repo properly (this means you can mount early SES4 DVD media instead of
a real repo if necessary).

Signed-off-by: Tim Serong <tserong@suse.com>