### PR TITLE
Script for deleting pacemaker resources

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -57,7 +57,7 @@ new_alias = repo_alias.gsub("SP1", "SP2").gsub(node[:platform_version], target_p
 
 template "/usr/sbin/crowbar-upgrade-os.sh" do
   source "crowbar-upgrade-os.erb"
-  mode "0770"
+  mode "0755"
   owner "root"
   group "root"
   action :create
@@ -80,7 +80,7 @@ use_ha = node["run_list_map"].key? "pacemaker-cluster-member"
 
 template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   source "crowbar-shutdown-services-before-upgrade.sh.erb"
-  mode "0770"
+  mode "0755"
   owner "root"
   group "root"
   action :create
@@ -106,12 +106,23 @@ end
 
 template "/usr/sbin/crowbar-pre-upgrade.sh" do
   source "crowbar-pre-upgrade.sh.erb"
-  mode "0770"
+  mode "0755"
   owner "root"
   group "root"
   action :create
   variables(
     use_ha: use_ha,
     os_auth_url_v2: os_auth_url_v2
+  )
+end
+
+template "/usr/sbin/crowbar-delete-pacemaker-resources.sh" do
+  source "crowbar-delete-pacemaker-resources.sh.erb"
+  mode "0755"
+  owner "root"
+  group "root"
+  action :create
+  variables(
+    use_ha: use_ha
   )
 end

--- a/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Old pacemaker resources must be deleted in the old setup before they get created from upgraded node
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+echo "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+
+if [[ -f $UPGRADEDIR/crowbar-delete-pacemaker-resources-ok ]] ; then
+    echo "Pacemaker resources already successfully deleted"
+    exit 0
+fi
+
+rm -f $UPGRADEDIR/crowbar-delete-pacemaker-resources-failed
+
+<% if @use_ha %>
+
+echo "Stopping pacemaker resources..."
+
+# Services need to be stopped before deletion.
+# Otherwise we could have services starting up in unwanted locations while deleting constraints.
+
+for type in clone group ms primitive; do
+    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /drbd|stonith|vip-/) {print \$2}"); do
+        crm --wait resource stop $resource
+    done
+done
+
+ret=$?
+if [ $ret != 0 ] ; then
+    echo "Error occured during stopping resources."
+    echo $ret > $UPGRADEDIR/crowbar-delete-pacemaker-resources-failed
+    exit $ret
+fi
+
+echo "Deleting pacemaker resources..."
+
+crm_cmd=""
+for type in location clone group ms primitive; do
+    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /drbd|stonith|vip-/) {print \$2}"); do
+        printf -v crm_cmd "${crm_cmd}delete $resource\n"
+    done
+done
+
+# Delete the resources in single transaction - let pacemaker decide the ordering
+crm configure <<EOF
+$crm_cmd
+EOF
+
+ret=$?
+if [ $ret != 0 ] ; then
+    echo "Error occured during deleting resources"
+    echo $ret > $UPGRADEDIR/crowbar-delete-pacemaker-resources-failed
+    exit $ret
+fi
+
+<% else %>
+
+echo "No HA setup found..."
+
+<% end %>
+
+touch $UPGRADEDIR/crowbar-delete-pacemaker-resources-ok

--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -21,7 +21,9 @@ fi
 echo "Evacuating l3 agents out of this node..."
 
 if [[ -f /usr/bin/neutron-ha-tool ]] ; then
+    set +x
     source /root/.openrc
+    set -x
     OS_AUTH_URL="<%= @os_auth_url_v2 %>" neutron-ha-tool --l3-agent-evacuate $(hostname)
 fi
 


### PR DESCRIPTION
We must delete old pacemaker resources from Cloud6 node
before the new ones get created from upgraded node.

See https://github.com/jsuchome/cloud-upgrade/blob/master/Step%2012.md , Step 4
