### PR TITLE
adapt the prechecks API

### DIFF
--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -73,8 +73,15 @@ class Api::CrowbarController < ApiController
   api :GET, "/api/crowbar/maintenance", "Check for maintenance updates on crowbar"
   header "Accept", "application/vnd.crowbar.v2.0+json", required: true
   api_version "2.0"
+  example '
+  {
+    "errors": [
+      "ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED: security patches available for installation."
+    ]
+  }
+  '
   def maintenance
-    render json: Api::Crowbar.maintenance_updates_status
+    render json: ::Crowbar::Checks::Maintenance.updates_status
   end
 
   api :GET, "/api/crowbar/repocheck", "Sanity check for Crowbar server repositories"

--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -74,9 +74,7 @@ class Api::CrowbarController < ApiController
   header "Accept", "application/vnd.crowbar.v2.0+json", required: true
   api_version "2.0"
   def maintenance
-    render json: {
-      maintenance_updates_installed: Api::Crowbar.maintenance_updates_installed?
-    }
+    render json: Api::Crowbar.maintenance_updates_status
   end
 
   api :GET, "/api/crowbar/repocheck", "Sanity check for Crowbar server repositories"

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -107,15 +107,44 @@ class Api::UpgradeController < ApiController
   api_version "2.0"
   example '
   {
-    "sanity_checks": true,
-    "maintenance_updates_installed": true,
-    "clusters_healthy": true,
-    "compute_resources_available": true,
-    "ceph_healthy": true
+    "checks": {
+      "network_checks": {
+        "required": true,
+        "passed": true,
+        "errors": {}
+      },
+      "maintenance_updates_installed": {
+        "required": true,
+        "passed": false,
+        "errors": {
+          "maintenance_updates_installed": {
+            "data": [
+              "ZYPPER_EXIT_INF_UPDATE_NEEDED: patches available for installation."
+            ],
+            "help": "make sure maintenance updates are installed"
+          }
+        }
+      },
+      "clusters_healthy": {
+        "required": true,
+        "passed": true,
+        "errors": {}
+      },
+      "compute_resources_available": {
+        "required": false,
+        "passed": true,
+        "errors": {}
+      },
+      "ceph_healthy": {
+        "required": true,
+        "passed": true,
+        "errors": {}
+      }
+    }
   }
   '
   def prechecks
-    render json: Api::Upgrade.check
+    render json: Api::Upgrade.checks
   end
 
   api :POST, "/api/upgrade/cancel", "Cancel the upgrade process by setting the nodes back to ready"

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 
-require "open3"
-
 module Api
   class Crowbar < Tableless
     class << self
@@ -111,25 +109,6 @@ module Api
           ret[:cloud][:repos][admin_architecture.to_sym] = {
             missing: ["SUSE OpenStack Cloud 8"]
           } unless cloud_available
-        end
-      end
-
-      def maintenance_updates_status
-        {}.tap do |ret|
-          Open3.popen3("zypper patch-check") do |_stdin, _stdout, _stderr, wait_thr|
-            case wait_thr.value.exitstatus
-            when 100
-              ret[:errors] ||= []
-              ret[:errors].push(
-                I18n.t("api.crowbar.maintenance_updates_status.patches_missing")
-              )
-            when 101
-              ret[:errors] ||= []
-              ret[:errors].push(
-                I18n.t("api.crowbar.maintenance_updates_status.security_patches_missing")
-              )
-            end
-          end
         end
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -192,7 +192,7 @@ module Api
       end
 
       def maintenance_updates_status
-        @maintenance_updates_status ||= Api::Crowbar.maintenance_updates_status
+        @maintenance_updates_status ||= ::Crowbar::Checks::Maintenance.updates_status
       end
 
       def network_checks

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -775,6 +775,23 @@ en:
       maintenance_updates_status:
         patches_missing: 'ZYPPER_EXIT_INF_UPDATE_NEEDED: patches available for installation.'
         security_patches_missing: 'ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED: security patches available for installation.'
