### PR TITLE
Bring back the old nodes upgrade method

### DIFF
--- a/crowbar_framework/app/controllers/installer/upgrades_controller.rb
+++ b/crowbar_framework/app/controllers/installer/upgrades_controller.rb
@@ -222,7 +222,7 @@ module Installer
           begin
             post_cleanup_repos
             @service_object.disable_non_core_proposals
-            @service_object.prepare_nodes_for_os_upgrade
+            @service_object.initiate_nodes_upgrade
 
             format.json do
               head status


### PR DESCRIPTION
New methods do not provide full functional replacement yet.
Let's use the old one until we have new solution ready. 

And yes, I've renamed the old method, because it really was misleading, it was not preparation, but really starting of the upgrade....


I'm bringing this back to enable green gating of upgrade CI job. It partially reverts https://github.com/crowbar/crowbar-core/pull/640/commits/b4e2946cda7e4e5753f294d787b7e5095512a829