### PR TITLE
move and rename repocheck api endpoints

### DIFF
--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -84,38 +84,4 @@ class Api::CrowbarController < ApiController
   def maintenance
     render json: ::Crowbar::Checks::Maintenance.updates_status
   end
-
-  api :GET, "/api/crowbar/repocheck", "Sanity check for Crowbar server repositories"
-  header "Accept", "application/vnd.crowbar.v2.0+json", required: true
-  api_version "2.0"
-  example '
-  {
-    "os": {
-      "available": true,
-      "repos": {}
-    },
-    "cloud": {
-      "available": false,
-      "repos": {
-        "x86_64": {
-          "missing": [
-            "SUSE OpenStack Cloud 7"
-          ]
-        }
-      }
-    }
-  }
-  '
-  error 503, "zypper is locked"
-  def repocheck
-    check = Api::Crowbar.repocheck
-
-    if check.key?(:error)
-      render json: {
-        error: check[:error]
-      }, status: check[:status]
-    else
-      render json: check
-    end
-  end
 end

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -204,6 +204,41 @@ class Api::UpgradeController < ApiController
     render json: Api::Upgrade.repocheck
   end
 
+  api :GET, "/api/upgrade/adminrepocheck",
+    "Sanity check for Crowbar server repositories"
+  header "Accept", "application/vnd.crowbar.v2.0+json", required: true
+  api_version "2.0"
+  example '
+  {
+    "os": {
+      "available": true,
+      "repos": {}
+    },
+    "openstack": {
+      "available": false,
+      "repos": {
+        "x86_64": {
+          "missing": [
+            "SUSE OpenStack Cloud 7"
+          ]
+        }
+      }
+    }
+  }
+  '
+  error 503, "zypper is locked"
+  def adminrepocheck
+    check = Api::Upgrade.adminrepocheck
+
+    if check.key?(:error)
+      render json: {
+        error: check[:error]
+      }, status: check[:status]
+    else
+      render json: check
+    end
+  end
+
   protected
 
   api :POST, "/api/upgrade/new",

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -164,7 +164,7 @@ class Api::UpgradeController < ApiController
     end
   end
 
-  api :GET, "/api/upgrade/repocheck", "Check for missing node repositories"
+  api :GET, "/api/upgrade/noderepocheck", "Check for missing node repositories"
   header "Accept", "application/vnd.crowbar.v2.0+json", required: true
   api_version "2.0"
   example '
@@ -200,8 +200,8 @@ class Api::UpgradeController < ApiController
     }
   }
   '
-  def repocheck
-    render json: Api::Upgrade.repocheck
+  def noderepocheck
+    render json: Api::Upgrade.noderepocheck
   end
 
   api :GET, "/api/upgrade/adminrepocheck",

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -74,44 +74,6 @@ module Api
         end
       end
 
-      def repocheck
-        # FIXME: once we start working on 7 to 8 upgrade we have to adapt the sles version
-        zypper_stream = Hash.from_xml(
-          `sudo /usr/bin/zypper-retry --xmlout products`
-        )["stream"]
-
-        {}.tap do |ret|
-          if zypper_stream["message"] =~ /^System management is locked/
-            return {
-              status: :service_unavailable,
-              message: I18n.t(
-                "api.crowbar.zypper_locked", zypper_locked_message: zypper_stream["message"]
-              )
-            }
-          end
-
-          products = zypper_stream["product_list"]["product"]
-
-          os_available = repo_version_available?(products, "SLES", "12.3")
-          ret[:os] = {
-            available: os_available,
-            repos: {}
-          }
-          ret[:os][:repos][admin_architecture.to_sym] = {
-            missing: ["SUSE Linux Enterprise Server 12 SP3"]
-          } unless os_available
-
-          cloud_available = repo_version_available?(products, "suse-openstack-cloud", "8")
-          ret[:openstack] = {
-            available: cloud_available,
-            repos: {}
-          }
-          ret[:openstack][:repos][admin_architecture.to_sym] = {
-            missing: ["SUSE OpenStack Cloud 8"]
-          } unless cloud_available
-        end
-      end
-
       def ceph_healthy?
         ceph_node = NodeObject.find("roles:ceph-mon AND ceph_config_environment:*").first
         return true if ceph_node.nil?

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -56,7 +56,7 @@ module Api
         end
       end
 
