### PR TITLE
Set SES platform to suse-12.2

### DIFF
--- a/crowbar_framework/lib/crowbar/product.rb
+++ b/crowbar_framework/lib/crowbar/product.rb
@@ -29,7 +29,7 @@ module Crowbar
 
     def self.ses_platform
       # Returns the platform used for SES
-      "suse-12.1"
+      "suse-12.2"
     end
   end
 end


### PR DESCRIPTION
This is suitable only for SES 4 (and has no impact on SOC deploys
of any version).

Signed-off-by: Tim Serong <tserong@suse.com>