+    upgrade:
+      prechecks:
+        network_checks:
+          help:
+            default: 'Examine the error messages'
+        maintenance_updates_check:
+          help:
+            default: 'Make sure maintenance updates are installed'
+        ceph_health_check:
+          help:
+            default: 'Make sure Ceph is healthy'
+        clusters_health_check:
+          help:
+            default: 'Make sure clusters are healthy'
+        compute_resources_check:
+          help:
+            default: 'Make sure there is enough compute power'
 
   # Global
   overview: 'Overview'

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -772,6 +772,9 @@ en:
       upgrade_ongoing: 'Upgrade is already ongoing. Please wait.'
       zypper_locked: '%{zypper_locked_message}'
       upgrade_script_path: 'Could not find %{path}'
+      maintenance_updates_status:
+        patches_missing: 'ZYPPER_EXIT_INF_UPDATE_NEEDED: patches available for installation.'
+        security_patches_missing: 'ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED: security patches available for installation.'
 
   # Global
   overview: 'Overview'

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -772,9 +772,6 @@ en:
       upgrade_ongoing: 'Upgrade is already ongoing. Please wait.'
       zypper_locked: '%{zypper_locked_message}'
       upgrade_script_path: 'Could not find %{path}'
-      maintenance_updates_status:
-        patches_missing: 'ZYPPER_EXIT_INF_UPDATE_NEEDED: patches available for installation.'
-        security_patches_missing: 'ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED: security patches available for installation.'
     upgrade:
       prechecks:
         network_checks:

--- a/crowbar_framework/lib/crowbar/checks/maintenance.rb
+++ b/crowbar_framework/lib/crowbar/checks/maintenance.rb
@@ -1,0 +1,46 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "open3"
+
+module Crowbar
+  module Checks
+    class Maintenance
+      class << self
+        def updates_status
+          {}.tap do |ret|
+            ret[:passed] = true
+            ret[:errors] = []
+            Open3.popen3("zypper patch-check") do |_stdin, _stdout, _stderr, wait_thr|
+              case wait_thr.value.exitstatus
+              when 100
+                ret[:passed] = false
+                ret[:errors].push(
+                  I18n.t("api.crowbar.maintenance_updates_status.patches_missing")
+                )
+              when 101
+                ret[:passed] = false
+                ret[:errors].push(
+                  I18n.t("api.crowbar.maintenance_updates_status.security_patches_missing")
+                )
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/crowbar_framework/lib/crowbar/checks/maintenance.rb
+++ b/crowbar_framework/lib/crowbar/checks/maintenance.rb
@@ -21,24 +21,16 @@ module Crowbar
     class Maintenance
       class << self
         def updates_status
-          {}.tap do |ret|
-            ret[:passed] = true
-            ret[:errors] = []
+          error =
             Open3.popen3("zypper patch-check") do |_stdin, _stdout, _stderr, wait_thr|
               case wait_thr.value.exitstatus
               when 100
-                ret[:passed] = false
-                ret[:errors].push(
-                  "ZYPPER_EXIT_INF_UPDATE_NEEDED: patches available for installation."
-                )
+                I18n.t("api.crowbar.maintenance_updates_status.patches_missing")
               when 101
-                ret[:passed] = false
-                ret[:errors].push(
-                  "ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED: security patches available for installation."
-                )
+                I18n.t("api.crowbar.maintenance_updates_status.security_patches_missing")
               end
             end
-          end
+          error ? { errors: [error] } : {}
         end
       end
     end

--- a/crowbar_framework/lib/crowbar/checks/maintenance.rb
+++ b/crowbar_framework/lib/crowbar/checks/maintenance.rb
@@ -29,12 +29,12 @@ module Crowbar
               when 100
                 ret[:passed] = false
                 ret[:errors].push(
-                  I18n.t("api.crowbar.maintenance_updates_status.patches_missing")
+                  "ZYPPER_EXIT_INF_UPDATE_NEEDED: patches available for installation."
                 )
               when 101
                 ret[:passed] = false
                 ret[:errors].push(
-                  I18n.t("api.crowbar.maintenance_updates_status.security_patches_missing")
+                  "ZYPPER_EXIT_INF_SEC_UPDATE_NEEDED: security patches available for installation."
                 )
               end
             end

