### PR TITLE
upgrade: Allow repeating some steps

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -44,7 +44,7 @@ module Api
 
         if upgrade_script_path.exist?
           upgrade_status = ::Crowbar::UpgradeStatus.new
-          upgrade_status.start_step
+          upgrade_status.start_step(:admin_upgrade)
           pid = spawn("sudo #{upgrade_script_path}")
           Process.detach(pid)
           Rails.logger.info("#{upgrade_script_path} executed with pid: #{pid}")

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -75,13 +75,19 @@ module Crowbar
       progress[:steps][current_step] || {}
     end
 
-    def start_step
+    # 'step' is name of the step user wants to start.
+    def start_step(step_name)
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
-        if running?
+        if running? step_name
           @logger.warn("The step has already been started")
           return false
         end
-        progress[:steps][current_step][:status] = :running
+        unless step_allowed? step_name
+          @logger.error("The start of step #{step_name} is requested in the wrong order")
+          return false
+        end
+        progress[:current_step] = step_name
+        progress[:steps][step_name][:status] = :running
         save
       end
     end
@@ -153,6 +159,24 @@ module Crowbar
         :nodes_upgrade,
         :finished
       ]
+    end
+
+    # Return true if user is allowed to execute given step
+    # In normal cases, that should be true only for next step in the sequence.
+    # But for some cases, we allow repeating of the step that has just passed.
+    def step_allowed?(step)
+      return true if step == current_step
+      if [
+        :upgrade_prechecks,
+        :admin_repo_checks,
+        :nodes_repo_checks
+      ].include? step
+        # Allow repeating one of these steps if it was the last one finished
+        # and no other one has been started yet.
+        i = upgrade_steps_6_7.index step
+        return upgrade_steps_6_7[i + 1] == current_step && pending?(current_step)
+      end
+      false
     end
 
     def lock_path

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -49,7 +49,7 @@ describe Crowbar::UpgradeStatus do
     it "determines whether current step is pending" do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.pending?).to be true
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.pending?).to be false
     end
 
@@ -58,7 +58,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.pending?).to be true
       expect(subject.pending?(:upgrade_prechecks)).to be true
       expect(subject.pending?(:admin_backup)).to be true
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.pending?).to be false
       expect(subject.pending?(:upgrade_prechecks)).to be false
       expect(subject.pending?(:admin_backup)).to be true
@@ -68,7 +68,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.running?).to be false
       expect(subject.running?(:upgrade_prechecks)).to be false
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.running?).to be true
       expect(subject.running?(:upgrade_prechecks)).to be true
     end
@@ -77,7 +77,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_step).to eql :upgrade_prechecks
       other_status = new_status
       expect(other_status.running?).to be false
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       other_status.load
       expect(other_status.running?).to be true
     end
@@ -85,7 +85,7 @@ describe Crowbar::UpgradeStatus do
     it "determines whether a given step is running" do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.running?(:upgrade_prepare)).to be false
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.running?(:upgrade_prepare)).to be false
     end
 
@@ -93,7 +93,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.current_step_state[:status]).to eql :pending
       expect(subject.running?).to be false
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.running?).to be true
       expect(subject.running?(:upgrade_prepare)).to be false
     end
@@ -101,14 +101,14 @@ describe Crowbar::UpgradeStatus do
     it "moves to next step when requested" do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.current_step_state[:status]).to eql :pending
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :upgrade_prepare
     end
 
     it "does not move to next step when current one failed" do
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step(false, failure: "error message")).to be false
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.current_step_state[:status]).to eql :failed
@@ -117,7 +117,7 @@ describe Crowbar::UpgradeStatus do
 
     it "does not allow to end step when it is not running" do
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :upgrade_prepare
       expect(subject.end_step).to be false
@@ -126,7 +126,7 @@ describe Crowbar::UpgradeStatus do
     it "does not allow to end step when it was started by another object" do
       pending("need some way to track step ownership")
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       other_status = new_status
       expect(other_status.end_step).to be false
       expect(subject.running?).to be true
@@ -139,9 +139,9 @@ describe Crowbar::UpgradeStatus do
 
     it "prevents starting a step while it is already running" do
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.current_step_state[:status]).to eql :running
-      expect(subject.start_step).to be false
+      expect(subject.start_step(:upgrade_prechecks)).to be false
       expect(subject.current_step_state[:status]).to eql :running
       expect(subject.current_step).to eql :upgrade_prechecks
     end
@@ -149,45 +149,75 @@ describe Crowbar::UpgradeStatus do
     it "prevents starting a step from a separate object while it is already running" do
       expect(subject.current_step).to eql :upgrade_prechecks
       other_status = new_status
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.current_step_state[:status]).to eql :running
       other_status.load
-      expect(other_status.start_step).to be false
+      expect(other_status.start_step(:upgrade_prechecks)).to be false
     end
 
     it "goes through the steps and returns finish when finished" do
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :upgrade_prepare
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prepare)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :admin_backup
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:admin_backup)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :admin_repo_checks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:admin_repo_checks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :admin_upgrade
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:admin_upgrade)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :database
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:database)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :nodes_repo_checks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:nodes_repo_checks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :nodes_services
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:nodes_services)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :nodes_db_dump
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:nodes_db_dump)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :nodes_upgrade
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:nodes_upgrade)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :finished
       expect(subject.finished?).to be true
       expect(subject.end_step).to be false
+    end
+
+    it "allows repeating some steps" do
+      expect(subject.start_step(:upgrade_prechecks)).to be true
+      expect(subject.end_step).to be true
+      expect(subject.running?(:upgrade_prechecks)).to be false
+      expect(subject.current_step).to eql :upgrade_prepare
+      expect(subject.start_step(:upgrade_prechecks)).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be false
+      expect(subject.running?(:upgrade_prechecks)).to be true
+      expect(subject.end_step).to be true
+    end
+
+    it "prevents repeating steps that do not allow repetition" do
+      expect(subject.start_step(:upgrade_prepare)).to be false
+      expect(subject.start_step(:admin_backup)).to be false
+      expect(subject.start_step(:admin_upgrade)).to be false
+      expect(subject.start_step(:database)).to be false
+      expect(subject.start_step(:nodes_services)).to be false
+      expect(subject.start_step(:nodes_db_dump)).to be false
+      expect(subject.start_step(:nodes_upgrade)).to be false
+    end
+
+    it "prevents repeating steps when it's too late or too early" do
+      expect(subject.start_step(:upgrade_prechecks)).to be true
+      expect(subject.end_step).to be true
+      expect(subject.start_step(:upgrade_prepare)).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be false
+      expect(subject.current_step).to eql :upgrade_prepare
+      expect(subject.start_step(:admin_repo_checks)).to be false
     end
   end
 end


### PR DESCRIPTION
User might want to repeat some of the steps even when they already
succeeded.

Besides the Cloud6 backport, API change in crowbar-init is also required.