### PR TITLE
Thread-safe locking

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -68,6 +68,12 @@ module Crowbar
       step[:status] == "running"
     end
 
+    def pending?(step_name = nil)
+      step = progress[:steps][step_name || current_step]
+      return false unless step
+      step[:status] == "pending"
+    end
+
     def finished?
       current_step == upgrade_steps_6_7.last
     end

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -1,11 +1,13 @@
 module Crowbar
   class UpgradeStatus
+    attr_reader :progress_file_path
     attr_accessor :progress
 
     # Return the current state of upgrade process.
     # We're keeping the information in the file so is accessible by
     # external applications and different crowbar versions.
-    def initialize
+    def initialize(json_file = "/var/lib/crowbar/upgrade/progress.json")
+      @progress_file_path = Pathname.new(json_file)
       load
     end
 
@@ -126,10 +128,6 @@ module Crowbar
         :nodes_upgrade,
         :finished
       ]
-    end
-
-    def progress_file_path
-      Pathname.new("/var/lib/crowbar/upgrade/progress.json")
     end
   end
 end

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -31,6 +31,7 @@ module Crowbar
       @progress[:steps] = upgrade_steps_6_7.map do |step|
         [step, { status: "pending" }]
       end.to_h
+      save
     end
 
     def load!

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -39,7 +39,7 @@ module Crowbar
 
     def start_step
       Crowbar::Lock::LocalBlocking.with_lock(shared: false) do
-        if progress[:steps][current_step][:status] == "running"
+        if running?
           Rails.logger.warn("The step has already been started")
           return false
         end
@@ -50,7 +50,7 @@ module Crowbar
 
     def end_step(success = true, errors = {})
       Crowbar::Lock::LocalBlocking.with_lock(shared: false) do
-        unless progress[:steps][current_step][:status] == "running"
+        unless running?
           Rails.logger.warn("The step is not running, could not be finished")
           return false
         end
@@ -60,6 +60,12 @@ module Crowbar
         }
         next_step
       end
+    end
+
+    def running?(step_name = nil)
+      step = progress[:steps][step_name || current_step]
+      return false unless step
+      step[:status] == "running"
     end
 
     def finished?

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -18,14 +18,14 @@ require "spec_helper"
 
 describe Crowbar::UpgradeStatus do
   before do
-    @json = Tempfile.open("upgrade_status_spec.json", &:path)
-    File.unlink @json
+    @state_file = Tempfile.open("upgrade_status_spec.state.yml", &:path)
+    File.unlink @state_file
   end
 
-  subject { Crowbar::UpgradeStatus.new(@json) }
+  subject { Crowbar::UpgradeStatus.new(@state_file) }
 
   after do
-    File.unlink @json if File.exist? @json
+    File.unlink @state_file if File.exist? @state_file
   end
 
   context "with a status file that does not exist" do
@@ -78,7 +78,7 @@ describe Crowbar::UpgradeStatus do
 
     it "determines whether current step is running" do
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.current_step_state[:status]).to eql "pending"
+      expect(subject.current_step_state[:status]).to eql :pending
       expect(subject.running?).to be false
       expect(subject.start_step).to be true
       expect(subject.running?).to be true
@@ -87,7 +87,7 @@ describe Crowbar::UpgradeStatus do
 
     it "moves to next step when requested" do
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.current_step_state[:status]).to eql "pending"
+      expect(subject.current_step_state[:status]).to eql :pending
       expect(subject.start_step).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :upgrade_prepare
@@ -118,9 +118,9 @@ describe Crowbar::UpgradeStatus do
     it "prevents starting a step while it is already running" do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.start_step).to be true
-      expect(subject.current_step_state[:status]).to eql "running"
+      expect(subject.current_step_state[:status]).to eql :running
       expect(subject.start_step).to be false
-      expect(subject.current_step_state[:status]).to eql "running"
+      expect(subject.current_step_state[:status]).to eql :running
       expect(subject.current_step).to eql :upgrade_prechecks
     end
 

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -24,6 +24,10 @@ describe Crowbar::UpgradeStatus do
 
   subject { Crowbar::UpgradeStatus.new(@state_file) }
 
+  def new_status
+    subject.class.new(@state_file)
+  end
+
   after do
     File.unlink @state_file if File.exist? @state_file
   end
@@ -69,6 +73,15 @@ describe Crowbar::UpgradeStatus do
       expect(subject.running?(:upgrade_prechecks)).to be true
     end
 
+    it "determines whether current step is running from another object" do
+      expect(subject.current_step).to eql :upgrade_prechecks
+      other_status = new_status
+      expect(other_status.running?).to be false
+      expect(subject.start_step).to be true
+      other_status.load
+      expect(other_status.running?).to be true
+    end
+
     it "determines whether a given step is running" do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.running?(:upgrade_prepare)).to be false
@@ -110,6 +123,15 @@ describe Crowbar::UpgradeStatus do
       expect(subject.end_step).to be false
     end
 
+    it "does not allow to end step when it was started by another object" do
+      pending("need some way to track step ownership")
+      expect(subject.current_step).to eql :upgrade_prechecks
+      expect(subject.start_step).to be true
+      other_status = new_status
+      expect(other_status.end_step).to be false
+      expect(subject.running?).to be true
+    end
+
     it "does not to stop the first step without starting it" do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.end_step).to be false
@@ -122,6 +144,15 @@ describe Crowbar::UpgradeStatus do
       expect(subject.start_step).to be false
       expect(subject.current_step_state[:status]).to eql :running
       expect(subject.current_step).to eql :upgrade_prechecks
