### PR TITLE
crowbar_register: Ensure ntp is installed

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -314,6 +314,9 @@ PATTERNS_INSTALL="$PATTERNS_INSTALL base enhanced_base sw_management"
 <% end -%>
 PACKAGES_INSTALL="$PACKAGES_INSTALL netcat ruby2.1-rubygem-chef"
 
+# We also need ntp for this script
+PACKAGES_INSTALL="$PACKAGES_INSTALL ntp"
+
 case $ARCH in
     x86_64) PACKAGES_INSTALL+=" biosdevname";;
 esac


### PR DESCRIPTION
We call ntpdate in the script, so it needs to be installed if we want it
to succeed.