### PR TITLE
[stable/3.0] upgrade: Move the cluster health check from crowbar_service

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -312,44 +312,6 @@ class CrowbarService < ServiceObject
     base
   end
 
-  # Simple check if HA clusters report some problems
-  # If there are no problems, empty hash is returned.
-  # If this fails, information about failed actions for each cluster founder is
-  # returned in a hash that looks like this:
-  # {
-  #     "crm_failures" => {
-  #             "node1" => "reason for crm status failure"
-  #     },
-  #     "failed_actions" => {
-  #             "node2" => "Failed action on this node"
-  #     }
-  # }
-  # User has to manually clean pacemaker resources before proceeding with the upgrade.
-  def check_cluster_health
-    ret = {}
-    crm_failures = {}
-    failed_actions = {}
-
-    cluster_founders = NodeObject.find("pacemaker_founder:true AND pacemaker_config_environment:*")
-    return ret if cluster_founders.empty?
-    check_if_nodes_are_available cluster_founders
-
-    cluster_founders.each do |n|
-      ssh_retval = n.run_ssh_cmd("crm status 2>&1")
-      if ssh_retval[:exit_code] != 0
-        crm_failures[n.name] = ssh_retval[:stdout]
-        next
-      end
-      ssh_retval = n.run_ssh_cmd("LANG=C crm status | grep -A 2 '^Failed Actions:'")
-      if ssh_retval[:exit_code] == 0
-        failed_actions[n.name] = ssh_retval[:stdout]
-      end
-    end
-    ret["crm_failures"] = crm_failures unless crm_failures.empty?
-    ret["failed_actions"] = failed_actions unless failed_actions.empty?
-    ret
-  end
-
   def prepare_nodes_for_crowbar_upgrade
     proposal = Proposal.find_by(barclamp: "crowbar", name: "default")
 


### PR DESCRIPTION
In master, we have this function under api/cluster (which is not present in 3.0), see https://github.com/crowbar/crowbar-ha/pull/138

But here in 3.0, it probably belongs to the same place where the other checks are (ceph_healthy? etc.)