### PR TITLE
[stable/3.0] adapt error messages of responses to be consistent

### DIFF
--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -30,7 +30,14 @@ class Api::CrowbarController < ApiController
       if crowbar_upgrade[:status] == :ok
         head :ok
       else
-        render json: { error: crowbar_upgrade[:message] }, status: crowbar_upgrade[:status]
+        render json: {
+          errors: {
+            admin_upgrade: {
+              data: crowbar_upgrade[:message],
+              help: I18n.t("api.crowbar.upgrade.help.default")
+            }
+          }
+        }, status: crowbar_upgrade[:status]
       end
     else
       render json: Api::Crowbar.upgrade

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -40,7 +40,14 @@ class Api::UpgradeController < ApiController
     if status == :ok
       head status
     else
-      render json: msg, status: status
+      render json: {
+        errors: {
+          prepare: {
+            data: msg,
+            help: I18n.t("api.upgrade.prepare.help.default")
+          }
+        }
+      }, status: status
     end
   end
 
@@ -54,7 +61,14 @@ class Api::UpgradeController < ApiController
     if cancel_upgrade[:status] == :ok
       head :ok
     else
-      render json: { error: cancel_upgrade[:message] }, status: cancel_upgrade[:status]
+      render json: {
+        errors: {
+          cancel: {
+            data: cancel_upgrade[:message],
+            help: I18n.t("api.upgrade.cancel.help.default")
+          }
+        }
+      }, status: cancel_upgrade[:status]
     end
   end
 end

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -770,6 +770,9 @@ en:
       upgrade_ongoing: 'Upgrade is already ongoing. Please wait.'
       zypper_locked: '%{zypper_locked_message}'
       upgrade_script_path: 'Could not find %{path}'
+      upgrade:
+        help:
+          default: 'Refer to the error message in the response'
     upgrade:
       prechecks:
         network_checks:
@@ -787,6 +790,12 @@ en:
         compute_resources_check:
           help:
             default: 'Make sure there is enough compute power'
+      prepare:
+        help:
+          default: 'Refer to the error message in the response'
+      cancel:
+        help:
+          default: 'Refer to the error message in the response'
 
   # Global
   overview: 'Overview'

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -74,8 +74,15 @@ describe Api::UpgradeController, type: :request do
 
       post "/api/upgrade/cancel", {}, headers
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to eq(
-        "{\"error\":\"an Error\"}"
+      expect(JSON.parse(response.body)).to eq(
+        {
+          errors: {
+            cancel: {
+              data: "an Error",
+              help: I18n.t("api.upgrade.cancel.help.default")
+            }
+          }
+        }.deep_stringify_keys
       )
     end
   end


### PR DESCRIPTION
the error message format needs to be adapted to be consistent
over the other api responses that could throw an error

we are using the same format here as in the prechecks, as this
was discussed and designed properly

(cherry picked from commit b2bf06c56bb5fe7e69ed1f53023df2145c857370)

partially backports https://github.com/crowbar/crowbar-core/pull/730