### PR TITLE
barclamp: Fix conduit_resolver from chef for s390x

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -13,6 +13,8 @@
 # limitations under the License.
 #
 
+require_relative "conduit_resolver.rb"
+
 module BarclampLibrary
   class Barclamp
     class NodeConduitResolver


### PR DESCRIPTION
For some reason s390x seems to need the require_relative, while it works
without that on the other archs.