### PR TITLE
perform the prepare in the background (bsc#997293)

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -83,21 +83,8 @@ class Api::UpgradeController < ApiController
   api_version "2.0"
   error 422, "Failed to prepare nodes for Crowbar upgrade"
   def prepare
-    status = :ok
-    msg = ""
-
-    begin
-      service_object = CrowbarService.new(Rails.logger)
-
-      service_object.prepare_nodes_for_crowbar_upgrade
-    rescue => e
-      msg = e.message
-      Rails.logger.error msg
-      status = :unprocessable_entity
-    end
-
-    if status == :ok
-      head status
+    if Api::Upgrade.prepare(background: true)
+      head :ok
     else
       render json: {
         errors: {
@@ -106,7 +93,7 @@ class Api::UpgradeController < ApiController
             help: I18n.t("api.upgrade.prepare.help.default")
           }
         }
-      }, status: status
+      }, status: :unprocessable_entity
     end
   end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -207,6 +207,16 @@ module Api
         true
       end
 
+      def prepare(options = {})
+        background = options.fetch(:background, false)
+
+        if background
+          prepare_nodes_for_crowbar_upgrade_background
+        else
+          prepare_nodes_for_crowbar_upgrade
+        end
+      end
+
       protected
 
       def upgrade_controller_nodes
@@ -376,6 +386,27 @@ module Api
 
       def admin_architecture
         NodeObject.admin_node.architecture
+      end
+
+      def prepare_nodes_for_crowbar_upgrade_background
+        @thread = Thread.new do
+          Rails.logger.debug("Started prepare in a background thread")
+          prepare_nodes_for_crowbar_upgrade
+        end
+
+        @thread.alive?
+      end
+
+      def prepare_nodes_for_crowbar_upgrade
+        service_object = CrowbarService.new(Rails.logger)
+        service_object.prepare_nodes_for_crowbar_upgrade
+
+        true
+      rescue => e
+        message = e.message
+        Rails.logger.error message
+
+        false
       end
     end
   end

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -208,6 +208,8 @@ module Api
       end
 
       def prepare(options = {})
+        ::Crowbar::UpgradeStatus.new.start_step
+
         background = options.fetch(:background, false)
 
         if background
@@ -401,9 +403,11 @@ module Api
         service_object = CrowbarService.new(Rails.logger)
         service_object.prepare_nodes_for_crowbar_upgrade
 
+        ::Crowbar::UpgradeStatus.new.end_step
         true
       rescue => e
         message = e.message
+        ::Crowbar::UpgradeStatus.new.end_step(false, { prepare_nodes_for_crowbar_upgrade: message })
         Rails.logger.error message
 
         false

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -54,7 +54,7 @@ describe Api::UpgradeController, type: :request do
 
     it "prepares the crowbar upgrade" do
       post "/api/upgrade/prepare", {}, headers
-      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response).to have_http_status(:ok)
     end
 
     it "stops related services on all nodes during upgrade" do

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -338,4 +338,30 @@ describe Api::Upgrade do
       expect(subject.class.best_method).to eq("none")
     end
   end
+
+  context "with preparing the upgrade" do
+    it "succeeds to spawn the prepare in the background" do
+      allow_any_instance_of(CrowbarService).to receive(
+        :prepare_nodes_for_crowbar_upgrade
+      ).and_return(true)
+
+      expect(subject.class.prepare(background: true)).to be true
+    end
+
+    it "succeeds to spawn the prepare in the foreground" do
+      allow_any_instance_of(CrowbarService).to receive(
+        :prepare_nodes_for_crowbar_upgrade
+      ).and_return(true)
+
+      expect(subject.class.prepare).to be true
+    end
+
+    it "fails to spawn the prepare in the foreground" do
+      allow_any_instance_of(CrowbarService).to receive(
+        :prepare_nodes_for_crowbar_upgrade
+      ).and_raise("Some error")
+
+      expect(subject.class.prepare).to be false
+    end
+  end
 end


### PR DESCRIPTION
this would (**EDIT**: _partially_) fix https://bugzilla.suse.com/show_bug.cgi?id=997293

(**EDIT**: it wouldn't, it would only fix one particular case, i.e. `/api/upgrade/prepare`)

and would obsolete https://github.com/SUSE-Cloud/automation/pull/1229
