### PR TITLE
[stable/3.0] move admin repochecks to /api/upgrade namespace

### DIFF
--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -40,16 +40,4 @@ class Api::CrowbarController < ApiController
   def maintenance
     render json: ::Crowbar::Checks::Maintenance.updates_status
   end
-
-  def repocheck
-    check = Api::Crowbar.repocheck
-
-    if check.key?(:error)
-      render json: {
-        error: check[:error]
-      }, status: check[:status]
-    else
-      render json: check
-    end
-  end
 end

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -57,4 +57,16 @@ class Api::UpgradeController < ApiController
       render json: { error: cancel_upgrade[:message] }, status: cancel_upgrade[:status]
     end
   end
+
+  def adminrepocheck
+    check = Api::Upgrade.adminrepocheck
+
+    if check.key?(:error)
+      render json: {
+        error: check[:error]
+      }, status: check[:status]
+    else
+      render json: check
+    end
+  end
 end

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -82,50 +82,6 @@ module Api
         end
       end
 
-      def repocheck
-        # FIXME: once we start working on 7 to 8 upgrade we have to adapt the sles version
-        zypper_stream = Hash.from_xml(
-          `sudo /usr/bin/zypper-retry --xmlout products`
-        )["stream"]
-
-        {}.tap do |ret|
-          if zypper_stream["message"] =~ /^System management is locked/
-            return {
-              status: :service_unavailable,
-              message: I18n.t(
-                "api.crowbar.zypper_locked", zypper_locked_message: zypper_stream["message"]
-              )
-            }
-          end
-
-          products = zypper_stream["product_list"]["product"]
-
-          os_available = repo_version_available?(products, "SLES", "12.2")
-          ret[:os] = {
-            available: os_available,
-            repos: {}
-          }
-          ret[:os][:repos][admin_architecture.to_sym] = {
-            missing: [
-              "SLES12-SP2-Pool",
-              "SLES12-SP2-Updates"
-            ]
-          } unless os_available
-
-          cloud_available = repo_version_available?(products, "suse-openstack-cloud", "7")
-          ret[:openstack] = {
-            available: cloud_available,
-            repos: {}
-          }
-          ret[:openstack][:repos][admin_architecture.to_sym] = {
-            missing: [
-              "SUSE-OpenStack-Cloud-7-Pool",
-              "SUSE-OpenStack-Cloud-7-Updates"
-            ]
-          } unless cloud_available
-        end
-      end
-
       # Simple check if HA clusters report some problems
       # If there are no problems, empty hash is returned.
       # If this fails, information about failed actions for each cluster founder is

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -53,6 +53,44 @@ module Api
         end
       end
 
+      def adminrepocheck
+        # FIXME: once we start working on 7 to 8 upgrade we have to adapt the sles version
+        zypper_stream = Hash.from_xml(
+          `sudo /usr/bin/zypper-retry --xmlout products`
+        )["stream"]
+
+        {}.tap do |ret|
+          if zypper_stream["message"] =~ /^System management is locked/
+            return {
+              status: :service_unavailable,
+              message: I18n.t(
+                "api.crowbar.zypper_locked", zypper_locked_message: zypper_stream["message"]
+              )
+            }
+          end
+
+          products = zypper_stream["product_list"]["product"]
+
+          os_available = repo_version_available?(products, "SLES", "12.3")
+          ret[:os] = {
+            available: os_available,
+            repos: {}
+          }
+          ret[:os][:repos][admin_architecture.to_sym] = {
+            missing: ["SUSE Linux Enterprise Server 12 SP3"]
+          } unless os_available
+
+          cloud_available = repo_version_available?(products, "suse-openstack-cloud", "8")
+          ret[:openstack] = {
+            available: cloud_available,
+            repos: {}
+          }
+          ret[:openstack][:repos][admin_architecture.to_sym] = {
+            missing: ["SUSE OpenStack Cloud 8"]
+          } unless cloud_available
+        end
+      end
+
       def target_platform(options = {})
         platform_exception = options.fetch(:platform_exception, nil)
 

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -201,7 +201,6 @@ Rails.application.routes.draw do
       get :upgrade
       post :upgrade
       get :maintenance
