### PR TITLE
determine the best upgrade mode

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -194,7 +194,10 @@ class Api::UpgradeController < ApiController
   }
   '
   def prechecks
-    render json: Api::Upgrade.checks
+    render json: {
+      checks: Api::Upgrade.checks,
+      best_method: Api::Upgrade.best_method
+    }
   end
 
   api :POST, "/api/upgrade/cancel", "Cancel the upgrade process by setting the nodes back to ready"

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -58,6 +58,19 @@ module Api
         end
       end
 
+      def best_method
+        checks_cached = checks
+        return "none" if checks_cached.any? do |_id, c|
+          c[:required] && !c[:passed]
+        end
+        return "non-disruptive" unless checks_cached.any? do |_id, c|
+          (c[:required] || !c[:required]) && !c[:passed]
+        end
+        return "disruptive" unless checks_cached.any? do |_id, c|
+          (c[:required] && !c[:passed]) && (!c[:required] && c[:passed])
+        end
+      end
+
       def noderepocheck
         response = {}
         addons = Api::Crowbar.addons

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -114,6 +114,9 @@ describe Api::UpgradeController, type: :request do
       allow(pacemaker).to receive(
         :ha_presence_check
       ).and_return({})
+      allow(Api::Upgrade).to receive(:checks).and_return(
+        JSON.parse(upgrade_prechecks)["checks"].deep_symbolize_keys
+      )
 
       get "/api/upgrade/prechecks", {}, headers
       expect(response).to have_http_status(:ok)

--- a/crowbar_framework/spec/fixtures/upgrade_prechecks.json
+++ b/crowbar_framework/spec/fixtures/upgrade_prechecks.json
@@ -1,32 +1,35 @@
 {
-  "network_checks": {
-    "required": true,
-    "passed": true,
-    "errors": {}
+  "checks":{
+    "network_checks": {
+      "required": true,
+      "passed": true,
+      "errors": {}
+    },
+    "maintenance_updates_installed": {
+      "required": true,
+      "passed": true,
+      "errors": {}
+    },
+    "compute_resources_available": {
+      "required": false,
+      "passed": true,
+      "errors": {}
+    },
+    "ceph_healthy": {
+      "required": true,
+      "passed": true,
+      "errors": {}
+    },
+    "ha_configured": {
+      "required": false,
+      "passed": true,
+      "errors":{}
+    },
+    "clusters_healthy": {
+      "required": true,
+      "passed": true,
+      "errors": {}
+    }
   },
-  "maintenance_updates_installed": {
-    "required": true,
-    "passed": true,
-    "errors": {}
-  },
-  "compute_resources_available": {
-    "required": false,
-    "passed": true,
-    "errors": {}
-  },
-  "ceph_healthy": {
-    "required": true,
-    "passed": true,
-    "errors": {}
-  },
-  "ha_configured": {
-    "required": false,
-    "passed": true,
-    "errors":{}
-  },
-  "clusters_healthy": {
-    "required": true,
-    "passed": true,
-    "errors": {}
-  }
+  "best_method":"non-disruptive"
 }


### PR DESCRIPTION
none: when a required check fails
non-disruptive: when all required checks succeed
disruptive: when only some non-required checks fail

### needs a backport

### related
* https://github.com/SUSE-Cloud/automation/pull/1378