### PR TITLE
[stable/3.0] Simple check if HA setup is deployed

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -125,6 +125,15 @@ module Api
       end
     end
 
+    def ha_deployed?
+      founders = NodeObject.find("pacemaker_founder:true AND pacemaker_config_environment:*")
+
+      if founders.empty?
+        Rails.logger.warn("No pacemaker cluster is configured.")
+        return false
+      end
+      true
+    end
 
     # Simple check if HA clusters report some problems
     # If there are no problems, empty hash is returned.

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -32,6 +32,7 @@ module Api
         clusters_healthy: clusters_healthy?,
         compute_resources_available: compute_resources_available?,
         ceph_healthy: ceph_healthy?
+        ha_deployed: ha_deployed?
       }
     end
 
@@ -59,6 +60,10 @@ module Api
 
     def compute_resources_available?
       Api::Crowbar.new.compute_resources_available?
+    end
+
+    def ha_deployed?
+      Api::Crowbar.new.ha_deployed?
     end
   end
 end


### PR DESCRIPTION
Before the start of the upgrade, we also should check if there's HA configuration, otherwise we could not guarantee non-disruptive upgrade.

I'm not sure if this is good enough, or if we should rather check for specific services (`neutron-server` ?) being in pacemaker cluster... ?