-      get :repocheck
     end
 
     resource :upgrade,
@@ -212,6 +211,7 @@ Rails.application.routes.draw do
       get :services
       get :prechecks
       post :cancel
+      get :adminrepocheck
     end
   end
 

--- a/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
@@ -26,13 +26,6 @@ describe Api::CrowbarController, type: :request do
         )
       ).to_json
     end
-    let!(:crowbar_repocheck) do
-      JSON.parse(
-        File.read(
-          "spec/fixtures/crowbar_repocheck.json"
-        )
-      ).to_json
-    end
 
     it "shows the crowbar object" do
       allow(Api::Crowbar).to(
@@ -85,16 +78,6 @@ describe Api::CrowbarController, type: :request do
       get "/api/crowbar/maintenance", {}, headers
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq(crowbar_maintenance)
-    end
-
-    it "checks the crowbar repositories" do
-      allow(Api::Crowbar).to(
-        receive(:repocheck).and_return(JSON.parse(crowbar_repocheck))
-      )
-
-      get "/api/crowbar/repocheck", {}, headers
-      expect(response).to have_http_status(:ok)
-      expect(response.body).to eq(crowbar_repocheck)
     end
   end
 end

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -17,6 +17,13 @@ describe Api::UpgradeController, type: :request do
         )
       ).to_json
     end
+    let!(:crowbar_repocheck) do
+      JSON.parse(
+        File.read(
+          "spec/fixtures/crowbar_repocheck.json"
+        )
+      ).to_json
+    end
 
     it "shows the upgrade status object" do
       allow(Api::Upgrade).to receive(:network_checks).and_return([])
@@ -77,6 +84,16 @@ describe Api::UpgradeController, type: :request do
       expect(response.body).to eq(
         "{\"error\":\"an Error\"}"
       )
+    end
+
+    it "checks the crowbar repositories" do
+      allow(Api::Upgrade).to(
+        receive(:adminrepocheck).and_return(JSON.parse(crowbar_repocheck))
+      )
+
+      get "/api/upgrade/adminrepocheck", {}, headers
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq(crowbar_repocheck)
     end
   end
 end

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -17,23 +17,6 @@ describe Api::Crowbar do
       )
     )
   end
-  let!(:crowbar_repocheck) do
-    JSON.parse(
-      File.read(
-        "spec/fixtures/crowbar_repocheck.json"
-      )
-    )
-  end
-  let!(:crowbar_repocheck_zypper) do
-    File.read(
-      "spec/fixtures/crowbar_repocheck_zypper.xml"
-    ).to_s
-  end
-  let!(:crowbar_repocheck_zypper_locked) do
-    File.read(
-      "spec/fixtures/crowbar_repocheck_zypper_locked.xml"
-    ).to_s
-  end
   let!(:node) { NodeObject.find_node_by_name("testing") }
 
   before(:each) do
@@ -262,58 +245,6 @@ describe Api::Crowbar do
         and_return([])
       )
       expect(subject.class.compute_resources_available?).to be true
