### PR TITLE
integrate repocheck for nodes in the upgrade api

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -80,6 +80,12 @@ class Api::UpgradeController < ApiController
     render json: { error: e.message }, status: :unprocessable_entity
   end
 
+  api :GET, "/api/upgrade/repocheck", "Check for missing node repositories"
+  api_version "2.0"
+  def repocheck
+    render json: @upgrade.repocheck
+  end
+
   protected
 
   def set_upgrade

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -24,7 +24,8 @@ module Api
 
       {}.tap do |ret|
         ret[addon] = {
-          "available" => true
+          "available" => true,
+          "repos" => {}
         }
         platform = Api::Upgrade.new.target_platform(platform_exception: addon)
 
@@ -40,7 +41,6 @@ module Api
                 feature, platform, architecture
               )
               ret[addon]["available"] &&= available
-              ret[addon]["repos"] ||= {}
               ret[addon]["repos"].deep_merge!(repolist.deep_stringify_keys)
             end
           else

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -20,6 +20,7 @@ module Api
       addon = options.fetch(:addon, "os")
       features = []
       features.push(addon)
+      architectures = node_architectures
 
       {}.tap do |ret|
         ret[addon] = {
@@ -28,8 +29,8 @@ module Api
         platform = Api::Upgrade.new.target_platform(platform_exception: addon)
 
         features.each do |feature|
-          if node_architectures(addon: addon).any?
-            node_architectures(addon: addon).each do |architecture|
+          if architectures[feature]
+            architectures[feature].each do |architecture|
               unless ::Crowbar::Repository.provided_and_enabled?(feature,
                                                                  platform,
                                                                  architecture)
@@ -51,25 +52,35 @@ module Api
 
     protected
 
-    def node_architectures(options = {})
-      addon = options.fetch(:addon, nil)
-      addon = "pacemaker" if addon == "ha"
-      architectures = []
-      proposals = Proposal.where(barclamp: addon)
-      return architectures if proposals.empty?
+    def node_architectures
+      {}.tap do |ret|
+        NodeObject.all.each do |node|
+          arch = node.architecture
+          ret["os"] ||= []
+          ret["os"].push(arch) unless ret["os"].include?(arch)
 
-      proposals.each do |prop|
-        next unless RoleObject.all.detect { |r| r.barclamp == addon && r.proposal? }
-        node_names = prop.properties["deployment"][addon]["elements"].values.flatten.uniq
-        next if node_names == []
+          if ceph_node?(node)
+            ret["ceph"] ||= []
+            ret["ceph"].push(arch) unless ret["ceph"].include?(arch)
+          else
+            ret["openstack"] ||= []
+            ret["openstack"].push(arch) unless ret["openstack"].include?(arch)
+          end
 
-        nodes = node_names.map { |n| NodeObject.find_node_by_name(n) }
-        nodes.map(&:architecture).uniq.each do |arch|
-          architectures.push(arch) unless architectures.include?(arch)
+          if pacemaker_node?(node)
+            ret["ha"] ||= []
+            ret["ha"].push(arch) unless ret["ha"].include?(arch)
+          end
         end
       end
+    end
 
-      architectures
+    def ceph_node?(node)
+      node.roles.include?("ceph-config-default")
+    end
+
+    def pacemaker_node?(node)
+      node.roles.grep(/^pacemaker-config-.*/).any?
     end
   end
 end

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -44,7 +44,7 @@ module Api
               ret[addon]["repos"].deep_merge!(repolist.deep_stringify_keys)
             end
           else
-            ret.delete(addon)
+            ret[addon]["available"] = false
           end
         end
       end

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -15,6 +15,57 @@
 #
 
 module Api
-  class Node
+  class Node < Tableless
+    def repocheck(options = {})
+      addon = options.fetch(:addon, "os")
+      features = []
+      features.push(addon)
+
+      {}.tap do |ret|
+        ret[addon] = {
+          "available" => true
+        }
+        platform = Api::Upgrade.new.target_platform(platform_exception: addon)
+
+        features.each do |feature|
+          node_architectures(addon: addon).each do |architecture|
+            unless ::Crowbar::Repository.provided_and_enabled?(feature,
+                                                               platform,
+                                                               architecture)
+              ::Openstack::Upgrade.enable_repos_for_feature(feature, Rails.logger)
+            end
+            available, repolist = ::Crowbar::Repository.provided_and_enabled_with_repolist(
+              feature, platform, architecture
+            )
+            ret[addon]["available"] &&= available
+            ret[addon]["repos"] ||= {}
+            ret[addon]["repos"].deep_merge!(repolist.deep_stringify_keys)
+          end
+        end
+      end
+    end
+
+    protected
+
+    def node_architectures(options = {})
+      addon = options.fetch(:addon, nil)
+      addon = "pacemaker" if addon == "ha"
+      architectures = []
+      proposals = Proposal.where(barclamp: addon)
+      return architectures if proposals.empty?
+
+      proposals.each do |prop|
+        next unless RoleObject.all.detect { |r| r.barclamp == addon && r.proposal? }
+        node_names = prop.properties["deployment"][addon]["elements"].values.flatten.uniq
+        next if node_names == []
+
+        nodes = node_names.map { |n| NodeObject.find_node_by_name(n) }
+        nodes.map(&:architecture).uniq.each do |arch|
+          architectures.push(arch) unless architectures.include?(arch)
+        end
+      end
+
+      architectures
+    end
   end
 end

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -35,6 +35,15 @@ module Api
       }
     end
 
