### PR TITLE
adapt admin repocheck response to the nodes repocheck response

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -107,12 +107,23 @@ module Api
 
         products = zypper_stream["product_list"]["product"]
 
+        os_available = repo_version_available?(products, "SLES", "12.2")
         ret[:os] = {
-          available: repo_version_available?(products, "SLES", "12.2")
+          available: os_available,
+          repos: {}
         }
+        ret[:os][:repos][admin_architecture.to_sym] = {
+          missing_repos: ["SUSE Linux Enterprise Server 12 SP2"]
+        } unless os_available
+
+        cloud_available = repo_version_available?(products, "suse-openstack-cloud", "8")
         ret[:cloud] = {
-          available: repo_version_available?(products, "suse-openstack-cloud", "8")
+          available: cloud_available,
+          repos: {}
         }
+        ret[:cloud][:repos][admin_architecture.to_sym] = {
+          missing_repos: ["SUSE OpenStack Cloud 8"]
+        } unless cloud_available
       end
     end
 
@@ -179,6 +190,10 @@ module Api
       products.any? do |p|
         p["version"] == version && p["name"] == product
       end
+    end
+
+    def admin_architecture
+      NodeObject.admin_node.architecture
     end
   end
 end

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -107,13 +107,13 @@ module Api
 
         products = zypper_stream["product_list"]["product"]
 
-        os_available = repo_version_available?(products, "SLES", "12.2")
+        os_available = repo_version_available?(products, "SLES", "12.3")
         ret[:os] = {
           available: os_available,
           repos: {}
         }
         ret[:os][:repos][admin_architecture.to_sym] = {
-          missing_repos: ["SUSE Linux Enterprise Server 12 SP2"]
+          missing_repos: ["SUSE Linux Enterprise Server 12 SP3"]
         } unless os_available
 
         cloud_available = repo_version_available?(products, "suse-openstack-cloud", "8")

--- a/crowbar_framework/spec/fixtures/crowbar_repocheck.json
+++ b/crowbar_framework/spec/fixtures/crowbar_repocheck.json
@@ -1,8 +1,10 @@
 {
   "os":{
-    "available":true
+    "available":true,
+    "repos": {}
   },
   "cloud":{
-    "available":true
+    "available":true,
+    "repos": {}
   }
 }

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -235,6 +235,9 @@ describe Api::Crowbar do
       allow_any_instance_of(Api::Crowbar).to(
         receive(:repo_version_available?).and_return(false)
       )
+      allow_any_instance_of(Api::Crowbar).to(
+        receive(:admin_architecture).and_return("x86_64")
+      )
       allow_any_instance_of(Kernel).to(
         receive(:`).with(
           "sudo /usr/bin/zypper-retry --xmlout products"


### PR DESCRIPTION
when using the repocheck API for nodes and for crowbar the result
should have the same structure

@vuntz @jsuchome that's just one proposal, the other solution would be to rename one of `/api/crowbar/repocheck` or `/api/upgrade/repocheck` to clear a bit the confusion that the check is performed in a different way. (see https://github.com/crowbar/crowbar-core/pull/644)

I am not sure what is best here, but IMO it is nicer to have `crowbarctl` return the same json structure for the `repocheck` subcommand (see https://github.com/crowbar/crowbar-client/pull/104)