### PR TITLE
Delete router namespaces to avoid router dups

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -25,6 +25,13 @@ if [[ -f /usr/bin/neutron-ha-tool ]] ; then
     OS_AUTH_URL="<%= @os_auth_url_v2 %>" neutron-ha-tool --l3-agent-evacuate $(hostname)
 fi
 
+# Even if agents are migrated, we want to explicitly destroy the router namespaces
+# because in some upgrade cases, the routers remain active when there are no
+# valid destinations for the migration
+for router_ns in `ip netns | grep qrouter`; do
+    ip netns delete $router_ns
+done
+
 # Shutdown pacemaker so the remaining OpenStack services are stopped
 # This is needed so that the zypper dup won't trigger any db migrations on package update
 service pacemaker stop


### PR DESCRIPTION
Even if agents are migrated, we want to explicitly destroy the router
namespaces because in some upgrade cases, the routers remain active
when there are no valid destinations for the migration.

Example case, cluster with two nodes. The first one is upgraded, so
routers are moved to the second one. Once first node finishes the
upgrade, routers exist in the first and second nodes at once (because of
chef-client). Killing those routers in the pre-upgrade step of the
second node avoids that situation.