### PR TITLE
Fix installation of UEFI nodes

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -118,6 +118,16 @@
         <type config:type="symbol">CT_DISK</type>
         <disklabel>gpt</disklabel>
         <partitions config:type="list">
+          <% if node["uefi"] %>
+          <partition>
+            <create config:type="boolean">true</create>
+            <format config:type="boolean">true</format>
+            <filesystem config:type="symbol">vfat</filesystem>
+            <partition_id config:type="integer">259</partition_id>
+            <mount>/boot/efi</mount>
+            <size>128M</size>
+          </partition>
+          <% end %>
           <partition>
             <create config:type="boolean">true</create>
             <partition_id config:type="integer">263</partition_id>
@@ -146,6 +156,16 @@
           <type config:type="symbol">CT_DISK</type>
           <initialize config:type="boolean">true</initialize>
           <partitions config:type="list">
+            <% if node["uefi"] %>
+            <partition>
+              <create config:type="boolean">true</create>
+              <format config:type="boolean">true</format>
+              <filesystem config:type="symbol">vfat</filesystem>
+              <partition_id config:type="integer">259</partition_id>
+              <mount>/boot/efi</mount>
+              <size>128M</size>
+            </partition>
+            <% end %>
             <partition>
               <create config:type="boolean">true</create>
               <partition_id config:type="integer">263</partition_id>


### PR DESCRIPTION
For successful installation of a node that is booted via EFI
we need to create a /boot/efi partition.

(cherry picked from commit d3616e56431d0a392df1d5345ae5093a9c63a2c1)