### PR TITLE
Always use the old mime-types version in Gemfile

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -48,11 +48,11 @@ gem "mixlib-shellout", "~> 1.3.0",
 gem "activerecord-session_store", "~> 0.1.0",
     require: "activerecord/session_store"
 
-if ENV["CI"] && ENV["CI"] == "true"
-  gem "mime-types", "~> 1.25.0",
+if ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
+  gem "mime-types", "~> 2.6.1",
     require: "mime/types"
 else
-  gem "mime-types", "~> 2.6.1",
+  gem "mime-types", "~> 1.25.0",
     require: "mime/types"
 end
 


### PR DESCRIPTION
We always have to use the old mime-types version in the Gemfile
otherwise bundler is not able to resolve the dependencies.