### PR TITLE
Find the correct OS values at admin node before passing them to the nodes

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -380,6 +380,17 @@ class CrowbarService < ServiceObject
       node.admin? || node[:platform] == "windows" || node.state != "crowbar_upgrade"
     end
     check_if_nodes_are_available upgrade_nodes
+
+    # reset the OS values at admin node...
+    admin_node = NodeObject.admin_node
+    admin_node["target_platform"] = ""
+    if admin_node["provisioner"] && admin_node["provisioner"]["default_os"]
+      admin_node["provisioner"].delete "default_os"
+    end
+    admin_node.save
+    # ... and let provisioner fill correct values for current OS
+    commit_and_check_proposal
+
     admin_node = NodeObject.admin_node
 
     upgrade_nodes.each do |node|


### PR DESCRIPTION
This is an attempt to fix https://bugzilla.suse.com/show_bug.cgi?id=1006770 . It looks like resetting the OS values before the upgrade is not working.

However, this solution is most likely wrong as well, e.g. because it requires saving the proposal twice and unnecessary (and possibly harmful?) extra run of chef clients on the nodes.

Ideally, the change should be done on admin server right before some initial run of chef-client there (and only there).

See https://github.com/crowbar/crowbar/pull/2276 for the different approach
