### PR TITLE
Fix breaking change of codeclimate-test-reporter

### DIFF
--- a/crowbar_framework/spec/spec_helper.rb
+++ b/crowbar_framework/spec/spec_helper.rb
@@ -24,7 +24,6 @@ if ENV["CODECLIMATE_REPO_TOKEN"]
   require "codeclimate-test-reporter"
 
   Coveralls.wear!
-  CodeClimate::TestReporter.start
 
   SimpleCov.start do
     add_filter "/spec"


### PR DESCRIPTION
Since codeclimate-test-reporter v1.0 is released our travis runs are
broken for master.

See https://github.com/codeclimate/ruby-test-reporter/blob/master/README.md