### PR TITLE
[stable/3.0] backport #652

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -105,12 +105,23 @@ module Api
 
         products = zypper_stream["product_list"]["product"]
 
+        os_available = repo_version_available?(products, "SLES", "12.2")
         ret[:os] = {
-          available: repo_version_available?(products, "SLES", "12.2")
+          available: os_available,
+          repos: {}
         }
+        ret[:os][:repos][admin_architecture.to_sym] = {
+          missing_repos: ["SUSE Linux Enterprise Server 12 SP2"]
+        } unless os_available
+
+        cloud_available = repo_version_available?(products, "suse-openstack-cloud", "7")
         ret[:cloud] = {
-          available: repo_version_available?(products, "suse-openstack-cloud", "7")
+          available: cloud_available,
+          repos: {}
         }
+        ret[:cloud][:repos][admin_architecture.to_sym] = {
+          missing_repos: ["SUSE OpenStack Cloud 7"]
+        } unless cloud_available
       end
     end
 
@@ -178,6 +189,10 @@ module Api
       products.any? do |p|
         p["version"] == version && p["name"] == product
       end
+    end
+
+    def admin_architecture
+      NodeObject.admin_node.architecture
     end
   end
 end

--- a/crowbar_framework/spec/fixtures/crowbar_repocheck.json
+++ b/crowbar_framework/spec/fixtures/crowbar_repocheck.json
@@ -1,8 +1,10 @@
 {
   "os":{
-    "available":true
+    "available":true,
+    "repos": {}
   },
   "cloud":{
-    "available":true
+    "available":true,
+    "repos": {}
   }
 }

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -221,6 +221,9 @@ describe Api::Crowbar do
       allow_any_instance_of(Api::Crowbar).to(
         receive(:repo_version_available?).and_return(false)
       )
+      allow_any_instance_of(Api::Crowbar).to(
+        receive(:admin_architecture).and_return("x86_64")
+      )
       allow_any_instance_of(Kernel).to(
         receive(:`).with(
           "sudo /usr/bin/zypper-retry --xmlout products"


### PR DESCRIPTION
https://github.com/crowbar/crowbar-core/pull/652

adapt repocheck response to the nodes repocheck response
when using the repocheck API for nodes and for crowbar the result
should have the same structure

(cherry picked from commit 76fa8fc113b04aeadc896f409a663c1526bca339)