### PR TITLE
Remove _repos prefix from missing and inactive repos

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -113,7 +113,7 @@ module Api
           repos: {}
         }
         ret[:os][:repos][admin_architecture.to_sym] = {
-          missing_repos: ["SUSE Linux Enterprise Server 12 SP3"]
+          missing: ["SUSE Linux Enterprise Server 12 SP3"]
         } unless os_available
 
         cloud_available = repo_version_available?(products, "suse-openstack-cloud", "8")
@@ -122,7 +122,7 @@ module Api
           repos: {}
         }
         ret[:cloud][:repos][admin_architecture.to_sym] = {
-          missing_repos: ["SUSE OpenStack Cloud 8"]
+          missing: ["SUSE OpenStack Cloud 8"]
         } unless cloud_available
       end
     end

--- a/crowbar_framework/lib/crowbar/repository.rb
+++ b/crowbar_framework/lib/crowbar/repository.rb
@@ -218,10 +218,10 @@ module Crowbar
 
             answer &&= r.available?
             unless r.available?
-              repos[:missing_repos] ||= {}
-              repos[:missing_repos][r.arch.to_sym] ||= []
-              unless repos[:missing_repos][r.arch.to_sym].include?(r.name)
-                repos[:missing_repos][r.arch.to_sym].push(r.name)
+              repos[:missing] ||= {}
+              repos[:missing][r.arch.to_sym] ||= []
+              unless repos[:missing][r.arch.to_sym].include?(r.name)
+                repos[:missing][r.arch.to_sym].push(r.name)
               end
             end
 
@@ -229,10 +229,10 @@ module Crowbar
             answer &&= r.active?
             next if r.active?
 
-            repos[:inactive_repos] ||= {}
-            repos[:inactive_repos][r.arch.to_sym] ||= []
-            unless repos[:inactive_repos][r.arch.to_sym].include?(r.name)
-              repos[:inactive_repos][r.arch.to_sym].push(r.name)
+            repos[:inactive] ||= {}
+            repos[:inactive][r.arch.to_sym] ||= []
+            unless repos[:inactive][r.arch.to_sym].include?(r.name)
+              repos[:inactive][r.arch.to_sym].push(r.name)
             end
           end
 

--- a/crowbar_framework/spec/fixtures/node_repocheck_missing.json
+++ b/crowbar_framework/spec/fixtures/node_repocheck_missing.json
@@ -2,13 +2,13 @@
   "os": {
     "available": false,
     "repos": {
-      "missing_repos": {
+      "missing": {
         "x86_64": [
           "SLES12-SP2-Pool",
           "SLES12-SP2-Updates"
         ]
       },
-      "inactive_repos": {
+      "inactive": {
         "x86_64": [
           "SLES12-SP2-Pool",
           "SLES12-SP2-Updates"
@@ -19,14 +19,14 @@
   "openstack": {
     "available": false,
     "repos": {
-      "missing_repos": {
+      "missing": {
         "x86_64": [
           "Cloud",
           "SUSE-OpenStack-Cloud-7-Pool",
           "SUSE-OpenStack-Cloud-7-Updates"
         ]
       },
-      "inactive_repos": {
+      "inactive": {
         "x86_64": [
           "Cloud",
           "SUSE-OpenStack-Cloud-7-Pool",

--- a/crowbar_framework/spec/models/api/node_spec.rb
+++ b/crowbar_framework/spec/models/api/node_spec.rb
@@ -23,13 +23,13 @@ describe Api::Node do
         [
           false,
           {
-            "missing_repos" => {
+            "missing" => {
               "x86_64" => [
                 "SLES12-SP2-Pool",
                 "SLES12-SP2-Updates"
               ]
             },
-            "inactive_repos" => {
+            "inactive" => {
               "x86_64" => [
                 "SLES12-SP2-Pool",
                 "SLES12-SP2-Updates"
@@ -48,14 +48,14 @@ describe Api::Node do
         [
           false,
           {
-            "missing_repos" => {
+            "missing" => {
               "x86_64" => [
                 "Cloud",
                 "SUSE-OpenStack-Cloud-7-Pool",
                 "SUSE-OpenStack-Cloud-7-Updates"
               ]
             },
-            "inactive_repos" => {
+            "inactive" => {
               "x86_64" => [
                 "Cloud",
                 "SUSE-OpenStack-Cloud-7-Pool",


### PR DESCRIPTION
The _repos prefix only provides already given information. We know that
we are working with repos at this point.

It also makes the output better readable, see: https://github.com/crowbar/crowbar-client/pull/104#issuecomment-246263007