### PR TITLE
Temporary fix to enable upgrade of the nodes

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -389,6 +389,14 @@ class CrowbarService < ServiceObject
     end
 
     commit_and_check_proposal
+
+    # FIXME: upgrade of the nodes needs to be correctly orchestrated, to upgrade nodes one by one
+    # Now we're adding this only to imitate original autoyast-based upgrade and to
+    # have current upgrade CI job working
+    upgrade_nodes.each do |node|
+      Rails.logger.info("initiating upgrade of node #{node.name}")
+      node.ssh_cmd("/usr/sbin/crowbar-upgrade-os.sh")
+    end
   end
 
   def revert_nodes_from_crowbar_upgrade


### PR DESCRIPTION
After merging https://github.com/crowbar/crowbar-core/pull/640 we are currently not upgrading the nodes, only preparing them for upgrade

Upgrade of the nodes needs to be correctly orchestrated, to upgrade nodes one by one
Now we're adding this only only to imitate original autoyast-based upgrad and to
have current upgrade CI job working.

Remove this code once we have correct orchestration in place.