### PR TITLE
[3.0] Replace deep_clone with deep_dup

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -256,7 +256,7 @@ class NodeObject < ChefObject
       end
     end
     # deep clone of @role.default_attributes, used when saving node
-    @attrs_last_saved = deep_clone(@role.default_attributes)
+    @attrs_last_saved = @role.default_attributes.deep_dup
     @node = node
   end
 
@@ -824,7 +824,7 @@ class NodeObject < ChefObject
     @node.save
 
     # update deep clone of @role.default_attributes
-    @attrs_last_saved = deep_clone(@role.default_attributes)
+    @attrs_last_saved = @role.default_attributes.deep_dup
 
     Rails.logger.debug("Done saving node: #{@node.name} - #{crowbar_revision}")
   end
@@ -1590,27 +1590,6 @@ class NodeObject < ChefObject
   end
 
   private
-
-  # Used for cloning role's default attributes.
-  def deep_clone object, options = {}
-    case object
-    when Numeric,TrueClass,FalseClass,NilClass,Symbol #immutable
-      object
-    when ::String
-      options[:full] ? object.clone : object
-    when ::Hash
-      object.reduce({}) do |acc,kv|
-        acc[deep_clone(kv[0])] = deep_clone(kv[1])
-        acc
-      end
-    when ::Array
-       object.reduce([]) do |acc,v|
-        acc << deep_clone(v)
-      end
-    else
-      object.clone #deep copy
-    end
-  end
 
   # this is used by the alias/description code split
   def chef_description


### PR DESCRIPTION
Active Support has already a native object dup method.

(cherry picked from commit 79670c10536071d6e627e726e7f890c9fffc5a66)