### PR TITLE
Revert "fix breakage from conversion of upgrade state to symbols"

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -15,7 +15,7 @@ module Crowbar
       }
       if progress_file_path.exist?
         Crowbar::Lock::LocalBlocking.with_lock(shared: true) do
-          @progress = JSON.load(progress_file_path.read)
+          @progress = JSON.load(progress_file_path.read).deep_symbolize_keys
         end
       else
         # in 'steps', we save the information about each step that was executed
@@ -26,11 +26,11 @@ module Crowbar
     end
 
     def current_substep
-      progress[:current_substep]
+      progress[:current_substep].nil? ? nil : progress[:current_substep].to_sym
     end
 
     def current_step
-      progress[:current_step]
+      progress[:current_step].to_sym
     end
 
     def current_step_state


### PR DESCRIPTION
This partially reverts commit 52589eee5b121fa198570967cb2bcfe830feb0e8.

The fix satisfied the tests but it was actually wrong because in the
end_step method we were mixing symbols and strings again