### PR TITLE
upgrade: Unset db-sync flag before upgrading the nodes, skip keystone bootstrap

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -385,6 +385,10 @@ class CrowbarService < ServiceObject
     upgrade_nodes.each do |node|
       node["target_platform"] = admin_node["provisioner"]["default_os"]
       node["crowbar_wall"]["crowbar_upgrade_step"] = "prepare-os-upgrade"
+      # skip initial keystone bootstrapping
+      if node["run_list_map"].key? "keystone-server"
+        node["keystone"]["bootstrap"] = true
+      end
       node.save
     end
 

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -392,6 +392,9 @@ class CrowbarService < ServiceObject
       node.save
     end
 
+    # unset `db_synced` flag for OpenStack components
+    ::Openstack::Upgrade.unset_db_synced
+
     commit_and_check_proposal
   end
 


### PR DESCRIPTION
I think it makes sense to do both action from the point where we're accessing all nodes (to be upgraded), and before we actually do the upgrades.
