### PR TITLE
Provide a s390x ohai subtree similar to the dmi subtree

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/linux/s390x.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/linux/s390x.rb
@@ -1,0 +1,41 @@
+provides "s390x"
+
+if File.exist? "/proc/sysinfo"
+  retval = Mash.new.tap do |result|
+    result[:system] = {}
+
+    result[:system][:manufacturer] = "PR/SM"
+
+    File.open("/proc/sysinfo").each do |line|
+      key, val = line.split(":", 2)
+      next unless val
+
+      key.gsub!(/:$/, "")
+      val.strip!
+
+      if key.include? "Control Program"
+        if val.include? "KVM"
+          result[:system][:manufacturer] = "KVM"
+        end
+
+        if val.include? "z/VM"
+          result[:system][:manufacturer] = "z/VM"
+        end
+      end
+
+      if key.include? "UUID"
+        result[:system][:uuid] = val
+      end
+
+      if key.include? "Extended Name"
+        result[:system][:product_name] = val
+      end
+
+      if key.include? "Sequence Code"
+        result[:system][:serial_number] = val
+      end
+    end
+  end
+
+  s390x retval
+end


### PR DESCRIPTION
Since DMI does not exist on mainframe, we need to create
a custom ohai plugin to capture the DMI information that
we need for s390x