-      def repocheck
+      def noderepocheck
         response = {}
         addons = Api::Crowbar.addons
         addons.push("os", "openstack").each do |addon|

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -65,6 +65,44 @@ module Api
         response
       end
 
+      def adminrepocheck
+        # FIXME: once we start working on 7 to 8 upgrade we have to adapt the sles version
+        zypper_stream = Hash.from_xml(
+          `sudo /usr/bin/zypper-retry --xmlout products`
+        )["stream"]
+
+        {}.tap do |ret|
+          if zypper_stream["message"] =~ /^System management is locked/
+            return {
+              status: :service_unavailable,
+              message: I18n.t(
+                "api.crowbar.zypper_locked", zypper_locked_message: zypper_stream["message"]
+              )
+            }
+          end
+
+          products = zypper_stream["product_list"]["product"]
+
+          os_available = repo_version_available?(products, "SLES", "12.3")
+          ret[:os] = {
+            available: os_available,
+            repos: {}
+          }
+          ret[:os][:repos][admin_architecture.to_sym] = {
+            missing: ["SUSE Linux Enterprise Server 12 SP3"]
+          } unless os_available
+
+          cloud_available = repo_version_available?(products, "suse-openstack-cloud", "8")
+          ret[:openstack] = {
+            available: cloud_available,
+            repos: {}
+          }
+          ret[:openstack][:repos][admin_architecture.to_sym] = {
+            missing: ["SUSE OpenStack Cloud 8"]
+          } unless cloud_available
+        end
+      end
+
       def target_platform(options = {})
         platform_exception = options.fetch(:platform_exception, nil)
 

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -250,7 +250,6 @@ Rails.application.routes.draw do
       get :upgrade
       post :upgrade
       get :maintenance
-      get :repocheck
 
       resources :backups,
         only: [:index, :show, :create, :destroy] do
@@ -278,6 +277,7 @@ Rails.application.routes.draw do
       get :prechecks
       post :cancel
       get :repocheck
+      get :adminrepocheck
     end
 
     resources :nodes,

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -276,7 +276,7 @@ Rails.application.routes.draw do
       post :nodes
       get :prechecks
       post :cancel
-      get :repocheck
+      get :noderepocheck
       get :adminrepocheck
     end
 

--- a/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
@@ -25,13 +25,6 @@ describe Api::CrowbarController, type: :request do
         )
       ).to_json
     end
-    let!(:crowbar_repocheck) do
-      JSON.parse(
-        File.read(
-          "spec/fixtures/crowbar_repocheck.json"
-        )
-      ).to_json
-    end
 
     it "shows the crowbar object" do
       allow(Api::Crowbar).to(
@@ -81,16 +74,6 @@ describe Api::CrowbarController, type: :request do
       get "/api/crowbar/maintenance", {}, headers
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq(crowbar_maintenance)
-    end
-
-    it "checks the crowbar repositories" do
-      allow(Api::Crowbar).to(
-        receive(:repocheck).and_return(JSON.parse(crowbar_repocheck))
-      )
-
-      get "/api/crowbar/repocheck", {}, headers
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to eq(crowbar_repocheck)
     end
   end
 end

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -159,7 +159,7 @@ describe Api::UpgradeController, type: :request do
         )
       end
 
-      get "/api/upgrade/repocheck", {}, headers
+      get "/api/upgrade/noderepocheck", {}, headers
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq(
         "{\"os\":{\"available\":true,\"repos\":{}},\"openstack\":{\"available\":true,\"repos\":{}}}"

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -17,6 +17,13 @@ describe Api::UpgradeController, type: :request do
         )
       ).to_json
     end
+    let!(:crowbar_repocheck) do
+      JSON.parse(
+        File.read(
+          "spec/fixtures/crowbar_repocheck.json"
+        )
+      ).to_json
+    end
 
     it "shows the upgrade status object" do
       allow(Api::Upgrade).to receive(:network_checks).and_return([])