+    def repocheck
+      response = {}
+      addons = Api::Crowbar.new.addons
+      addons.push("os").each do |addon|
+        response.merge!(Api::Node.new.repocheck(addon: addon))
+      end
+      response
+    end
+
     def target_platform(options = {})
       platform_exception = options.fetch(:platform_exception, nil)
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -38,7 +38,7 @@ module Api
     def repocheck
       response = {}
       addons = Api::Crowbar.new.addons
-      addons.push("os").each do |addon|
+      addons.push("os", "openstack").each do |addon|
         response.merge!(Api::Node.new.repocheck(addon: addon))
       end
       response

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -277,6 +277,7 @@ Rails.application.routes.draw do
       get :services
       get :prechecks
       post :cancel
+      get :repocheck
     end
 
     resources :nodes,

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -75,5 +75,17 @@ describe Api::UpgradeController, type: :request do
         "{\"error\":\"an Error\"}"
       )
     end
+
+    it "checks for node repositories" do
+      allow_any_instance_of(Api::Upgrade).to(
+        receive(:target_platform).and_return("suse-12.2")
+      )
+
+      get "/api/upgrade/repocheck", {}, headers
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq(
+        "{\"os\":{\"available\":true},\"openstack\":{\"available\":true}}"
+      )
+    end
   end
 end

--- a/crowbar_framework/spec/fixtures/node_repocheck.json
+++ b/crowbar_framework/spec/fixtures/node_repocheck.json
@@ -10,5 +10,9 @@
   "ha": {
     "available": true,
     "repos": {}
+  },
+  "openstack": {
+    "available": true,
+    "repos": {}
   }
 }

--- a/crowbar_framework/spec/fixtures/node_repocheck.json
+++ b/crowbar_framework/spec/fixtures/node_repocheck.json
@@ -1,0 +1,14 @@
+{
+  "os": {
+    "available": true,
+    "repos": {}
+  },
+  "ceph": {
+    "available": true,
+    "repos": {}
+  },
+  "ha": {
+    "available": true,
+    "repos": {}
+  }
+}

--- a/crowbar_framework/spec/fixtures/node_repocheck_missing.json
+++ b/crowbar_framework/spec/fixtures/node_repocheck_missing.json
@@ -16,40 +16,6 @@
       }
     }
   },
