### PR TITLE
[3.0] upgrade: Allow repeated execution of selected steps

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -44,7 +44,7 @@ module Api
 
         if upgrade_script_path.exist?
           upgrade_status = ::Crowbar::UpgradeStatus.new
-          upgrade_status.start_step
+          upgrade_status.start_step(:admin_upgrade)
           pid = spawn("sudo #{upgrade_script_path}")
           Process.detach(pid)
           Rails.logger.info("#{upgrade_script_path} executed with pid: #{pid}")

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -26,7 +26,7 @@ module Api
       def checks
         upgrade_status = ::Crowbar::UpgradeStatus.new
         # the check for current_step means to allow running the step at any point in time
-        upgrade_status.start_step if upgrade_status.current_step == :upgrade_prechecks
+        upgrade_status.start_step(:upgrade_prechecks)
 
         {}.tap do |ret|
           network = ::Crowbar::Sanity.check
@@ -101,7 +101,7 @@ module Api
 
       def adminrepocheck
         upgrade_status = ::Crowbar::UpgradeStatus.new
-        upgrade_status.start_step if upgrade_status.current_step == :admin_repo_checks
+        upgrade_status.start_step(:admin_repo_checks)
         # FIXME: once we start working on 7 to 8 upgrade we have to adapt the sles version
         zypper_stream = Hash.from_xml(
           `sudo /usr/bin/zypper-retry --xmlout products`
@@ -154,9 +154,8 @@ module Api
             upgrade_status.end_step(
               false,
               adminrepocheck: "Missing repositories: #{missing_repos}"
-            ) if upgrade_status.current_step == :admin_repo_checks
+            )
           else
-            next unless upgrade_status.current_step == :admin_repo_checks
             upgrade_status.end_step
           end
         end
@@ -195,7 +194,7 @@ module Api
       end
 
       def prepare(options = {})
-        ::Crowbar::UpgradeStatus.new.start_step
+        ::Crowbar::UpgradeStatus.new.start_step(:upgrade_prepare)
 
         background = options.fetch(:background, false)
 
@@ -311,7 +310,10 @@ module Api
         true
       rescue => e
         message = e.message
-        ::Crowbar::UpgradeStatus.new.end_step(false, { prepare_nodes_for_crowbar_upgrade: message })
+        ::Crowbar::UpgradeStatus.new.end_step(
+          false,
+          prepare_nodes_for_crowbar_upgrade: message
+        )
         Rails.logger.error message
 
         false

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -49,7 +49,7 @@ describe Crowbar::UpgradeStatus do
     it "determines whether current step is pending" do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.pending?).to be true
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.pending?).to be false
     end
 
@@ -58,7 +58,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.pending?).to be true
       expect(subject.pending?(:upgrade_prechecks)).to be true
       expect(subject.pending?(:admin_backup)).to be true
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.pending?).to be false
       expect(subject.pending?(:upgrade_prechecks)).to be false
       expect(subject.pending?(:admin_backup)).to be true
@@ -68,7 +68,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.running?).to be false
       expect(subject.running?(:upgrade_prechecks)).to be false
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.running?).to be true
       expect(subject.running?(:upgrade_prechecks)).to be true
     end
@@ -77,7 +77,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_step).to eql :upgrade_prechecks
       other_status = new_status
       expect(other_status.running?).to be false
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       other_status.load
       expect(other_status.running?).to be true
     end
@@ -85,7 +85,7 @@ describe Crowbar::UpgradeStatus do
     it "determines whether a given step is running" do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.running?(:upgrade_prepare)).to be false
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.running?(:upgrade_prepare)).to be false
     end
 
@@ -93,7 +93,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.current_step_state[:status]).to eql :pending
       expect(subject.running?).to be false
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.running?).to be true
       expect(subject.running?(:upgrade_prepare)).to be false
     end
