### PR TITLE
conduit_resolver: Handle missing DMI information more graceful

### DIFF
--- a/crowbar_framework/lib/crowbar/conduit_resolver.rb
+++ b/crowbar_framework/lib/crowbar/conduit_resolver.rb
@@ -270,6 +270,8 @@ module Crowbar
 
     ## Return the DMI system attributes from the node
     def cr_dmi_system
+      return {} if @node[:dmi].nil? || node[:dmi][:system].nil?
+
       @node[:dmi][:system]
     end
 


### PR DESCRIPTION
This is a forward port of 06ed833ca, which was missed when moving to
conduit_resolver.