### PR TITLE
fix/adapt UI part of the backup creation

### DIFF
--- a/crowbar_framework/app/controllers/backups_controller.rb
+++ b/crowbar_framework/app/controllers/backups_controller.rb
@@ -82,6 +82,6 @@ class BackupsController < ApplicationController
   end
 
   def backup_params
-    params.require(:backup).permit(:name)
+    params.require(:api_backup).permit(:name)
   end
 end


### PR DESCRIPTION
the backup name parameter in the post request should be wrapped now
in an api_backup hash

to test this, just try to create a backup from the UI (utils/backup and restore) and try to create a new backup with and without this patch