### PR TITLE
Fix test

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/zzz-prompt.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/zzz-prompt.sh.erb
@@ -7,7 +7,7 @@ fi
 # Only set the crazy prompt on terminals that support colors
 # it looks horrible on monochromatic terminals
 
-if [ $(tput colors) -ge 8 ]; then
+if test $(tput colors 2> /dev/null || echo 0) -ge 8; then
     case $(readlink /proc/$$/exe 2>/dev/null) in
         */zsh)
             PS1=$'<%= @zsh_prompt_from_template.call %> '


### PR DESCRIPTION
The test operator `[` expects a value on the left hand side of `x -ge 8`.
However, if the `tput` command fails, for example because it doesn't recognize
the terminal type, then the expression fails. The `[[` operator is more
robust.