+    end
+
+    it "prevents starting a step from a separate object while it is already running" do
+      expect(subject.current_step).to eql :upgrade_prechecks
+      other_status = new_status
+      expect(subject.start_step).to be true
+      expect(subject.current_step_state[:status]).to eql :running
+      other_status.load
+      expect(other_status.start_step).to be false
     end
 
     it "goes through the steps and returns finish when finished" do

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -31,12 +31,41 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_step).to eql :upgrade_prechecks
     end
 
+    it "determines whether current step is running" do
+      allow(File).to receive(:open).and_return(true)
+      expect(subject.current_step).to eql :upgrade_prechecks
+      expect(subject.current_step_state[:status]).to eql "pending"
+      expect(subject.running?).to be false
+      expect(subject.running?(:upgrade_prechecks)).to be false
+      expect(subject.start_step).to be true
+      expect(subject.running?).to be true
+      expect(subject.running?(:upgrade_prechecks)).to be true
+    end
+
+    it "determines whether a given step is running" do
+      allow(File).to receive(:open).and_return(true)
+      expect(subject.current_step).to eql :upgrade_prechecks
+      expect(subject.current_step_state[:status]).to eql "pending"
+      expect(subject.running?(:upgrade_prepare)).to be false
+      expect(subject.start_step).to be true
+      expect(subject.running?(:upgrade_prepare)).to be false
+    end
+
+    it "determines whether current step is running" do
+      allow(File).to receive(:open).and_return(true)
+      expect(subject.current_step).to eql :upgrade_prechecks
+      expect(subject.current_step_state[:status]).to eql "pending"
+      expect(subject.running?).to be false
+      expect(subject.start_step).to be true
+      expect(subject.running?).to be true
+      expect(subject.running?(:upgrade_prepare)).to be false
+    end
+
     it "moves to next step when requested" do
       allow(File).to receive(:open).and_return(true)
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.current_step_state[:status]).to eql "pending"
       expect(subject.start_step).to be true
-      expect(subject.current_step_state[:status]).to eql "running"
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :upgrade_prepare
     end

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -31,10 +31,29 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_step).to eql :upgrade_prechecks
     end
 
+    it "determines whether current step is pending" do
+      allow(File).to receive(:open).and_return(true)
+      expect(subject.current_step).to eql :upgrade_prechecks
+      expect(subject.pending?).to be true
+      expect(subject.start_step).to be true
+      expect(subject.pending?).to be false
+    end
+
+    it "determines whether given step is pending" do
+      allow(File).to receive(:open).and_return(true)
+      expect(subject.current_step).to eql :upgrade_prechecks
+      expect(subject.pending?).to be true
+      expect(subject.pending?(:upgrade_prechecks)).to be true
+      expect(subject.pending?(:admin_backup)).to be true
+      expect(subject.start_step).to be true
+      expect(subject.pending?).to be false
+      expect(subject.pending?(:upgrade_prechecks)).to be false
+      expect(subject.pending?(:admin_backup)).to be true
+    end
+
     it "determines whether current step is running" do
       allow(File).to receive(:open).and_return(true)
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.current_step_state[:status]).to eql "pending"
       expect(subject.running?).to be false
       expect(subject.running?(:upgrade_prechecks)).to be false
       expect(subject.start_step).to be true
@@ -45,7 +64,6 @@ describe Crowbar::UpgradeStatus do
     it "determines whether a given step is running" do
       allow(File).to receive(:open).and_return(true)
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.current_step_state[:status]).to eql "pending"
       expect(subject.running?(:upgrade_prepare)).to be false
       expect(subject.start_step).to be true
       expect(subject.running?(:upgrade_prepare)).to be false

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -34,6 +34,10 @@ describe Crowbar::UpgradeStatus do
       expect(subject.finished?).to be false
     end
 
+    it "ensures that the defaults are saved" do
+      expect(subject.progress_file_path.exist?).to be true
+    end
+
     it "returns first step as current step" do
       expect(subject.current_step).to eql :upgrade_prechecks
     end

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -17,20 +17,21 @@
 require "spec_helper"
 
 describe Crowbar::UpgradeStatus do
+  before do
+    allow(File).to receive(:exist?).and_return(false)
+  end
+
   context "with a status file that does not exist" do
     it "ensures the default initial values are correct" do
-      allow(File).to receive(:exist?).and_return(false)
       expect(subject.current_substep).to be_nil
       expect(subject.finished?).to be false
     end
 
     it "returns first step as current step" do
-      allow(File).to receive(:exist?).and_return(false)
       expect(subject.current_step).to eql :upgrade_prechecks
     end
 
     it "moves to next step when requested" do
-      allow(File).to receive(:exist?).and_return(false)
       allow(File).to receive(:open).and_return(true)
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.current_step_state[:status]).to eql "pending"
@@ -41,7 +42,6 @@ describe Crowbar::UpgradeStatus do
     end
 
     it "does not move to next step when current one failed" do
-      allow(File).to receive(:exist?).and_return(false)
       allow(File).to receive(:open).and_return(true)
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.start_step).to be true
@@ -77,7 +77,6 @@ describe Crowbar::UpgradeStatus do
     end
 
     it "goes through the steps and returns finish when finished" do
-      allow(File).to receive(:exist?).and_return(false)
       allow(File).to receive(:open).and_return(true)
       expect(subject.start_step).to be true
       expect(subject.end_step).to be true


### PR DESCRIPTION
Make the library thread-safe, so that multiple clients (web UI or `crowbarctl`) can simultaneously read/write upgrade state in a safe manner.

Still TODO:

- [ ] fix pending test
- [ ] change `#start_step` and `#end_step` to take a step name as mandatory parameter, and add (and test) checks within the critical code regions protected by locks which validate that it's permitted to start or end the given step