### PR TITLE
[stable/3.0] Simple check for presence of HA-based configuration

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -201,6 +201,22 @@ module Api
         true
       end
 
+      # Check for presence of HA setup, which is a requirement for non-disruptive upgrade
+      def ha_presence_check
+        ret = {}
+        unless addon_installed? "ha"
+          ret[:errors] = [I18n.t("api.crowbar.ha_not_installed")]
+          return ret
+        end
+
+        founders = NodeObject.find("pacemaker_founder:true AND pacemaker_config_environment:*")
+
+        if founders.empty?
+          ret[:errors] = [I18n.t("api.crowbar.ha_not_configured")]
+        end
+        ret
+      end
+
       protected
 
       def lib_path

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -32,7 +32,8 @@ module Api
           maintenance_updates_installed: maintenance_updates_installed?,
           clusters_healthy: clusters_healthy?,
           compute_resources_available: compute_resources_available?,
-          ceph_healthy: ceph_healthy?
+          ceph_healthy: ceph_healthy?,
+          ha_deployed: ha_presence_check.empty?
         }
       end
 
@@ -77,6 +78,10 @@ module Api
 
       def compute_resources_available?
         Api::Crowbar.compute_resources_available?
+      end
+
+      def ha_presence_check
+        Api::Crowbar.ha_presence_check
       end
     end
   end

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -771,6 +771,8 @@ en:
       upgrade_ongoing: 'Upgrade is already ongoing. Please wait.'
       zypper_locked: '%{zypper_locked_message}'
       upgrade_script_path: 'Could not find %{path}'
+      ha_not_installed: 'HA add-on is not installed.'
+      ha_not_configured: 'No Pacemaker cluster is configured.'
 
   # Global
   overview: 'Overview'

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -21,9 +21,11 @@ describe Api::UpgradeController, type: :request do
     it "shows the upgrade status object" do
       allow(Crowbar::Sanity).to receive(:sane?).and_return(true)
       allow(Api::Crowbar).to(
-        receive(:addons).and_return([])
+        receive(:addons).and_return(["ha"])
       )
-
+      allow(Api::Upgrade).to(
+        receive(:ha_presence_check).and_return({})
+      )
       get "/api/upgrade", {}, headers
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq(upgrade_status)
@@ -41,6 +43,13 @@ describe Api::UpgradeController, type: :request do
 
     it "shows a sanity check in preparation for the upgrade" do
       allow(Crowbar::Sanity).to receive(:sane?).and_return(true)
+
+      allow_any_instance_of(Api::Crowbar).to(
+        receive(:addons).and_return(["ha"])
+      )
+      allow(Api::Upgrade).to(
+        receive(:ha_presence_check).and_return({})
+      )
 
       get "/api/upgrade/prechecks", {}, headers
       expect(response).to have_http_status(:ok)

--- a/crowbar_framework/spec/fixtures/upgrade_prechecks.json
+++ b/crowbar_framework/spec/fixtures/upgrade_prechecks.json
@@ -3,5 +3,6 @@
   "maintenance_updates_installed":true,
   "clusters_healthy":true,
   "compute_resources_available":true,
-  "ceph_healthy":true
+  "ceph_healthy":true,
+  "ha_deployed":true
 }

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -1,7 +1,7 @@
 {
   "crowbar": {
     "version": "3.0",
-    "addons": [],
+    "addons": ["ha"],
     "upgrade": {
       "upgrading": false,
       "success": false,
@@ -13,6 +13,7 @@
     "maintenance_updates_installed":true,
     "clusters_healthy":true,
     "compute_resources_available":true,
-    "ceph_healthy":true
+    "ceph_healthy":true,
+    "ha_deployed":true
   }
 }

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -233,6 +233,47 @@ describe Api::Crowbar do
     end
   end
 
+  context "with HA deployed" do
+    it "succeeds to confirm that HA is deployed" do
+
+      allow(Api::Crowbar).to(
+        receive(:addon_installed?).
+        and_return(true)
+      )
+      allow(NodeObject).to(
+        receive(:find).with("pacemaker_founder:true AND pacemaker_config_environment:*").
+        and_return([node])
+      )
+      expect(subject.class.ha_presence_check).to eq({})
+    end
+  end
+
+  context "with HA installed but not deployed" do
+    it "fails when finding out HA is not deployed" do
+
+      allow(Api::Crowbar).to(
+        receive(:addon_installed?).
+        and_return(true)
+      )
+      allow(NodeObject).to(
+        receive(:find).with("pacemaker_founder:true AND pacemaker_config_environment:*").
+        and_return([])
+      )
+      expect(subject.class.ha_presence_check).to have_key(:errors)
+    end
+  end
+
+  context "with HA not even installed" do
+    it "fails when finding out HA is not deployed" do
+
+      allow(Api::Crowbar).to(
+        receive(:addon_installed?).
+        and_return(false)
+      )
+      expect(subject.class.ha_presence_check).to have_key(:errors)
+    end
+  end
+
   context "with enough compute resources" do
     it "succeeds to find enough compute nodes" do
       allow(NodeObject).to(

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -39,15 +39,6 @@ describe Api::Upgrade do
     end
   end
 
-  context "with a successful check" do
-    it "checks the maintenance updates on crowbar" do
-      allow(Crowbar::Sanity).to receive(:sane?).and_return(true)
-
-      expect(subject.class).to respond_to(:check)
-      expect(subject.class.check.deep_stringify_keys).to eq(upgrade_prechecks)
-    end
-  end
-
   context "canceling the upgrade" do
     it "successfully cancels the upgrade" do
       allow_any_instance_of(CrowbarService).to receive(

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -15,12 +15,22 @@ describe Api::Upgrade do
       )
     )
   end
+  let!(:node) { NodeObject.find_node_by_name("testing") }
 
   context "with a successful status" do
     it "checks the status" do
       allow(Crowbar::Sanity).to receive(:sane?).and_return(true)
-      allow_any_instance_of(Api::Crowbar).to(
+      allow(Api::Crowbar).to(
         receive(:features).and_return([])
+      )
+
+      allow(Api::Crowbar).to(
+        receive(:addons).and_return(
+          ["ha"]
+        )
+      )
+      allow(Api::Crowbar).to(
+        receive(:ha_presence_check).and_return({})
       )
 
       expect(subject.class).to respond_to(:status)


### PR DESCRIPTION
Adapted testsuite to addition of ha_deployed? check

(cherry picked from commit 0069bff189e2647ea6eaac281a56946c16330c52)

We should probably merge this one only after the **backport** for https://github.com/crowbar/crowbar-core/pull/672 is merged