### PR TITLE
use exception_notification to log all exceptions in the database

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -37,6 +37,7 @@ gem "yaml_db", "~> 0.3.0"
 gem "easy_diff", "~> 0.0.5"
 gem "apipie-rails", "~> 0.3.6"
 gem "pg", "~> 0.17.1"
+gem "exception_notification", "~> 4.2.1"
 
 gem "ohai", "~> 6.24.2"
 gem "chef", "~> 10.32.2"

--- a/crowbar_framework/config/application.rb
+++ b/crowbar_framework/config/application.rb
@@ -43,6 +43,11 @@ module Crowbar
       g.fallbacks[:rspec] = :test_unit
     end
 
+    config.middleware.use(
+      ExceptionNotification::Rack,
+      crowbar_error: {}
+    )
+
     config.before_configuration do
       Dotenv.load *Dir.glob(Rails.root.join("config", "*.env"))
 

--- a/crowbar_framework/config/boot.rb
+++ b/crowbar_framework/config/boot.rb
@@ -45,6 +45,9 @@ else
   gem "pg", "~> 0.17.1"
   require "pg"
 
+  gem "exception_notification", "~> 4.2.1"
+  require "exception_notification"
+
   # general stuff
   gem "activerecord-session_store", version: "~> 0.1.0"
   require "activerecord/session_store"

--- a/crowbar_framework/config/initializers/crowbar_error_notifier.rb
+++ b/crowbar_framework/config/initializers/crowbar_error_notifier.rb
@@ -1,0 +1,30 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module ExceptionNotifier
+  class CrowbarErrorNotifier
+    def initialize(options)
+    end
+
+    def call(exception, options = {})
+      Api::Error.create(
+        error: exception.class,
+        message: exception.message,
+        backtrace: exception.backtrace
+      )
+    end
+  end
+end


### PR DESCRIPTION
this would be using the Api::Error model to write any exception
into the database.
collecting all exceptions in a single place saves the time to crawl
through the logs.
