### PR TITLE
[stable/3.0] enable collecting a repolist of missing/inactive repos

### DIFF
--- a/crowbar_framework/lib/crowbar/repository.rb
+++ b/crowbar_framework/lib/crowbar/repository.rb
@@ -130,11 +130,19 @@ module Crowbar
       end
 
       def provided_and_enabled?(feature, platform = nil, arch = nil)
-        provided_with_enabled?(feature, platform, arch, true)
+        provided_with_enabled(feature, platform, arch, true).first
+      end
+
+      def provided_and_enabled_with_repolist(feature, platform = nil, arch = nil)
+        provided_with_enabled(feature, platform, arch, true)
       end
 
       def provided?(feature, platform = nil, arch = nil)
-        provided_with_enabled?(feature, platform, arch, false)
+        provided_with_enabled(feature, platform, arch, false).first
+      end
+
+      def provided_with_repolist(feature, platform = nil, arch = nil)
+        provided_with_enabled(feature, platform, arch, false)
       end
 
       def platform_available?(platform, arch)
@@ -170,19 +178,23 @@ module Crowbar
 
       private
 
-      def provided_with_enabled?(feature, platform = nil, arch = nil, check_enabled = true)
+      def provided_with_enabled(feature, platform = nil, arch = nil, check_enabled = true)
+        repos = {
+          missing_repos: [],
+          inactive_repos: []
+        }
         answer = false
 
         if platform.nil?
           all_platforms.each do |p|
-            if provided_with_enabled?(feature, p, arch, check_enabled)
+            if provided_with_enabled(feature, p, arch, check_enabled).first
               answer = true
               break
             end
           end
         elsif arch.nil?
           arches(platform).each do |a|
-            if provided_with_enabled?(feature, platform, a, check_enabled)
+            if provided_with_enabled(feature, platform, a, check_enabled).first
               answer = true
               break
             end
@@ -199,17 +211,18 @@ module Crowbar
 
             r = new(platform, arch, repo)
             answer &&= r.available?
+            repos[:missing_repos].push(r.name) unless answer
 
             break unless check_enabled
             answer &&= r.active?
+            repos[:inactive_repos].push(r.name) unless answer
           end
 
           answer = false unless found
         end
 
-        answer
+        [answer, repos]
       end
-
     end
 
     def initialize(platform, arch, repo)


### PR DESCRIPTION
this becomes useful in the upgrade UI during the repochecks

(cherry picked from commit 4819c649a7f3acf99694f1518a110b9994670596)