### PR TITLE
puma: Reduce puma worker and use more threads

### DIFF
--- a/chef/cookbooks/crowbar/files/default/crowbar.service
+++ b/chef/cookbooks/crowbar/files/default/crowbar.service
@@ -14,8 +14,8 @@ TimeoutStopSec=10
 WorkingDirectory=/opt/dell/crowbar_framework
 
 Environment="CROWBAR_ENV=production"
-Environment="CROWBAR_THREADS=10"
-Environment="CROWBAR_WORKERS=5"
+Environment="CROWBAR_THREADS=16"
+Environment="CROWBAR_WORKERS=2"
 Environment="CROWBAR_LISTEN=127.0.0.1"
 Environment="CROWBAR_PORT=3000"
 EnvironmentFile=-/etc/sysconfig/crowbar

--- a/chef/cookbooks/crowbar/templates/default/sysconfig.crowbar.erb
+++ b/chef/cookbooks/crowbar/templates/default/sysconfig.crowbar.erb
@@ -11,19 +11,19 @@ CROWBAR_ENV="production"
 ## Path:            Crowbar
 ## Description:     Maximum number of threads
 ## Type:            integer
-## Default:         10
+## Default:         16
 ## ServiceRestart:  crowbar
 # Sets the maximum number of threads used by the web server.
-CROWBAR_THREADS="10"
+CROWBAR_THREADS="16"
 
 ## Path:            Crowbar
 ## Description:     Maximum number of worker processes
 ## Type:            integer
-## Default:         5
+## Default:         2
 ## ServiceRestart:  crowbar
 # Sets the maximum number of separate worker processes spawned by the
 # web server.
-CROWBAR_WORKERS="5"
+CROWBAR_WORKERS="2"
 
 ## Path:            Crowbar
 ## Description:     Listen address

--- a/configs/crowbar.service
+++ b/configs/crowbar.service
@@ -14,8 +14,8 @@ TimeoutStopSec=10
 WorkingDirectory=/opt/dell/crowbar_framework
 
 Environment="CROWBAR_ENV=production"
-Environment="CROWBAR_THREADS=10"
-Environment="CROWBAR_WORKERS=5"
+Environment="CROWBAR_THREADS=16"
+Environment="CROWBAR_WORKERS=2"
 Environment="CROWBAR_LISTEN=127.0.0.1"
 Environment="CROWBAR_PORT=3000"
 EnvironmentFile=-/etc/sysconfig/crowbar

--- a/crowbar_framework/config/puma.rb
+++ b/crowbar_framework/config/puma.rb
@@ -1,8 +1,8 @@
 ROOT = File.expand_path("../../", __FILE__)
 ENVIRONMENT = ENV["CROWBAR_ENV"] || "production"
 
-THREADS = ENV["CROWBAR_THREADS"] || 10
-WORKERS = ENV["CROWBAR_WORKERS"] || 5
+THREADS = ENV["CROWBAR_THREADS"] || 16
+WORKERS = ENV["CROWBAR_WORKERS"] || 2
 
 LISTEN = ENV["CROWBAR_LISTEN"] || "127.0.0.1"
 PORT = ENV["CROWBAR_PORT"] || 3000
@@ -34,7 +34,7 @@ bind "tcp://#{LISTEN}:#{PORT}"
 on_worker_boot do
   ::ActiveSupport.on_load(:active_record) do
     config = Rails.application.config.database_configuration[Rails.env]
-    config["pool"] = ENV["CROWBAR_THREADS"] || 10
+    config["pool"] = ENV["CROWBAR_THREADS"] || 16
 
     ::ActiveRecord::Base.establish_connection(config)
   end


### PR DESCRIPTION
Each puma worker will starts it's own ruby stack which consumes a lot of
memory. Instead of doing this we should use more threads.