### PR TITLE
adding a status to the rest of the upgrade steps on cloud 6 side

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -43,10 +43,14 @@ module Api
         end
 
         if upgrade_script_path.exist?
+          upgrade_status = ::Crowbar::UpgradeStatus.new
+          upgrade_status.start_step
           pid = spawn("sudo #{upgrade_script_path}")
           Process.detach(pid)
           Rails.logger.info("#{upgrade_script_path} executed with pid: #{pid}")
 
+          # we can't really call upgrade_status.end_step here yet as the upgrade is running
+          # in the background
           {
             status: :ok,
             message: ""

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -94,6 +94,8 @@ module Api
       end
 
       def adminrepocheck
+        upgrade_status = ::Crowbar::UpgradeStatus.new
+        upgrade_status.start_step
         # FIXME: once we start working on 7 to 8 upgrade we have to adapt the sles version
         zypper_stream = Hash.from_xml(
           `sudo /usr/bin/zypper-retry --xmlout products`
@@ -137,6 +139,12 @@ module Api
           ret[:openstack][:repos][admin_architecture.to_sym] = {
             missing: ["SUSE OpenStack Cloud 8"]
           } unless cloud_available
+
+          if ret.any? { |_k, v| !v[:available] }
+            upgrade_status.end_step(false, adminrepocheck: "Missing repositories")
+          else
+            upgrade_status.end_step
+          end
         end
       end
 

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -279,6 +279,7 @@ Rails.application.routes.draw do
       post :cancel
       get :noderepocheck
       get :adminrepocheck
+      post :adminbackup
     end
 
     resources :nodes,

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -27,6 +27,7 @@ describe Api::UpgradeController, type: :request do
     let(:pacemaker) do
       Class.new
     end
+    let(:tarball) { Rails.root.join("spec", "fixtures", "crowbar_backup.tar.gz") }
 
     it "shows the upgrade status object" do
       allow(Api::Upgrade).to receive(:network_checks).and_return([])
@@ -195,6 +196,17 @@ describe Api::UpgradeController, type: :request do
       get "/api/upgrade/adminrepocheck", {}, headers
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq(crowbar_repocheck)
+    end
+
+    it "creates a backup of the admin server" do
+      allow_any_instance_of(Crowbar::Backup::Export).to receive(:export).and_return(true)
+      allow_any_instance_of(Kernel).to receive(:system).and_return(true)
+      allow_any_instance_of(Api::Backup).to receive(:path).and_return(tarball)
+      allow_any_instance_of(Api::Backup).to receive(:delete_archive).and_return(true)
+      allow_any_instance_of(Api::Backup).to receive(:create_archive).and_return(true)
+
+      post "/api/upgrade/adminbackup", { backup: { name: "crowbar_upgrade" } }, headers
+      expect(response).to have_http_status(:ok)
     end
   end
 end


### PR DESCRIPTION
### IMPORTANT TO BACKPORTING

the backups commit needs to be backported to use the old `Backups` model in the old backups_controller