### PR TITLE
provisioner: Ensure /srv/tftpboot/validation.pem is correct

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -316,12 +316,10 @@ else
   end
 end
 
-bash "copy validation pem" do
-  code <<-EOH
-  cp /etc/chef/validation.pem #{tftproot}
-  chmod 0444 #{tftproot}/validation.pem
-EOH
-  not_if "test -f #{tftproot}/validation.pem"
+file "#{tftproot}/validation.pem" do
+  content IO.read("/etc/chef/validation.pem")
+  mode "0644"
+  action :create
 end
 
 # By default, install the same OS that the admin node is running


### PR DESCRIPTION
If for some reason /srv/tftpboot/validation.pem gets overwritten, then
it's impossible to allocate new nodes. We should make sure that
we converge properly here.
