### PR TITLE
bsc#999637: Remove firewall sanity check

### DIFF
--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -761,7 +761,6 @@ en:
       ip_resolved: 'Could not resolve %{fqdn} to an IPv4 or IPv6 address.'
       loopback_unresolved: '%{fqdn} resolves to a loopback address.'
       ip_configured: 'No local interface is configured with a correct IP address.'
-      firewall_disabled: 'Firewall is not completely disabled.'
       ping_succeeds: 'Failed to ping %{fqdn}; please check your network configuration.'
     check:
       cache_error: 'Failed to cache sanity checks'

--- a/crowbar_framework/lib/crowbar/checks/network.rb
+++ b/crowbar_framework/lib/crowbar/checks/network.rb
@@ -67,10 +67,6 @@ module Crowbar
         true
       end
 
-      def firewall_disabled?
-        !system("sudo LANG=C iptables -n -L | grep -qvE '^$|^Chain [^ ]|^target     prot'")
-      end
-
       def ping_succeeds?
         system("ping -c 1 #{fqdn} > /dev/null 2>&1")
       end

--- a/crowbar_framework/lib/crowbar/sanity.rb
+++ b/crowbar_framework/lib/crowbar/sanity.rb
@@ -58,7 +58,6 @@ module Crowbar
             :ip_resolved,
             :loopback_unresolved,
             :ip_configured,
-            :firewall_disabled,
             :ping_succeeds
           ].each do |c|
             next if check.send("#{c}?")

--- a/crowbar_framework/spec/lib/crowbar/checks/network_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/checks/network_spec.rb
@@ -66,26 +66,6 @@ describe Crowbar::Checks::Network do
     end
   end
 
-  describe "#firewall_disabled?" do
-    it "returns false if firewall is enabled" do
-      allow_any_instance_of(Kernel).to(
-        receive(:system).with(
-          "sudo LANG=C iptables -n -L | grep -qvE '^$|^Chain [^ ]|^target     prot'"
-        ).and_return(true)
-      )
-      expect(subject.firewall_disabled?).to be false
-    end
-
-    it "returns true if firewall is disabled" do
-      allow_any_instance_of(Kernel).to(
-        receive(:system).with(
-          "sudo LANG=C iptables -n -L | grep -qvE '^$|^Chain [^ ]|^target     prot'"
-        ).and_return(false)
-      )
-      expect(subject.firewall_disabled?).to be true
-    end
-  end
-
   describe "#ping_succeeds?" do
     it "returns true if fqdn is pingable" do
       allow_any_instance_of(Kernel).to(


### PR DESCRIPTION
Commit
https://github.com/crowbar/crowbar-core/commit/73a0ce5ff0cd335c51e0bae2175c2d8c675f97fa
exposed an inconsistency between the firewall rules needed for the bmc-nat
barclamp and crowbar's firewall sanity check. The sanity check is too broad as
it does not tolerate _any_ iptables rule. A more sensible sanity check would
need to parse the firewall rules more intelligently to ensure that the admin
node is accessible and yet allow for rules added by individual barclamps.

In the interest of addressing https://bugzilla.suse.com/show_bug.cgi?id=999637
I am removing the sanity check for now.