### PR TITLE
Stop openstack services before upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -75,67 +75,14 @@ when "openstack_shutdown"
 
   include_recipe "crowbar::stop-services-before-upgrade"
 
-  bash "delete pacemaker resources in non-DB cluster" do
-    code <<-EOF
-      if /etc/init.d/openais status ; then
-        cibadmin -E -f
-      fi
-    EOF
-    only_if { ::File.exist?("/usr/sbin/cibadmin") }
-  end
-
-  # Stop DRBD and corosync.
-  # (Note that this node is not running database)
-  service "drbd" do
-    action :stop
-  end
-  service "openais" do
-    action :stop
-  end
-  service "openais-shutdown" do
-    action :stop
-  end
-
 when "dump_openstack_database"
 
   include_recipe "crowbar::stop-services-before-upgrade"
 
 when "db_shutdown"
 
-  bash "stop remaining pacemaker resources" do
-    code <<-EOF
-      for type in clone ms primitive; do
-        for resource in $(crm configure show | grep ^$type | cut -d " " -f2);
-        do
-          crm --force --wait resource stop $resource
-        done
-      done
-    EOF
-    only_if { ::File.exist?("/usr/sbin/crm") }
-  end
+  # nothing to see here, move along
 
-  bash "delete pacemaker resources in DB cluster" do
-    code <<-EOF
-      if /etc/init.d/openais status ; then
-        cibadmin -E -f
-      fi
-    EOF
-    only_if { ::File.exist?("/usr/sbin/cibadmin") }
-  end
-
-  # Stop the database and corosync
-  service "drbd" do
-    action :stop
-  end
-  service "openais" do
-    action :stop
-  end
-  service "postgresql" do
-    action :stop
-  end
-  service "openais-shutdown" do
-    action :stop
-  end
 when "done_openstack_shutdown", "wait_for_openstack_shutdown"
   Chef::Log.debug("Nothing to do on this node, waiting for others to finish their work...")
 else

--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -54,7 +54,6 @@ when "crowbar_upgrade"
         systemctl disable $i
       done
     EOF
-    not_if { ::File.exist?("/usr/sbin/crm") }
   end
 
   # Disable crowbar-join

--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -47,7 +47,7 @@ when "crowbar_upgrade"
 
   bash "disable_openstack_services" do
     code <<-EOF
-      for i in $(systemctl list-units openstack* --no-legend | cut -d" " -f1 | grep -v keystone | grep -v neutron) \
+      for i in $(systemctl list-units openstack* --no-legend | cut -d" " -f1 | grep -Ev 'keystone|neutron') \
                drbd.service \
                pacemaker.service;
       do

--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -47,13 +47,14 @@ when "crowbar_upgrade"
 
   bash "disable_openstack_services" do
     code <<-EOF
-      for i in $(systemctl list-units openstack* --no-legend | cut -d" " -f1) \
+      for i in $(systemctl list-units openstack* --no-legend | cut -d" " -f1 | grep -v keystone | grep -v neutron) \
                drbd.service \
                pacemaker.service;
       do
         systemctl disable $i
       done
     EOF
+    not_if { ::File.exist?("/usr/sbin/crm") }
   end
 
   # Disable crowbar-join

--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -47,7 +47,7 @@ when "crowbar_upgrade"
 
   bash "disable_openstack_services" do
     code <<-EOF
-      for i in $(systemctl list-units openstack* --no-legend | cut -d" " -f1 | grep -Ev 'keystone|neutron') \
+      for i in $(systemctl list-units openstack* --no-legend | cut -d" " -f1) \
                drbd.service \
                pacemaker.service;
       do

--- a/chef/cookbooks/crowbar/recipes/stop-services-before-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/stop-services-before-upgrade.rb
@@ -24,7 +24,7 @@
 bash "stop pacemaker resources" do
   code <<-EOF
     for type in clone ms primitive; do
-      for resource in $(crm configure show | grep ^$type | grep -Ev "postgresql|vip-admin-database|rabbitmq" | cut -d " " -f2);
+      for resource in $(crm configure show | grep ^$type | grep -Ev "postgresql|vip-admin-database|rabbitmq|keystone|neutron" | cut -d " " -f2);
       do
         crm --force --wait resource stop $resource
       done
@@ -52,7 +52,7 @@ end
 # Note that for HA setup, they should be already stopped by pacemaker.
 bash "stop OpenStack services" do
   code <<-EOF
-    for i in /etc/init.d/openstack-* \
+    for i in `ls /etc/init.d/openstack-* | grep -Ev 'keystone|neutron'` \
              /etc/init.d/apache2 \
              /etc/init.d/rabbitmq-server \
              /etc/init.d/ovs-usurp-config-* \
@@ -63,6 +63,7 @@ bash "stop OpenStack services" do
       fi
     done
   EOF
+  not_if { ::File.exist?("/usr/sbin/crm") }
 end
 
 # On SLE11 the startup and shutdown logs are created as root, adjust

--- a/chef/cookbooks/crowbar/recipes/stop-services-before-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/stop-services-before-upgrade.rb
@@ -38,7 +38,7 @@ end
 # Note that for HA setup, they should be already stopped by pacemaker.
 bash "stop OpenStack services" do
   code <<-EOF
-    for i in `ls /etc/init.d/openstack-* | grep -Ev 'keystone|neutron'` \
+    for i in /etc/init.d/openstack-* \
              /etc/init.d/apache2 \
              /etc/init.d/rabbitmq-server \
              /etc/init.d/ovs-usurp-config-* \


### PR DESCRIPTION
Skip keystone and neutron so L3 agents can migrate.