### PR TITLE
Use the same key for Cloud product as with nodes repocheck call.

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -102,11 +102,11 @@ module Api
           } unless os_available
 
           cloud_available = repo_version_available?(products, "suse-openstack-cloud", "8")
-          ret[:cloud] = {
+          ret[:openstack] = {
             available: cloud_available,
             repos: {}
           }
-          ret[:cloud][:repos][admin_architecture.to_sym] = {
+          ret[:openstack][:repos][admin_architecture.to_sym] = {
             missing: ["SUSE OpenStack Cloud 8"]
           } unless cloud_available
         end

--- a/crowbar_framework/spec/fixtures/crowbar_repocheck.json
+++ b/crowbar_framework/spec/fixtures/crowbar_repocheck.json
@@ -3,7 +3,7 @@
     "available":true,
     "repos": {}
   },
-  "cloud":{
+  "openstack":{
     "available":true,
     "repos": {}
   }


### PR DESCRIPTION
Needs backport to 3.0