### PR TITLE
Show the response from cluster health check in the upgrade prechecks

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -53,7 +53,7 @@ module Api
           ret[:clusters_healthy] = {
             required: true,
             passed: clusters_healthy?,
-            errors: clusters_health_check_errors
+            errors: clusters_health_report_errors
           } if Api::Crowbar.addons.include?("ha")
         end
       end
@@ -268,9 +268,12 @@ module Api
         ha_presence_status.empty?
       end
 
+      def clusters_health_report
+        @clusters_health_report ||= Api::Pacemaker.health_report
+      end
+
       def clusters_healthy?
-        # FIXME: to be implemented
-        true
+        clusters_health_report.empty?
       end
 
       def compute_resources_status
@@ -331,15 +334,27 @@ module Api
         }
       end
 
-      def clusters_health_check_errors
-        return {} if clusters_healthy?
+      def clusters_health_report_errors
+        ret = {}
+        return ret if clusters_healthy?
 
-        {
-          clusters_health: {
-            data: [], # TODO: implement cluster health check errors
-            help: I18n.t("api.upgrade.prechecks.clusters_health_check.help.default")
-          }
-        }
+        crm_failures = clusters_health_report["crm_failures"]
+        failed_actions = clusters_health_report["failed_actions"]
+        ret[:clusters_health_crm_failures] = {
+          data: crm_failures.values,
+          help: I18n.t(
+            "api.upgrade.prechecks.clusters_health.crm_failures",
+            nodes: crm_failures.join(",")
+          )
+        } if crm_failures
+        ret[:clusters_health_failed_actions] = {
+          data: failed_actions.values,
+          help: I18n.t(
+            "api.upgrade.prechecks.clusters_health.failed_actions",
+            nodes: failed_actions.keys.join(",")
+          )
+        } if failed_actions
+        ret
       end
 
       def compute_resources_check_errors

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -786,7 +786,9 @@ en:
         ceph_health_check:
           help:
             default: 'Make sure Ceph is healthy'
-        clusters_health_check:
+        clusters_health:
+          crm_failures: '"crm status" failed at nodes %nodes.'
+          failed_actions: '"crm status" is showing some failed actions at nodes %nodes.'
           help:
             default: 'Make sure clusters are healthy'
         compute_resources_check:

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -72,6 +72,9 @@ describe Api::Upgrade do
     allow(pacemaker).to receive(
       :ha_presence_check
     ).and_return({})
+    allow(pacemaker).to receive(
+      :health_report
+    ).and_return({})
   end
 
   context "with a successful status" do


### PR DESCRIPTION
I made it more special than the other checks, based on current return values of `Api::Pacemaker.health_report`. But maybe it is wrong and I should rather adapt `Api::Pacemaker.health_report` to return `:errors` just like the other checks ... ideas?

This is the kind of response that current `Api::Pacemaker.health_report` could return:

```
 # Simple check if HA clusters report some problems
 # If there are no problems, empty hash is returned.
 # If this fails, information about failed actions for each cluster founder is
 # returned in a hash that looks like this:
       {
           "crm_failures" => {
                   "node1" => "reason for crm status failure"
           },
           "failed_actions" => {
                   "node2" => "Failed actions at this node",
                   "node3" => "Failed actions at this node"

           }
       }
 # User has to manually clean pacemaker resources before proceeding with the upgrade.
```
