### PR TITLE
Fix chef-client crash on admin server during a crowbar_register

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -407,7 +407,7 @@ curl -L -o /etc/chef/validation.pem \
 TMP_ATTRIBUTES=$(mktemp --suffix .json)
 
 # Make sure that we have the right target platform
-echo "{ \"target_platform\": \"$CROWBAR_OS\" }" > "$TMP_ATTRIBUTES"
+echo "{ \"target_platform\": \"$CROWBAR_OS\", \"crowbar_wall\": { \"registering\": true } }" > "$TMP_ATTRIBUTES"
 
 post_state $HOSTNAME "discovering"
 chef-client -S http://$ADMIN_IP:4000/ -N "$HOSTNAME" --json-attributes "$TMP_ATTRIBUTES"

--- a/chef/cookbooks/utils/libraries/helpers.rb
+++ b/chef/cookbooks/utils/libraries/helpers.rb
@@ -70,6 +70,6 @@ module CrowbarHelper
 
   def self.in_sledgehammer?(node)
     states = ["ready", "readying", "recovering", "applying"]
-    not states.include?(node[:state])
+    !node.fetch(:crowbar_wall, {})[:registering] && !states.include?(node[:state])
   end
 end


### PR DESCRIPTION
When we're in crowbar_register, we're not in sledgehammer. So we have
access to everything, like the ability to install packages.

This enables the ohai cookbook to install the cstruct gem in
crowbar_register. Without this, there's a period of time during the
crowbar_register call where the node has incomplete ohai data, resulting
in the inability to resolve conduits, which then causes crashes on the
admin server:

```
================================================================================
Recipe Compile Error in /var/chef/cache/cookbooks/provisioner/recipes/role_provisioner_server.rb
================================================================================
NoMethodError
-------------
undefined method `[]' for nil:NilClass
Cookbook Trace:
---------------
/var/chef/cache/cookbooks/provisioner/recipes/update_nodes.rb:23:in `block in find_node_boot_mac_addresses'
/var/chef/cache/cookbooks/provisioner/recipes/update_nodes.rb:22:in `each'
/var/chef/cache/cookbooks/provisioner/recipes/update_nodes.rb:22:in `find_node_boot_mac_addresses'
/var/chef/cache/cookbooks/provisioner/recipes/update_nodes.rb:114:in `block in from_file'
/var/chef/cache/cookbooks/provisioner/recipes/update_nodes.rb:46:in `each'
/var/chef/cache/cookbooks/provisioner/recipes/update_nodes.rb:46:in `from_file'
/var/chef/cache/cookbooks/provisioner/recipes/role_provisioner_server.rb:22:in `from_file'
Relevant File Content:
----------------------
/var/chef/cache/cookbooks/provisioner/recipes/update_nodes.rb:
16:  def find_node_boot_mac_addresses(node, admin_data_net)
17:    # If we don't have an admin IP allocated yet using node.macaddress is
18:    # our best guess for the boot macaddress
19:    return [node[:macaddress]] if admin_data_net.nil? || admin_data_net.interface_list.nil?
20:    result = []
21:    admin_interfaces = admin_data_net.interface_list
22:    admin_interfaces.each do |interface|
23>>     node["network"]["interfaces"][interface]["addresses"].each do |addr, addr_data|
24:        next if addr_data["family"] != "lladdr"
25:        result << addr unless result.include? addr
26:      end
27:    end
28:    result
29:  end
30:
31:  states = node["provisioner"]["dhcp"]["state_machine"]
32:  tftproot = node["provisioner"]["root"]
```

This may actually be the cause for
https://bugzilla.suse.com/show_bug.cgi?id=990745