### PR TITLE
Move missing methods onto the upgrade api model

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -228,15 +228,6 @@ module Api
         Api::Node.repocheck(addon: addon)[addon]["available"]
       end
 
-      def repo_version_available?(products, product, version)
-        products.any? do |p|
-          p["version"] == version && p["name"] == product
-        end
-      end
-
-      def admin_architecture
-        NodeObject.admin_node.architecture
-      end
     end
   end
 end

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -172,6 +172,16 @@ module Api
           }
         }
       end
+
+      def repo_version_available?(products, product, version)
+        products.any? do |p|
+          p["version"] == version && p["name"] == product
+        end
+      end
+
+      def admin_architecture
+        NodeObject.admin_node.architecture
+      end
     end
   end
 end


### PR DESCRIPTION
During the movement of the api repochecks/adminrepochecks
from crowbar to the upgrade namespace a couple of needed
methods were left that are necessary for the calls to work


backport of https://github.com/crowbar/crowbar-core/pull/754