-  "ceph": {
-    "available": false,
-    "repos": {
-      "missing_repos": {
-        "x86_64": [
-          "SUSE-Enterprise-Storage-3-Pool",
-          "SUSE-Enterprise-Storage-3-Updates"
-        ]
-      },
-      "inactive_repos": {
-        "x86_64": [
-          "SUSE-Enterprise-Storage-3-Pool",
-          "SUSE-Enterprise-Storage-3-Updates"
-        ]
-      }
-    }
-  },
-  "ha": {
-    "available": false,
-    "repos": {
-      "missing_repos": {
-        "x86_64": [
-          "SLE12-SP2-HA-Pool",
-          "SLE12-SP2-HA-Updates"
-        ]
-      },
-      "inactive_repos": {
-        "x86_64": [
-          "SLE12-SP2-HA-Pool",
-          "SLE12-SP2-HA-Updates"
-        ]
-      }
-    }
-  },
   "openstack": {
     "available": false,
     "repos": {

--- a/crowbar_framework/spec/fixtures/node_repocheck_missing.json
+++ b/crowbar_framework/spec/fixtures/node_repocheck_missing.json
@@ -1,0 +1,53 @@
+{
+  "os": {
+    "available": false,
+    "repos": {
+      "missing_repos": {
+        "x86_64": [
+          "SLES12-SP2-Pool",
+          "SLES12-SP2-Updates"
+        ]
+      },
+      "inactive_repos": {
+        "x86_64": [
+          "SLES12-SP2-Pool",
+          "SLES12-SP2-Updates"
+        ]
+      }
+    }
+  },
+  "ceph": {
+    "available": false,
+    "repos": {
+      "missing_repos": {
+        "x86_64": [
+          "SUSE-Enterprise-Storage-3-Pool",
+          "SUSE-Enterprise-Storage-3-Updates"
+        ]
+      },
+      "inactive_repos": {
+        "x86_64": [
+          "SUSE-Enterprise-Storage-3-Pool",
+          "SUSE-Enterprise-Storage-3-Updates"
+        ]
+      }
+    }
+  },
+  "ha": {
+    "available": false,
+    "repos": {
+      "missing_repos": {
+        "x86_64": [
+          "SLE12-SP2-HA-Pool",
+          "SLE12-SP2-HA-Updates"
+        ]
+      },
+      "inactive_repos": {
+        "x86_64": [
+          "SLE12-SP2-HA-Pool",
+          "SLE12-SP2-HA-Updates"
+        ]
+      }
+    }
+  }
+}

--- a/crowbar_framework/spec/fixtures/node_repocheck_missing.json
+++ b/crowbar_framework/spec/fixtures/node_repocheck_missing.json
@@ -49,5 +49,24 @@
         ]
       }
     }
+  },
+  "openstack": {
+    "available": false,
+    "repos": {
+      "missing_repos": {
+        "x86_64": [
+          "Cloud",
+          "SUSE-OpenStack-Cloud-7-Pool",
+          "SUSE-OpenStack-Cloud-7-Updates"
+        ]
+      },
+      "inactive_repos": {
+        "x86_64": [
+          "Cloud",
+          "SUSE-OpenStack-Cloud-7-Pool",
+          "SUSE-OpenStack-Cloud-7-Updates"
+        ]
+      }
+    }
   }
 }

--- a/crowbar_framework/spec/models/api/node_spec.rb
+++ b/crowbar_framework/spec/models/api/node_spec.rb
@@ -40,56 +40,6 @@ describe Api::Node do
       )
     )
   end