@@ -157,6 +164,16 @@ describe Api::UpgradeController, type: :request do
       expect(response.body).to eq(
         "{\"os\":{\"available\":true,\"repos\":{}},\"openstack\":{\"available\":true,\"repos\":{}}}"
       )
+    end
+
+    it "checks the crowbar repositories" do
+      allow(Api::Upgrade).to(
+        receive(:adminrepocheck).and_return(JSON.parse(crowbar_repocheck))
+      )
+
+      get "/api/upgrade/adminrepocheck", {}, headers
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq(crowbar_repocheck)
     end
   end
 end

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -22,6 +22,23 @@ describe Api::Upgrade do
       )
     )
   end
+  let!(:crowbar_repocheck) do
+    JSON.parse(
+      File.read(
+        "spec/fixtures/crowbar_repocheck.json"
+      )
+    )
+  end
+  let!(:crowbar_repocheck_zypper) do
+    File.read(
+      "spec/fixtures/crowbar_repocheck_zypper.xml"
+    ).to_s
+  end
+  let!(:crowbar_repocheck_zypper_locked) do
+    File.read(
+      "spec/fixtures/crowbar_repocheck_zypper_locked.xml"
+    ).to_s
+  end
 
   before(:each) do
     allow(Api::Node).to(
@@ -177,6 +194,62 @@ describe Api::Upgrade do
       end
 
       expect(subject.class.repocheck).to eq(expected)
+    end
+  end
+
+  context "with repositories not in place" do
+    it "lists the repositories that are not available" do
+      allow(Api::Upgrade).to(
+        receive(:repo_version_available?).and_return(false)
+      )
+      allow(Api::Upgrade).to(
+        receive(:admin_architecture).and_return("x86_64")
+      )
+      allow_any_instance_of(Kernel).to(
+        receive(:`).with(
+          "sudo /usr/bin/zypper-retry --xmlout products"
+        ).and_return(crowbar_repocheck_zypper)
+      )
+
+      expect(subject.class.adminrepocheck.deep_stringify_keys).to_not(
+        eq(crowbar_repocheck)
+      )
+    end
+  end
+
+  context "with a locked zypper" do
+    it "shows an error message that zypper is locked" do
+      allow(Api::Crowbar).to(
+        receive(:repo_version_available?).and_return(false)
+      )
+      allow_any_instance_of(Kernel).to(
+        receive(:`).with(
+          "sudo /usr/bin/zypper-retry --xmlout products"
+        ).and_return(crowbar_repocheck_zypper_locked)
+      )
+
+      check = subject.class.adminrepocheck
+      expect(check[:status]).to eq(:service_unavailable)
+      expect(check[:message]).to eq(
+        Hash.from_xml(crowbar_repocheck_zypper_locked)["stream"]["message"]
+      )
+    end
+  end
+
+  context "with repositories in place" do
+    it "lists the available repositories" do
+      allow(Api::Upgrade).to(
+        receive(:repo_version_available?).and_return(true)
+      )
+      allow_any_instance_of(Kernel).to(
+        receive(:`).with(
+          "sudo /usr/bin/zypper-retry --xmlout products"
+        ).and_return(crowbar_repocheck_zypper)
+      )
+
+      expect(subject.class.adminrepocheck.deep_stringify_keys).to(
+        eq(crowbar_repocheck)
+      )
     end
   end
 

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -164,7 +164,7 @@ describe Api::Upgrade do
         k.delete("ha")
       end
 
-      expect(subject.class.repocheck).to eq(os_repo_fixture)
+      expect(subject.class.noderepocheck).to eq(os_repo_fixture)
     end
   end
 
@@ -193,7 +193,7 @@ describe Api::Upgrade do
         k.delete("ha")
       end
 
-      expect(subject.class.repocheck).to eq(expected)
+      expect(subject.class.noderepocheck).to eq(expected)
     end
   end
 


### PR DESCRIPTION
```perl
/api/crowbar/repocheck -> /api/upgrade/adminrepocheck
/api/upgrade/repocheck -> /api/upgrade/noderepocheck
```

`crowbarctl` PR https://github.com/crowbar/crowbar-client/pull/114

needs a (partial) backport