### PR TITLE
Do not add the pre-upgrade attribute from the recipe

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -73,11 +73,6 @@ when "prepare-os-upgrade"
 
   include_recipe "crowbar::prepare-upgrade-scripts"
 
-  execute "set pre-upgrade node attribute" do
-    command "crm node attribute $(hostname) set pre-upgrade true"
-    only_if { node.roles.include? "pacemaker-cluster-member" }
-  end
-
 when "openstack_shutdown"
 
   include_recipe "crowbar::stop-services-before-upgrade"

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -146,16 +146,10 @@ module Api
           }
         end
 
-        # Initiate the services shutdown by calling scripts on all nodes.
-        # For each cluster, it is enough to initiate the shutdown from one node (e.g. founder)
-        NodeObject.find("state:crowbar_upgrade AND pacemaker_founder:true").each do |node|
-          node.ssh_cmd("/usr/sbin/crowbar-shutdown-services-before-upgrade.sh")
-        end
-        # Shutdown the services for non clustered nodes
-        NodeObject.find("state:crowbar_upgrade AND NOT run_list_map:pacemaker-cluster-member").
-          each do |node|
-          node.ssh_cmd("/usr/sbin/crowbar-shutdown-services-before-upgrade.sh")
-        end
+        # Initiate the services shutdown for all nodes
+        NodeObject.find("state:crowbar_upgrade").each(
+          &:shutdown_services_before_upgrade
+        )
 
         {
           status: :ok,

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -114,38 +114,13 @@ describe Api::Upgrade do
         :prepare_nodes_for_os_upgrade
       ).and_return(true)
       allow(NodeObject).to(
-        receive(:find).with("state:crowbar_upgrade AND pacemaker_founder:true").
+        receive(:find).with("state:crowbar_upgrade").
         and_return([NodeObject.find_node_by_name("testing.crowbar.com")])
       )
-      allow(NodeObject).to(
-        receive(:find).with("state:crowbar_upgrade AND NOT run_list_map:pacemaker-cluster-member").
-        and_return([])
+      allow_any_instance_of(NodeObject).to(
+        receive(:shutdown_services_before_upgrade).
+        and_return(true)
       )
-      allow_any_instance_of(NodeObject).to receive(:ssh_cmd).with(
-        "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh"
-      ).and_return(true)
-
-      expect(subject.class.services).to eq(
-        status: :ok,
-        message: ""
-      )
-    end
-
-    it "prepares and shuts down services on non clustered nodes" do
-      allow_any_instance_of(CrowbarService).to receive(
-        :prepare_nodes_for_os_upgrade
-      ).and_return(true)
-      allow(NodeObject).to(
-        receive(:find).with("state:crowbar_upgrade AND pacemaker_founder:true").
-        and_return([])
-      )
-      allow(NodeObject).to(
-        receive(:find).with("state:crowbar_upgrade AND NOT run_list_map:pacemaker-cluster-member").
-        and_return([NodeObject.find_node_by_name("testing.crowbar.com")])
-      )
-      allow_any_instance_of(NodeObject).to receive(:ssh_cmd).with(
-        "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh"
-      ).and_return(true)
 
       expect(subject.class.services).to eq(
         status: :ok,


### PR DESCRIPTION
When done from recipe, it could be possibly executed later when
upgraded node is doing its first chef-client run.

So let's rather do it explicitely at the point when we are preparing
all nodes for the upgrade.

(This partially reverts https://github.com/crowbar/crowbar-core/pull/702)