--- a/crowbar_framework/lib/crowbar/checks/network.rb
+++ b/crowbar_framework/lib/crowbar/checks/network.rb
@@ -22,85 +22,87 @@ require "logger"
 module Crowbar
   module Checks
     class Network
-      def fqdn_detected?
-        if hostname.blank? || domain.blank? || fqdn.blank?
-          return false
+      class << self
+        def fqdn_detected?
+          if hostname.blank? || domain.blank? || fqdn.blank?
+            return false
+          end
+
+          true
         end
 
-        true
-      end
+        def ip_resolved?
+          if ipv4_addrs.empty? && ipv6_addrs.empty?
+            return false
+          end
 
-      def ip_resolved?
-        if ipv4_addrs.empty? && ipv6_addrs.empty?
-          return false
+          true
         end
 
-        true
-      end
+        def loopback_unresolved?
+          if ipv4_addrs.detect { |e| /^127/ =~ e } || ipv6_addrs.detect { |e| /^::[0-9]$/ =~ e }
+            return false
+          end
 
-      def loopback_unresolved?
-        if ipv4_addrs.detect { |e| /^127/ =~ e } || ipv6_addrs.detect { |e| /^::[0-9]$/ =~ e }
-          return false
+          true
         end
 
-        true
-      end
+        def ip_configured?
+          ipv4_configured = false
+          ipv6_configured = false
 
-      def ip_configured?
-        ipv4_configured = false
-        ipv6_configured = false
+          addr_infos = Socket.ip_address_list
+          addr_infos.each do |addr_info|
+            ipv4_configured = true if ipv4_addrs.include?(addr_info.ip_address)
+            ipv6_configured = true if ipv6_addrs.include?(addr_info.ip_address)
+          end
 
-        addr_infos = Socket.ip_address_list
-        addr_infos.each do |addr_info|
-          ipv4_configured = true if ipv4_addrs.include?(addr_info.ip_address)
-          ipv6_configured = true if ipv6_addrs.include?(addr_info.ip_address)
+          unless ipv4_configured || ipv4_addrs.empty?
+            return false
+          end
+          # we don't really depend on IPv6, so no big deal
+          #unless ipv6_configured || ipv6_addrs.empty?
+          #  return false
+          #end
+
+          true
         end
 
-        unless ipv4_configured || ipv4_addrs.empty?
-          return false
+        def ping_succeeds?
+          system("ping -c 1 #{fqdn} > /dev/null 2>&1")
         end
-        # we don't really depend on IPv6, so no big deal
-        #unless ipv6_configured || ipv6_addrs.empty?
-        #  return false
-        #end
 
-        true
-      end
+        def hostname
+          @hostname ||= `hostname -s`.strip
+        end
 
-      def ping_succeeds?
-        system("ping -c 1 #{fqdn} > /dev/null 2>&1")
-      end
+        def domain
+          @domain ||= `hostname -d`.strip
+        end
 
-      def hostname
-        @hostname ||= `hostname -s`.strip
-      end
+        def fqdn
+          @fqdn ||= `hostname -f`.strip
+        end
 
-      def domain
-        @domain ||= `hostname -d`.strip
-      end
+        def ipv4_addrs
+          @ipv4_addrs ||= ip_addrs(:ipv4)
+        end
 
-      def fqdn
-        @fqdn ||= `hostname -f`.strip
-      end
+        def ipv6_addrs
+          @ipv6_addrs ||= ip_addrs(:ipv6)
+        end
 
-      def ipv4_addrs
-        @ipv4_addrs ||= ip_addrs(:ipv4)
-      end
+        protected
 
-      def ipv6_addrs
-        @ipv6_addrs ||= ip_addrs(:ipv6)
-      end
-
-      protected
-
-      def ip_addrs(version = :ipv4)
-        [].tap do |addresses|
-          Resolv.getaddresses(fqdn).each do |address|
-            ip_addr = IPAddr.new(address)
-            if version == :ipv6
-              addresses.push address if ip_addr.ipv6?
-            else
-              addresses.push address if ip_addr.ipv4?
+        def ip_addrs(version = :ipv4)
+          [].tap do |addresses|
+            Resolv.getaddresses(fqdn).each do |address|
+              ip_addr = IPAddr.new(address)
+              if version == :ipv6
+                addresses.push address if ip_addr.ipv6?
+              else
+                addresses.push address if ip_addr.ipv4?
+              end
             end
           end
         end

