### PR TITLE
upgrade: switch neutron-ha-tool to use v3 API

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -92,18 +92,6 @@ end
 # Following script executes all actions that are needed directly on the node
 # directly before the OS upgrade is initiated.
 
-# Find out v2 auth URL that is needed for neutron-ha-tool
-os_auth_url_v2 = ""
-if use_ha && node["run_list_map"].key?("neutron-network")
-  keystone_settings = KeystoneHelper.keystone_settings(node, @cookbook_name)
-  os_auth_url_v2 = KeystoneHelper.versioned_service_URL(
-    keystone_settings["protocol"],
-    keystone_settings["internal_url_host"],
-    keystone_settings["service_port"],
-    "2.0"
-  )
-end
-
 template "/usr/sbin/crowbar-pre-upgrade.sh" do
   source "crowbar-pre-upgrade.sh.erb"
   mode "0755"
@@ -111,8 +99,7 @@ template "/usr/sbin/crowbar-pre-upgrade.sh" do
   group "root"
   action :create
   variables(
-    use_ha: use_ha,
-    os_auth_url_v2: os_auth_url_v2
+    use_ha: use_ha
   )
 end
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -26,7 +26,7 @@ if [[ -f /usr/bin/neutron-ha-tool ]] ; then
     set +x
     source /root/.openrc
     set -x
-    OS_AUTH_URL="<%= @os_auth_url_v2 %>" neutron-ha-tool --l3-agent-evacuate $(hostname)
+    neutron-ha-tool --l3-agent-evacuate $(hostname)
 fi
 
 # Shutdown pacemaker so the remaining OpenStack services are stopped


### PR DESCRIPTION
We do not need to workaround it by using v2 API any more.