-    end
-  end
-
-  context "with repositories in place" do
-    it "lists the available repositories" do
-      allow(Api::Crowbar).to(
-        receive(:repo_version_available?).and_return(true)
-      )
-      allow_any_instance_of(Kernel).to(
-        receive(:`).with(
-          "sudo /usr/bin/zypper-retry --xmlout products"
-        ).and_return(crowbar_repocheck_zypper)
-      )
-
-      expect(subject.class.repocheck.deep_stringify_keys).to eq(crowbar_repocheck)
-    end
-  end
-
-  context "with repositories not in place" do
-    it "lists the repositories that are not available" do
-      allow(Api::Crowbar).to(
-        receive(:repo_version_available?).and_return(false)
-      )
-      allow(Api::Crowbar).to(
-        receive(:admin_architecture).and_return("x86_64")
-      )
-      allow_any_instance_of(Kernel).to(
-        receive(:`).with(
-          "sudo /usr/bin/zypper-retry --xmlout products"
-        ).and_return(crowbar_repocheck_zypper)
-      )
-
-      expect(subject.class.repocheck.deep_stringify_keys).to_not eq(crowbar_repocheck)
-    end
-  end
-
-  context "with a locked zypper" do
-    it "shows an error message that zypper is locked" do
-      allow(Api::Crowbar).to(
-        receive(:repo_version_available?).and_return(false)
-      )
-      allow_any_instance_of(Kernel).to(
-        receive(:`).with(
-          "sudo /usr/bin/zypper-retry --xmlout products"
-        ).and_return(crowbar_repocheck_zypper_locked)
-      )
-
-      check = subject.class.repocheck
-      expect(check[:status]).to eq(:service_unavailable)
-      expect(check[:message]).to eq(
-        Hash.from_xml(crowbar_repocheck_zypper_locked)["stream"]["message"]
-      )
     end
   end
 end

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -15,6 +15,23 @@ describe Api::Upgrade do
       )
     )
   end
+  let!(:crowbar_repocheck) do
+    JSON.parse(
+      File.read(
+        "spec/fixtures/crowbar_repocheck.json"
+      )
+    )
+  end
+  let!(:crowbar_repocheck_zypper) do
+    File.read(
+      "spec/fixtures/crowbar_repocheck_zypper.xml"
+    ).to_s
+  end
+  let!(:crowbar_repocheck_zypper_locked) do
+    File.read(
+      "spec/fixtures/crowbar_repocheck_zypper_locked.xml"
+    ).to_s
+  end
 
   context "with a successful status" do
     it "checks the status" do
@@ -44,6 +61,62 @@ describe Api::Upgrade do
 
       expect(subject.class).to respond_to(:checks)
       expect(subject.class.checks.deep_stringify_keys).to eq(upgrade_prechecks)
+    end
+  end
+
+  context "with repositories not in place" do
+    it "lists the repositories that are not available" do
+      allow(Api::Upgrade).to(
+        receive(:repo_version_available?).and_return(false)
+      )
+      allow(Api::Upgrade).to(
+        receive(:admin_architecture).and_return("x86_64")
+      )
+      allow_any_instance_of(Kernel).to(
+        receive(:`).with(
+          "sudo /usr/bin/zypper-retry --xmlout products"
+        ).and_return(crowbar_repocheck_zypper)
+      )
+
+      expect(subject.class.adminrepocheck.deep_stringify_keys).to_not(
+        eq(crowbar_repocheck)
+      )
+    end
+  end
+
+  context "with a locked zypper" do
+    it "shows an error message that zypper is locked" do
+      allow(Api::Crowbar).to(
+        receive(:repo_version_available?).and_return(false)
+      )
+      allow_any_instance_of(Kernel).to(
+        receive(:`).with(
+          "sudo /usr/bin/zypper-retry --xmlout products"
+        ).and_return(crowbar_repocheck_zypper_locked)
+      )
+
+      check = subject.class.adminrepocheck
+      expect(check[:status]).to eq(:service_unavailable)
+      expect(check[:message]).to eq(
+        Hash.from_xml(crowbar_repocheck_zypper_locked)["stream"]["message"]
+      )
+    end
+  end
+
+  context "with repositories in place" do
+    it "lists the available repositories" do
+      allow(Api::Upgrade).to(
+        receive(:repo_version_available?).and_return(true)
+      )
+      allow_any_instance_of(Kernel).to(
+        receive(:`).with(
+          "sudo /usr/bin/zypper-retry --xmlout products"
+        ).and_return(crowbar_repocheck_zypper)
+      )
+
+      expect(subject.class.adminrepocheck.deep_stringify_keys).to(
+        eq(crowbar_repocheck)
+      )
     end
   end
 


### PR DESCRIPTION
the admin repochecks are really upgrade specific and don't belong
to the crowbar namespace

(cherry picked from commit 26371aac9a21cf384c3047f82f799b18744086bf)

partially backports https://github.com/crowbar/crowbar-core/pull/732