### PR TITLE
set bind directory to be readable by everybody (bsc#997530)

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -43,7 +43,7 @@ end
 directory "/etc/bind" do
   owner "root"
   group bindgroup
-  mode 0770
+  mode 0775
   action :create
 end
 


### PR DESCRIPTION
it has been readable before (see c955804f) and the current permissions
are breaking backup creation, as crowbar isn't allowed to read from
the directory

https://bugzilla.suse.com/show_bug.cgi?id=997530