### PR TITLE
Remove _repos prefix from missing and inactive repos

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -111,7 +111,7 @@ module Api
           repos: {}
         }
         ret[:os][:repos][admin_architecture.to_sym] = {
-          missing_repos: ["SUSE Linux Enterprise Server 12 SP2"]
+          missing: ["SUSE Linux Enterprise Server 12 SP2"]
         } unless os_available
 
         cloud_available = repo_version_available?(products, "suse-openstack-cloud", "7")
@@ -120,7 +120,7 @@ module Api
           repos: {}
         }
         ret[:cloud][:repos][admin_architecture.to_sym] = {
-          missing_repos: ["SUSE OpenStack Cloud 7"]
+          missing: ["SUSE OpenStack Cloud 7"]
         } unless cloud_available
       end
     end


### PR DESCRIPTION
The _repos prefix only provides already given information. We know that
we are working with repos at this point.

(cherry picked from commit 05bb171fe2388e8d635192711b55f5873dd87e31)