### PR TITLE
crowbar_register: Add entry to /etc/hosts for resolving our hostname

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -466,4 +466,15 @@ post_state $HOSTNAME "installed"
 # Wait for DHCP to update
 sleep 30
 
+# Make sure we can always resolve our hostname; we use DHCP to find what's our
+# admin IP
+DHCP_VARS=$(mktemp)
+/usr/lib/wicked/bin/wickedd-dhcp4 --test --test-output $DHCP_VARS $BOOTDEV
+if test $? -eq 0; then
+    eval $(grep ^IPADDR= "$DHCP_VARS")
+    ADMIN_IP=${IPADDR%%/*}
+    echo "$ADMIN_IP $HOSTNAME ${HOSTNAME%%.*}" >> /etc/hosts
+fi
+rm -f "$DHCP_VARS"
+
 /usr/sbin/crowbar_join --setup --debug --verbose


### PR DESCRIPTION
This helps make sure that, in case the DNS server is down, we can
still resolve our hostname. We already do that in the autoyast profile,
but we forgot to add this to crowbar_register.

See https://github.com/crowbar/barclamp-provisioner/pull/344