### PR TITLE
[stable/3.0] fix undefined method join for Hash

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -287,7 +287,7 @@ module Api
           data: crm_failures.values,
           help: I18n.t(
             "api.upgrade.prechecks.clusters_health.crm_failures",
-            nodes: crm_failures.join(",")
+            nodes: crm_failures.keys.join(",")
           )
         } if crm_failures
         ret[:clusters_health_failed_actions] = {


### PR DESCRIPTION
we actually want to join the keys here, which are the node names