### PR TITLE
Add ceph_client network (fate#319122)

### DIFF
--- a/chef/data_bags/crowbar/migrate/network/101_add_ceph_client_network.rb
+++ b/chef/data_bags/crowbar/migrate/network/101_add_ceph_client_network.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  a["networks"]["ceph_client"] = ta["networks"]["ceph_client"] unless a["networks"].key? "ceph_client"
+
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["networks"].delete "ceph_client" unless ta["networks"].key? "ceph_client"
+
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-network.json
+++ b/chef/data_bags/crowbar/template-network.json
@@ -161,6 +161,19 @@
             "host": { "start": "192.168.125.10", "end": "192.168.125.239" }
           }
         },
+        "ceph_client": {
+          "conduit": "intf1",
+          "vlan": 250,
+          "use_vlan": true,
+          "add_bridge": false,
+          "mtu": 1500,
+          "subnet": "192.168.127.0",
+          "netmask": "255.255.255.0",
+          "broadcast": "192.168.127.255",
+          "ranges": {
+            "host": { "start": "192.168.127.10", "end": "192.168.127.239" }
+          }
+        },
         "public": {
           "conduit": "intf1",
           "vlan": 300,
@@ -267,7 +280,7 @@
     "network": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "network": [ "readying", "ready", "applying" ]
       },


### PR DESCRIPTION
This adds a separate ceph client network, instead of having ceph
client traffic go over the admin network.

Note:

- The VLAN ID and IP address range were arbitrary choices.
- We might want to look at a different conduit, or at least this
  may be the right time to revisit a proposal for setting up bonds
  for ceph traffic (https://github.com/crowbar/crowbar-core/pull/64)
- I'm not sure what will happen during upgrades.  I guess I need
  to add a migration to make sure the new network gets added...?

Signed-off-by: Tim Serong <tserong@suse.com>