--- a/crowbar_framework/lib/crowbar/checks/network.rb
+++ b/crowbar_framework/lib/crowbar/checks/network.rb
@@ -61,9 +61,9 @@ module Crowbar
             return false
           end
           # we don't really depend on IPv6, so no big deal
-          #unless ipv6_configured || ipv6_addrs.empty?
-          #  return false
-          #end
+          # unless ipv6_configured || ipv6_addrs.empty?
+          #   return false
+          # end
 
           true
         end
@@ -99,10 +99,11 @@ module Crowbar
             Resolv.getaddresses(fqdn).each do |address|
               ip_addr = IPAddr.new(address)
               if version == :ipv6
-                addresses.push address if ip_addr.ipv6?
+                next unless ip_addr.ipv6?
               else
-                addresses.push address if ip_addr.ipv4?
+                next unless ip_addr.ipv4?
               end
+              addresses.push address
             end
           end
         end

--- a/crowbar_framework/lib/crowbar/sanity.rb
+++ b/crowbar_framework/lib/crowbar/sanity.rb
@@ -50,7 +50,7 @@ module Crowbar
       protected
 
       def network_checks
-        check = Crowbar::Checks::Network.new
+        check = Crowbar::Checks::Network
 
         [].tap do |errors|
           [

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -19,10 +19,14 @@ describe Api::UpgradeController, type: :request do
     end
 
     it "shows the upgrade status object" do
-      allow(Crowbar::Sanity).to receive(:sane?).and_return(true)
-      allow(Api::Crowbar).to(
-        receive(:addons).and_return([])
-      )
+      allow(Api::Upgrade).to receive(:network_checks).and_return([])
+      allow(Crowbar::Sanity).to receive(:check).and_return([])
+      allow(Api::Upgrade).to receive(
+        :maintenance_updates_status
+      ).and_return({})
+      allow(Api::Crowbar).to receive(
+        :addons
+      ).and_return(["ceph", "ha"])
 
       get "/api/upgrade", {}, headers
       expect(response).to have_http_status(:ok)
@@ -74,7 +78,14 @@ describe Api::UpgradeController, type: :request do
     end
 
     it "shows a sanity check in preparation for the upgrade" do
-      allow(Crowbar::Sanity).to receive(:sane?).and_return(true)
+      allow(Api::Upgrade).to receive(:network_checks).and_return([])
+      allow(::Crowbar::Sanity).to receive(:check).and_return([])
+      allow(Api::Upgrade).to receive(
+        :maintenance_updates_status
+      ).and_return({})
+      allow(Api::Crowbar).to receive(
+        :addons
+      ).and_return(["ha", "ceph"])
 
       get "/api/upgrade/prechecks", {}, headers
       expect(response).to have_http_status(:ok)

--- a/crowbar_framework/spec/fixtures/crowbar_maintenance.json
+++ b/crowbar_framework/spec/fixtures/crowbar_maintenance.json
@@ -1,3 +1,4 @@
 {
-  "maintenance_updates_installed":true
+  "passed":true,
+  "errors":[]
 }

--- a/crowbar_framework/spec/fixtures/upgrade_prechecks.json
+++ b/crowbar_framework/spec/fixtures/upgrade_prechecks.json
@@ -1,7 +1,27 @@
 {
-  "sanity_checks":true,
-  "maintenance_updates_installed":true,
-  "clusters_healthy":true,
-  "compute_resources_available":true,
-  "ceph_healthy":true
+  "network_checks": {
+    "required": true,
+    "passed": true,
+    "errors": {}
+  },
+  "maintenance_updates_installed": {
+    "required": true,
+    "passed": true,
+    "errors": {}
+  },
+  "compute_resources_available": {
+    "required": false,
+    "passed": true,
+    "errors": {}
+  },
+  "ceph_healthy": {
+    "required": true,
+    "passed": true,
+    "errors": {}
+  },
+  "clusters_healthy": {
+    "required": true,
+    "passed": true,
+    "errors": {}
+  }
 }

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -1,7 +1,10 @@
 {
   "crowbar": {
     "version": "4.0",
-    "addons": [],
+    "addons": [
+      "ceph",
+      "ha"
+    ],
     "upgrade": {
       "upgrading": false,
       "success": false,
@@ -9,10 +12,30 @@
     }
   },
   "checks": {
-    "sanity_checks":true,
-    "maintenance_updates_installed":true,
-    "clusters_healthy":true,
-    "compute_resources_available":true,
-    "ceph_healthy":true
+    "network_checks": {
+      "required": true,
+      "passed": true,
+      "errors": {}
+    },
+    "maintenance_updates_installed": {
+      "required": true,
+      "passed": true,
+      "errors": {}
+    },
+    "compute_resources_available": {
+      "required": false,
+      "passed": true,
+      "errors": {}
+    },
+    "ceph_healthy": {
+      "required": true,
+      "passed": true,
+      "errors": {}
+    },
+    "clusters_healthy": {
+      "required": true,
+      "passed": true,
+      "errors": {}
+    }
   }
 }

--- a/crowbar_framework/spec/lib/crowbar/checks/maintenance_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/checks/maintenance_spec.rb
@@ -1,0 +1,38 @@
+#
+# Copyright 2015, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+describe ::Crowbar::Checks::Maintenance do
+  subject { ::Crowbar::Checks::Maintenance }
+
+  context "with maintenance updates installed" do
+    it "succeeds" do
+      expect(subject.updates_status[:passed]).to be true
+    end
+  end
+
+  context "with no maintenance updates installed" do
+    it "fails" do
+      # override global allow from spec_helper
+      allow(::Crowbar::Checks::Maintenance).to(
+        receive(:updates_status).
+        and_return(passed: false, errors: ["Some Error"])
+      )
+      expect(subject.updates_status[:passed]).to be false
+    end
+  end
+end

--- a/crowbar_framework/spec/lib/crowbar/checks/maintenance_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/checks/maintenance_spec.rb
@@ -33,6 +33,7 @@ describe ::Crowbar::Checks::Maintenance do
         and_return(passed: false, errors: ["Some Error"])
       )
       expect(subject.updates_status[:passed]).to be false
