### PR TITLE
api cleanup: move business logic into the model

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -59,12 +59,11 @@ class Api::UpgradeController < ApiController
   end
 
   def cancel
-    service_object = CrowbarService.new(Rails.logger)
-    service_object.revert_nodes_from_crowbar_upgrade
-
-    head :ok
-  rescue => e
-    render json: { error: e.message }, status: :unprocessable_entity
+    if @upgrade.cancel
+      head :ok
+    else
+      render json: { error: @upgrade.errors.full_messages.first }, status: :unprocessable_entity
+    end
   end
 
   protected

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -35,6 +35,18 @@ module Api
       }
     end
 
+    def cancel
+      service_object = CrowbarService.new(Rails.logger)
+      service_object.revert_nodes_from_crowbar_upgrade
+
+      true
+    rescue => e
+      errors.add(:base, e.message)
+      Rails.logger.error(e.message)
+
+      false
+    end
+
     protected
 
     def crowbar_upgrade_status

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -40,4 +40,24 @@ describe Api::Upgrade do
       expect(subject.check.deep_stringify_keys).to eq(upgrade_prechecks)
     end
   end
+
+  context "canceling the upgrade" do
+    it "successfully cancels the upgrade" do
+      allow_any_instance_of(CrowbarService).to receive(
+        :revert_nodes_from_crowbar_upgrade
+      ).and_return(true)
+
+      expect(subject.cancel).to be true
+      expect(subject.errors).to be_empty
+    end
+
+    it "fails to cancel the upgrade" do
+      allow_any_instance_of(CrowbarService).to receive(
+        :revert_nodes_from_crowbar_upgrade
+      ).and_raise("Some Error")
+
+      expect(subject.cancel).to be false
+      expect(subject.errors).not_to be_empty
+    end
+  end
 end


### PR DESCRIPTION
(cherry picked from commit f63124f35ab561de2f986f0de0fcd95f4d1e0e15)

backport of relavant parts of https://github.com/crowbar/crowbar-core/pull/666