-  let!(:ceph_repo_missing) do
-    allow(::Crowbar::Repository).to(
-      receive(:provided_and_enabled_with_repolist).with(
-        "ceph", "suse-12.2", "x86_64"
-      ).and_return(
-        [
-          false,
-          {
-            "missing_repos" => {
-              "x86_64" => [
-                "SUSE-Enterprise-Storage-3-Pool",
-                "SUSE-Enterprise-Storage-3-Updates"
-              ]
-            },
-            "inactive_repos" => {
-              "x86_64" => [
-                "SUSE-Enterprise-Storage-3-Pool",
-                "SUSE-Enterprise-Storage-3-Updates"
-              ]
-            }
-          }
-        ]
-      )
-    )
-  end
-  let!(:ha_repo_missing) do
-    allow(::Crowbar::Repository).to(
-      receive(:provided_and_enabled_with_repolist).with(
-        "ha", "suse-12.2", "x86_64"
-      ).and_return(
-        [
-          false,
-          {
-            "missing_repos" => {
-              "x86_64" => [
-                "SLE12-SP2-HA-Pool",
-                "SLE12-SP2-HA-Updates"
-              ]
-            },
-            "inactive_repos" => {
-              "x86_64" => [
-                "SLE12-SP2-HA-Pool",
-                "SLE12-SP2-HA-Updates"
-              ]
-            }
-          }
-        ]
-      )
-    )
-  end
   let!(:openstack_repo_missing) do
     allow(::Crowbar::Repository).to(
       receive(:provided_and_enabled_with_repolist).with(
@@ -123,7 +73,12 @@ describe Api::Node do
       receive(:target_platform).and_return("suse-12.2")
     )
     allow_any_instance_of(Api::Node).to(
-      receive(:node_architectures).and_return(["x86_64"])
+      receive(:node_architectures).and_return(
+        "os" => ["x86_64"],
+        "openstack" => ["x86_64"],
+        "ceph" => ["x86_64"],
+        "ha" => ["x86_64"]
+      )
     )
     allow(::Crowbar::Repository).to(
       receive(:provided_and_enabled?).and_return(true)
@@ -167,7 +122,7 @@ describe Api::Node do
       expected = {}
       got = {}
 
-      ["os", "ceph", "ha", "openstack"].each do |feature|
+      ["os", "openstack"].each do |feature|
         # stub repolist
         send("#{feature}_repo_missing".to_sym)
 

--- a/crowbar_framework/spec/models/api/node_spec.rb
+++ b/crowbar_framework/spec/models/api/node_spec.rb
@@ -1,0 +1,153 @@
+require "spec_helper"
+
+describe Api::Node do
+  let!(:node_repocheck) do
+    JSON.parse(
+      File.read(
+        "spec/fixtures/node_repocheck.json"
+      )
+    )
+  end
+  let!(:node_repocheck_missing) do
+    JSON.parse(
+      File.read(
+        "spec/fixtures/node_repocheck_missing.json"
+      )
+    )
+  end
+  let!(:os_repo_missing) do
+    allow(::Crowbar::Repository).to(
+      receive(:provided_and_enabled_with_repolist).with(
+        "os", "suse-12.2", "x86_64"
+      ).and_return(
+        [
+          false,
+          {
+            "missing_repos" => {
+              "x86_64" => [
+                "SLES12-SP2-Pool",
+                "SLES12-SP2-Updates"
+              ]
+            },
+            "inactive_repos" => {
+              "x86_64" => [
+                "SLES12-SP2-Pool",
+                "SLES12-SP2-Updates"
+              ]
+            }
+          }
+        ]
+      )
+    )
+  end
+  let!(:ceph_repo_missing) do
+    allow(::Crowbar::Repository).to(
+      receive(:provided_and_enabled_with_repolist).with(
+        "ceph", "suse-12.2", "x86_64"
+      ).and_return(
+        [
+          false,
+          {
+            "missing_repos" => {
+              "x86_64" => [
+                "SUSE-Enterprise-Storage-3-Pool",
+                "SUSE-Enterprise-Storage-3-Updates"
+              ]
+            },
+            "inactive_repos" => {
+              "x86_64" => [
+                "SUSE-Enterprise-Storage-3-Pool",
+                "SUSE-Enterprise-Storage-3-Updates"
+              ]
+            }
+          }
+        ]
+      )
+    )
+  end
+  let!(:ha_repo_missing) do
+    allow(::Crowbar::Repository).to(
+      receive(:provided_and_enabled_with_repolist).with(
+        "ha", "suse-12.2", "x86_64"
+      ).and_return(
+        [
+          false,
+          {
+            "missing_repos" => {
+              "x86_64" => [
+                "SLE12-SP2-HA-Pool",
+                "SLE12-SP2-HA-Updates"
+              ]
+            },
+            "inactive_repos" => {
+              "x86_64" => [
+                "SLE12-SP2-HA-Pool",
+                "SLE12-SP2-HA-Updates"
+              ]
+            }
+          }
+        ]
+      )
+    )
+  end
+
+  before(:each) do
+    allow_any_instance_of(Api::Upgrade).to(
+      receive(:target_platform).and_return("suse-12.2")
+    )
+    allow_any_instance_of(Api::Node).to(
+      receive(:node_architectures).and_return(["x86_64"])
+    )
+    allow(::Crowbar::Repository).to(
+      receive(:provided_and_enabled?).and_return(true)
+    )
+  end
+
+  context "with a successful nodes repocheck" do
+    it "finds the os repositories required to upgrade the nodes" do
+      allow(::Crowbar::Repository).to(
+        receive(:provided_and_enabled_with_repolist).with(
+          "os", "suse-12.2", "x86_64"
+        ).and_return([true, {}])
+      )
+
+      os_repo_fixture = node_repocheck.tap do |k|
+        k.delete("ceph")
+        k.delete("ha")
+      end
+
+      expect(subject.repocheck).to eq(os_repo_fixture)
+    end
+
+    it "finds the os and addon repositories required to upgrade the nodes" do
+      ["os", "ceph", "ha"].each do |feature|
+        allow(::Crowbar::Repository).to(
+          receive(:provided_and_enabled_with_repolist).with(
+            feature, "suse-12.2", "x86_64"
+          ).and_return([true, {}])
+        )
+
+        expect(subject.repocheck(addon: feature)).to eq(
+          feature.to_s => node_repocheck[feature]
+        )
+      end
+    end
+  end
+
+  context "with a failed nodes repocheck" do
+    it "doesn't find the repositories required to upgrade the nodes" do
+      expected = {}
+      got = {}
+
+      ["os", "ceph", "ha"].each do |feature|
+        # stub repolist
+        send("#{feature}_repo_missing".to_sym)
+
+        expected[feature] = node_repocheck_missing[feature]
+        got.merge!(subject.repocheck(addon: feature))
+      end
+
+      expect(got).to eq(expected)
+    end
+  end
+end

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -59,7 +59,7 @@ describe Api::Upgrade do
       allow(::Crowbar::Repository).to(
         receive(:provided_and_enabled?).and_return(true)
       )
-      ["os", "ceph", "ha"].each do |feature|
+      ["os", "ceph", "ha", "openstack"].each do |feature|
         allow(::Crowbar::Repository).to(
           receive(:provided_and_enabled_with_repolist).with(
             feature, "suse-12.2", "x86_64"

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -15,6 +15,13 @@ describe Api::Upgrade do
       )
     )
   end
+  let!(:node_repocheck) do
+    JSON.parse(
+      File.read(
+        "spec/fixtures/node_repocheck.json"
+      )
+    )
+  end
 
   context "with a successful creation of an upgrade object" do
     it "checks the type" do
@@ -32,12 +39,40 @@ describe Api::Upgrade do
     end
   end
 
-  context "with a successful check" do
+  context "with a successful maintenance updates check" do
     it "checks the maintenance updates on crowbar" do
       allow(Crowbar::Sanity).to receive(:sane?).and_return(true)
 
       expect(subject).to respond_to(:check)
       expect(subject.check.deep_stringify_keys).to eq(upgrade_prechecks)
+    end
+  end
+
+  context "with a successful node repocheck" do
+    it "checks the repositories for the nodes" do
+      allow_any_instance_of(Api::Upgrade).to(
+        receive(:target_platform).and_return("suse-12.2")
+      )
+      allow_any_instance_of(Api::Node).to(
+        receive(:node_architectures).and_return(["x86_64"])
+      )
+      allow(::Crowbar::Repository).to(
+        receive(:provided_and_enabled?).and_return(true)
+      )
+      ["os", "ceph", "ha"].each do |feature|
+        allow(::Crowbar::Repository).to(
+          receive(:provided_and_enabled_with_repolist).with(
+            feature, "suse-12.2", "x86_64"
+          ).and_return([true, {}])
+        )
+      end
+
+      os_repo_fixture = node_repocheck.tap do |k|
+        k.delete("ceph")
+        k.delete("ha")
+      end
+
+      expect(subject.repocheck).to eq(os_repo_fixture)
     end
   end
 end

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -50,11 +50,25 @@ describe Api::Upgrade do
 
   context "with a successful node repocheck" do
     it "checks the repositories for the nodes" do
-      allow_any_instance_of(Api::Upgrade).to(
-        receive(:target_platform).and_return("suse-12.2")
+      allow_any_instance_of(Api::Node).to(
+        receive(:node_architectures).and_return(
+          "os" => ["x86_64"],
+          "openstack" => ["x86_64"],
+          "ceph" => ["x86_64"],
+          "ha" => ["x86_64"]
+        )
       )
       allow_any_instance_of(Api::Node).to(
-        receive(:node_architectures).and_return(["x86_64"])
+        receive(:ceph_node?).and_return(true)
+      )
+      allow_any_instance_of(Api::Node).to(
+        receive(:pacemaker_node?).and_return(true)
+      )
+      allow(NodeObject).to(
+        receive(:all).and_return([NodeObject.find_node_by_name("testing")])
+      )
+      allow_any_instance_of(Api::Upgrade).to(
+        receive(:target_platform).and_return("suse-12.2")
       )
       allow(::Crowbar::Repository).to(
         receive(:provided_and_enabled?).and_return(true)


### PR DESCRIPTION
integrate the repochecks for nodes, which can be performed for the system repos and the addon repos.

expose an accumulated check through the upgrade API

some code moved from https://github.com/crowbar/crowbar-ceph/pull/68 