+      expect(subject.updates_status[:errors]).to eq(["Some Error"])
     end
   end
 end

--- a/crowbar_framework/spec/lib/crowbar/checks/network_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/checks/network_spec.rb
@@ -17,6 +17,7 @@
 require "spec_helper"
 
 describe Crowbar::Checks::Network do
+  subject { Crowbar::Checks::Network }
   before :each do
     allow(subject).to receive_messages(
       hostname: "crowbar",

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -95,7 +95,7 @@ describe Api::Crowbar do
 
   context "with maintenance updates installed" do
     it "succeeds" do
-      expect(subject.class.maintenance_updates_installed?).to be true
+      expect(subject.maintenance_updates_status[:passed]).to be true
     end
   end
 
@@ -103,10 +103,10 @@ describe Api::Crowbar do
     it "fails" do
       # override global allow from spec_helper
       allow(Api::Crowbar).to(
-        receive(:maintenance_updates_installed?).
-        and_return(false)
+        receive(:maintenance_updates_status).
+        and_return(passed: false, errors: ["Some Error"])
       )
-      expect(subject.class.maintenance_updates_installed?).to be false
+      expect(subject.class.maintenance_updates_status[:passed]).to be false
     end
   end
 

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -93,23 +93,6 @@ describe Api::Crowbar do
     end
   end
 
-  context "with maintenance updates installed" do
-    it "succeeds" do
-      expect(subject.maintenance_updates_status[:passed]).to be true
-    end
-  end
-
-  context "with no maintenance updates installed" do
-    it "fails" do
-      # override global allow from spec_helper
-      allow(Api::Crowbar).to(
-        receive(:maintenance_updates_status).
-        and_return(passed: false, errors: ["Some Error"])
-      )
-      expect(subject.class.maintenance_updates_status[:passed]).to be false
-    end
-  end
-
   context "with addons enabled" do
     it "lists the enabled addons" do
       ["ceph", "ha"].each do |addon|

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -52,10 +52,13 @@ describe Api::Upgrade do
 
   context "with a successful status" do
     it "checks the status" do
-      allow(Crowbar::Sanity).to receive(:sane?).and_return(true)
-      allow_any_instance_of(Api::Crowbar).to(
-        receive(:features).and_return([])
-      )
+      allow(Api::Upgrade).to receive(:network_checks).and_return([])
+      allow(Api::Upgrade).to receive(
+        :maintenance_updates_status
+      ).and_return({})
+      allow(Api::Crowbar).to receive(
+        :addons
+      ).and_return(["ceph", "ha"])
 
       expect(subject.class).to respond_to(:status)
       expect(subject.class.status).to be_a(Hash)
@@ -65,10 +68,16 @@ describe Api::Upgrade do
 
   context "with a successful maintenance updates check" do
     it "checks the maintenance updates on crowbar" do
-      allow(Crowbar::Sanity).to receive(:sane?).and_return(true)
+      allow(Api::Upgrade).to receive(:network_checks).and_return([])
+      allow(Api::Upgrade).to receive(
+        :maintenance_updates_status
+      ).and_return({})
+      allow(Api::Crowbar).to receive(
+        :addons
+      ).and_return(["ceph", "ha"])
 
-      expect(subject.class).to respond_to(:check)
-      expect(subject.class.check.deep_stringify_keys).to eq(upgrade_prechecks)
+      expect(subject.class).to respond_to(:checks)
+      expect(subject.class.checks.deep_stringify_keys).to eq(upgrade_prechecks)
     end
   end
 

--- a/crowbar_framework/spec/spec_helper.rb
+++ b/crowbar_framework/spec/spec_helper.rb
@@ -105,9 +105,9 @@ RSpec.configure do |config|
     allow(Crowbar::Settings).to receive(:domain).and_return("crowbar.com")
     allow_any_instance_of(Proposal).to receive(:properties_template_dir).
       and_return(Rails.root.join("spec/fixtures/data_bags"))
-    allow(Api::Crowbar).to(
-      receive(:maintenance_updates_installed?).
-      and_return(true)
+    allow_any_instance_of(Api::Crowbar).to(
+      receive(:maintenance_updates_status).
+      and_return(passed: true, errors: [])
     )
   end
 

--- a/crowbar_framework/spec/spec_helper.rb
+++ b/crowbar_framework/spec/spec_helper.rb
@@ -105,8 +105,8 @@ RSpec.configure do |config|
     allow(Crowbar::Settings).to receive(:domain).and_return("crowbar.com")
     allow_any_instance_of(Proposal).to receive(:properties_template_dir).
       and_return(Rails.root.join("spec/fixtures/data_bags"))
-    allow_any_instance_of(Api::Crowbar).to(
-      receive(:maintenance_updates_status).
+    allow(::Crowbar::Checks::Maintenance).to(
+      receive(:updates_status).
       and_return(passed: true, errors: [])
     )
   end


### PR DESCRIPTION
we are including specific errors now in the response

example:

```json
{
  "checks": {
    "network_checks": {
      "required": true,
      "passed": true,
      "errors": {}
    },
    "maintenance_updates_installed": {
      "required": true,
      "passed": false,
      "errors": {
        "maintenance_updates_installed": {
          "data": [
            "ZYPPER_EXIT_INF_UPDATE_NEEDED: patches available for installation."
          ],
          "help": "make sure maintenance updates are installed"
        }
      }
    },
    "clusters_healthy": {
      "required": true,
      "passed": true,
      "errors": {}
    },
    "compute_resources_available": {
      "required": false,
      "passed": true,
      "errors": {}
    },
    "ceph_healthy": {
      "required": true,
      "passed": true,
      "errors": {}
    }
  }
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/crowbar/crowbar-core/672)
<!-- Reviewable:end -->
