### PR TITLE
[stable/3.0] don't provoke repository enabling

### DIFF
--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -28,7 +28,7 @@ class Api::CrowbarController < ApiController
       crowbar_upgrade = Api::Crowbar.upgrade!
 
       if crowbar_upgrade[:status] == :ok
-        render json: Api::Crowbar.upgrade
+        head :ok
       else
         render json: { error: crowbar_upgrade[:message] }, status: crowbar_upgrade[:status]
       end


### PR DESCRIPTION
when we check the status of the upgrade, we are trying an implicit
enabling of the repositories in the upgrade case.
at this stage this is just wrong, so we drop this check and
sacrifice the api response to just report status 200 instead of
the upgrade status in the response

(cherry picked from commit 3774a12f95b68e686e41b46bd9d71a851bcd7fa1)