### PR TITLE
upgrade: workaround potential network issues during the upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -89,9 +89,16 @@ template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   )
 end
 
+# Find all ovs bridges that we manage to be able to reset their fail-mode
+# in preparation for the OS upgrade
+bridges_to_reset = []
+Barclamp::Inventory.list_networks(node).each do |network|
+  next unless network.add_ovs_bridge
+  bridges_to_reset << network.bridge_name
+end
+
 # Following script executes all actions that are needed directly on the node
 # directly before the OS upgrade is initiated.
-
 template "/usr/sbin/crowbar-pre-upgrade.sh" do
   source "crowbar-pre-upgrade.sh.erb"
   mode "0755"
@@ -99,7 +106,8 @@ template "/usr/sbin/crowbar-pre-upgrade.sh" do
   group "root"
   action :create
   variables(
-    use_ha: use_ha
+    use_ha: use_ha,
+    bridges_to_reset: bridges_to_reset
   )
 end
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -45,4 +45,10 @@ fi
 echo "No HA setup found..."
 
 <% end %>
+
+<% @bridges_to_reset.each do |bridge| %>
+echo "Resetting fail-mode on ovs-bridge <%= bridge %>"
+ovs-vsctl set-fail-mode <%= bridge %> standalone
+<% end %>
+
 touch $UPGRADEDIR/crowbar-pre-upgrade-ok

--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -51,4 +51,7 @@ echo "Resetting fail-mode on ovs-bridge <%= bridge %>"
 ovs-vsctl set-fail-mode <%= bridge %> standalone
 <% end %>
 
+echo "Reloading wicked configuration for all interfaces"
+wicked ifreload all
+
 touch $UPGRADEDIR/crowbar-pre-upgrade-ok


### PR DESCRIPTION
After evacuating routers and stopping the remaining services reset the
fail-mode of the ovs bridges to keep network connectivty during the
package upgrade.
https://bugzilla.suse.com/show_bug.cgi?id=1002734

Additionally adds a workaround for https://bugzilla.suse.com/show_bug.cgi?id=1011889 by forcing a wicked ifreload call in the preupgrade script.
