### PR TITLE
Search for number of compute nodes.

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -128,9 +128,12 @@ module Api
     end
 
     def compute_resources_available?
-      compute_nodes = NodeObject.find("roles:nova-compute-kvm")
-      if compute_nodes.size == 1
-        Rails.logger.warn("Only one compute node found; non-disruptive upgrade is not possible!")
+      ["kvm", "xen"].each do |virt|
+        compute_nodes = NodeObject.find("roles:nova-compute-#{virt}")
+        next unless compute_nodes.size == 1
+        Rails.logger.warn(
+          "Found only one compute node of #{virt} type; non-disruptive upgrade is not possible"
+        )
         return false
       end
       true

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -127,6 +127,15 @@ module Api
       true
     end
 
+    def compute_resources_available?
+      compute_nodes = NodeObject.find("roles:nova-compute-kvm")
+      if compute_nodes.size == 1
+        Rails.logger.warn("Only one compute node found; non-disruptive upgrade is not possible!")
+        return false
+      end
+      true
+    end
+
     protected
 
     def lib_path

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -72,8 +72,7 @@ module Api
     end
 
     def compute_resources_available?
-      # FIXME: to be implemented
-      true
+      Api::Crowbar.new.compute_resources_available?
     end
   end
 end

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -172,14 +172,29 @@ describe Api::Crowbar do
         receive(:find).with("roles:nova-compute-kvm").
         and_return([node, node])
       )
+      allow(NodeObject).to(
+        receive(:find).with("roles:nova-compute-xen").
+        and_return([node, node])
+      )
       expect(subject.compute_resources_available?).to be true
     end
   end
 
   context "with not enough compute resources" do
-    it "finds there is only one compute node and fails" do
+    it "finds there is only one KVM compute node and fails" do
       allow(NodeObject).to(
         receive(:find).with("roles:nova-compute-kvm").
+        and_return([node])
+      )
+      expect(subject.compute_resources_available?).to be false
+    end
+    it "finds there is only one XEN compute node and fails" do
+      allow(NodeObject).to(
+        receive(:find).with("roles:nova-compute-kvm").
+        and_return([node, node])
+      )
+      allow(NodeObject).to(
+        receive(:find).with("roles:nova-compute-xen").
         and_return([node])
       )
       expect(subject.compute_resources_available?).to be false
@@ -190,6 +205,10 @@ describe Api::Crowbar do
     it "finds there is no compute node at all" do
       allow(NodeObject).to(
         receive(:find).with("roles:nova-compute-kvm").
+        and_return([])
+      )
+      allow(NodeObject).to(
+        receive(:find).with("roles:nova-compute-xen").
         and_return([])
       )
       expect(subject.compute_resources_available?).to be true


### PR DESCRIPTION
Ideally we would like to have a check telling us that it will be
possible to migrate all workloads out from one node.
We can't have such check 100% reliable, so we rather won't do any.

(cherry picked from commit 139fd6904ac582db7d4442a9605e63fb3e2ed72d)

Forward port of https://github.com/crowbar/crowbar-core/pull/623