### PR TITLE
Do not remove the OS values from crowbar

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -43,13 +43,6 @@ module Api
         end
 
         if upgrade_script_path.exist?
-          # admin node will have different OS after the upgrade
-          admin_node = NodeObject.admin_node
-          admin_node["target_platform"] = ""
-          if admin_node["provisioner"] && admin_node["provisioner"]["default_os"]
-            admin_node["provisioner"].delete "default_os"
-          end
-          admin_node.save
 
           pid = spawn("sudo #{upgrade_script_path}")
           Process.detach(pid)


### PR DESCRIPTION
The OS values are updated directly by the upgrade script, see https://github.com/crowbar/crowbar/pull/2282

This is a revert of https://github.com/crowbar/crowbar-core/commit/5626f2fc324ddd3f701de2c4a3cd0873f1b9694c

