### PR TITLE
upgrade: Use the symbols for the state of upgrade steps

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -70,7 +70,7 @@ module Crowbar
           return false
         end
         progress[:steps][current_step] = {
-          status: success ? "passed" : "failed",
+          status: success ? :passed : :failed,
           errors: errors
         }
         next_step
@@ -110,7 +110,7 @@ module Crowbar
     # advance the current step if the latest one finished successfully
     def next_step
       return true if finished?
-      return false if current_step_state[:status] != "passed"
+      return false if current_step_state[:status] != :passed
       i = upgrade_steps_6_7.index current_step
       progress[:current_step] = upgrade_steps_6_7[i + 1]
     end

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -111,7 +111,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.start_step).to be true
       expect(subject.end_step(false, failure: "error message")).to be false
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.current_step_state[:status]).to eql "failed"
+      expect(subject.current_step_state[:status]).to eql :failed
       expect(subject.current_step_state[:errors]).to_not be_empty
     end
 


### PR DESCRIPTION
We're already using symbols for step names and even for :pending state.

(cherry picked from commit cf0e3abf2c9e7d30399f80039c8876dc90d5b45f)

Backport of https://github.com/crowbar/crowbar-core/pull/806