### PR TITLE
don't inherit API models from Tableless

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -17,7 +17,7 @@
 require "open3"
 
 module Api
-  class Crowbar < Tableless
+  class Crowbar
     class << self
       def status
         {

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -15,7 +15,7 @@
 #
 
 module Api
-  class Node < Tableless
+  class Node
     def initialize(name = nil)
       @node = NodeObject.find_node_by_name name
     end

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -17,7 +17,7 @@
 require "open3"
 
 module Api
-  class Upgrade < Tableless
+  class Upgrade
     class << self
       def status
         {


### PR DESCRIPTION
These API models don't use any methods from `Tableless`, so don't inherit from it.
