### PR TITLE
adapt api error responses for consistency

### DIFF
--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -64,7 +64,14 @@ class Api::CrowbarController < ApiController
       if crowbar_upgrade[:status] == :ok
         render json: Api::Crowbar.upgrade
       else
-        render json: { error: crowbar_upgrade[:message] }, status: crowbar_upgrade[:status]
+        render json: {
+          errors: {
+            admin_upgrade: {
+              data: crowbar_upgrade[:message],
+              help: I18n.t("api.crowbar.upgrade.help.default")
+            }
+          }
+        }, status: crowbar_upgrade[:status]
       end
     else
       render json: Api::Crowbar.upgrade

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -73,7 +73,14 @@ class Api::UpgradeController < ApiController
     if status == :ok
       head status
     else
-      render json: msg, status: status
+      render json: {
+        errors: {
+          prepare: {
+            data: msg,
+            help: I18n.t("api.upgrade.prepare.help.default")
+          }
+        }
+      }, status: status
     end
   end
 
@@ -87,7 +94,14 @@ class Api::UpgradeController < ApiController
     if stop_services[:status] == :ok
       head :ok
     else
-      render json: { error: stop_services[:message] }, status: stop_services[:status]
+      render json: {
+        errors: {
+          services: {
+            data: stop_services[:message],
+            help: I18n.t("api.upgrade.services.help.default")
+          }
+        }
+      }, status: stop_services[:status]
     end
   end
 
@@ -101,7 +115,14 @@ class Api::UpgradeController < ApiController
     if Api::Upgrade.nodes
       head :ok
     else
-      render json: { error: "Node Upgrade failed" }, status: :unprocessable_entity
+      render json: {
+        errors: {
+          nodes: {
+            data: "Node Upgrade failed",
+            help: I18n.t("api.upgrade.nodes.help.default")
+          }
+        }
+      }, status: :unprocessable_entity
     end
   end
 
@@ -160,7 +181,14 @@ class Api::UpgradeController < ApiController
     if cancel_upgrade[:status] == :ok
       head :ok
     else
-      render json: { error: cancel_upgrade[:message] }, status: cancel_upgrade[:status]
+      render json: {
+        errors: {
+          cancel: {
+            data: cancel_upgrade[:message],
+            help: I18n.t("api.upgrade.cancel.help.default")
+          }
+        }
+      }, status: cancel_upgrade[:status]
     end
   end
 

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -118,7 +118,7 @@ class Api::UpgradeController < ApiController
       render json: {
         errors: {
           nodes: {
-            data: "Node Upgrade failed",
+            data: I18n.t("api.upgrade.nodes.failed"),
             help: I18n.t("api.upgrade.nodes.help.default")
           }
         }

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -799,6 +799,7 @@ en:
         help:
           default: 'Refer to the error message in the response'
       nodes:
+        failed: 'Node upgrade failed'
         help:
           default: 'Refer to the error message in the response'
       cancel:

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -772,6 +772,9 @@ en:
       upgrade_ongoing: 'Upgrade is already ongoing. Please wait.'
       zypper_locked: '%{zypper_locked_message}'
       upgrade_script_path: 'Could not find %{path}'
+      upgrade:
+        help:
+          default: 'Refer to the error message in the response'
     upgrade:
       prechecks:
         network_checks:
@@ -789,6 +792,18 @@ en:
         compute_resources_check:
           help:
             default: 'Make sure there is enough compute power'
+      prepare:
+        help:
+          default: 'Refer to the error message in the response'
+      services:
+        help:
+          default: 'Refer to the error message in the response'
+      nodes:
+        help:
+          default: 'Refer to the error message in the response'
+      cancel:
+        help:
+          default: 'Refer to the error message in the response'
 
   # Global
   overview: 'Overview'

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -118,8 +118,15 @@ describe Api::UpgradeController, type: :request do
 
       post "/api/upgrade/cancel", {}, headers
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to eq(
-        "{\"error\":\"an Error\"}"
+      expect(JSON.parse(response.body)).to eq(
+        {
+          errors: {
+            cancel: {
+              data: "an Error",
+              help: I18n.t("api.upgrade.cancel.help.default")
+            }
+          }
+        }.deep_stringify_keys
       )
     end
 


### PR DESCRIPTION
use the same format as we have in the prechecks, as this was already discussed as the best format

```ruby
code: {
  data: ... whatever data type ...,
  help: String # "this is how you might fix the error"
}
```