### PR TITLE
ohai: Install tcpdump package

### DIFF
--- a/chef/cookbooks/ohai/recipes/default.rb
+++ b/chef/cookbooks/ohai/recipes/default.rb
@@ -87,6 +87,9 @@ unless node[:platform_family] == "windows"
     if node[:kernel][:machine] =~ /(x86|aarch64)/
       package("dmidecode").run_action(:install)
     end
+
+    # we also need tcpdump for the crowbar plugin
+    package("tcpdump").run_action(:install)
   end
 end
 


### PR DESCRIPTION
It is used by the crowbar package, so ensure it is actually installed.