@@ -101,14 +101,14 @@ describe Crowbar::UpgradeStatus do
     it "moves to next step when requested" do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.current_step_state[:status]).to eql :pending
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :upgrade_prepare
     end
 
     it "does not move to next step when current one failed" do
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step(false, failure: "error message")).to be false
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.current_step_state[:status]).to eql :failed
@@ -117,7 +117,7 @@ describe Crowbar::UpgradeStatus do
 
     it "does not allow to end step when it is not running" do
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :upgrade_prepare
       expect(subject.end_step).to be false
@@ -126,7 +126,7 @@ describe Crowbar::UpgradeStatus do
     it "does not allow to end step when it was started by another object" do
       pending("need some way to track step ownership")
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       other_status = new_status
       expect(other_status.end_step).to be false
       expect(subject.running?).to be true
@@ -139,9 +139,9 @@ describe Crowbar::UpgradeStatus do
 
     it "prevents starting a step while it is already running" do
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.current_step_state[:status]).to eql :running
-      expect(subject.start_step).to be false
+      expect(subject.start_step(:upgrade_prechecks)).to be false
       expect(subject.current_step_state[:status]).to eql :running
       expect(subject.current_step).to eql :upgrade_prechecks
     end
@@ -149,45 +149,75 @@ describe Crowbar::UpgradeStatus do
     it "prevents starting a step from a separate object while it is already running" do
       expect(subject.current_step).to eql :upgrade_prechecks
       other_status = new_status
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.current_step_state[:status]).to eql :running
       other_status.load
-      expect(other_status.start_step).to be false
+      expect(other_status.start_step(:upgrade_prechecks)).to be false
     end
 
     it "goes through the steps and returns finish when finished" do
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :upgrade_prepare
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:upgrade_prepare)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :admin_backup
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:admin_backup)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :admin_repo_checks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:admin_repo_checks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :admin_upgrade
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:admin_upgrade)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :database
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:database)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :nodes_repo_checks
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:nodes_repo_checks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :nodes_services
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:nodes_services)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :nodes_db_dump
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:nodes_db_dump)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :nodes_upgrade
-      expect(subject.start_step).to be true
+      expect(subject.start_step(:nodes_upgrade)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :finished
       expect(subject.finished?).to be true
       expect(subject.end_step).to be false
+    end
+
+    it "allows repeating some steps" do
+      expect(subject.start_step(:upgrade_prechecks)).to be true
+      expect(subject.end_step).to be true
+      expect(subject.running?(:upgrade_prechecks)).to be false
+      expect(subject.current_step).to eql :upgrade_prepare
+      expect(subject.start_step(:upgrade_prechecks)).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be false
+      expect(subject.running?(:upgrade_prechecks)).to be true
+      expect(subject.end_step).to be true
+    end
+
+    it "prevents repeating steps that do not allow repetition" do
+      expect(subject.start_step(:upgrade_prepare)).to be false
+      expect(subject.start_step(:admin_backup)).to be false
+      expect(subject.start_step(:admin_upgrade)).to be false
+      expect(subject.start_step(:database)).to be false
+      expect(subject.start_step(:nodes_services)).to be false
+      expect(subject.start_step(:nodes_db_dump)).to be false
+      expect(subject.start_step(:nodes_upgrade)).to be false
+    end
+
+    it "prevents repeating steps when it's too late or too early" do
+      expect(subject.start_step(:upgrade_prechecks)).to be true
+      expect(subject.end_step).to be true
+      expect(subject.start_step(:upgrade_prepare)).to be true
+      expect(subject.start_step(:upgrade_prechecks)).to be false
+      expect(subject.current_step).to eql :upgrade_prepare
+      expect(subject.start_step(:admin_repo_checks)).to be false
     end
   end
 end


### PR DESCRIPTION
User might want to repeat some of the steps even when they already
succeeded.

(cherry picked from commit f88889317a7937150f4d8cce2aceb60a7c946319)

Backport of https://github.com/crowbar/crowbar-core/pull/816