### PR TITLE
don't provoke repository enabling

### DIFF
--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -61,7 +61,7 @@ class Api::CrowbarController < ApiController
       crowbar_upgrade = Api::Crowbar.upgrade!
 
       if crowbar_upgrade[:status] == :ok
-        render json: Api::Crowbar.upgrade
+        head :ok
       else
         render json: { error: crowbar_upgrade[:message] }, status: crowbar_upgrade[:status]
       end


### PR DESCRIPTION
when we check the status of the upgrade, we are trying an implicit
enabling of the repositories in the upgrade case.
at this stage this is just wrong, so we drop this check and
sacrifice the api response to just report status 200 instead of
the upgrade status in the response

(this needs a backport)