### PR TITLE
nfs-client: Install nfs-client package

### DIFF
--- a/chef/cookbooks/nfs-client/recipes/default.rb
+++ b/chef/cookbooks/nfs-client/recipes/default.rb
@@ -23,6 +23,8 @@ need_remount = []
 
 comment_option = 'comment="managed-by-crowbar-barclamp-nfs-client"'
 
+package "nfs-client"
+
 ### Prepare data about NFS mounts we'll handle
 
 node[:nfs_client][:exports].each do |name, data|


### PR DESCRIPTION
Without this, we don't have mount.nfs, which is going to be an issue :-)

(cherry picked from commit eb16eddf78379b45d780306e154079cffb41111a)

Backport of https://github.com/crowbar/crowbar-core/pull/762