### PR TITLE
upgrade: Execute crowbar_join from extra script

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -135,3 +135,11 @@ template "/usr/sbin/crowbar-post-upgrade.sh" do
     has_drbd: has_drbd
   )
 end
+
+template "/usr/sbin/crowbar-chef-upgraded.sh" do
+  source "crowbar-chef-upgraded.sh.erb"
+  mode "0775"
+  owner "root"
+  group "root"
+  action :create
+end

--- a/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
@@ -1,0 +1,24 @@
+#!/bin/bash
+#
+# This script executes crowbar_join and initial chef-client run on upgraded node
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+echo "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+
+if [[ -f $UPGRADEDIR/crowbar-chef-upgraded-ok ]] ; then
+    echo "crowbar_join and chef-client actions were already successfully executed"
+    exit 0
+fi
+
+# Move node to ready state and execute chef-client for the first time
+crowbar_join --start
+
+touch $UPGRADEDIR/crowbar-chef-upgraded-ok

--- a/chef/cookbooks/crowbar/templates/default/crowbar-post-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-post-upgrade.sh.erb
@@ -72,7 +72,4 @@ echo "No HA setup found..."
 
 <% end %>
 
-# Move node to ready state and execute chef-client for the first time
-crowbar_join --start
-
 touch $UPGRADEDIR/crowbar-post-upgrade-ok

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -57,6 +57,14 @@ module Api
       false
     end
 
+    def join_and_chef
+      if execute_and_wait_for_finish("/usr/sbin/crowbar-chef-upgraded.sh", 600)
+        save_node_state("Initial chef-client run was successful.")
+        return true
+      end
+      false
+    end
+
     def wait_for_ssh_state(desired_state, action)
       Timeout.timeout(300) do
         loop do

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -283,6 +283,7 @@ module Api
 
         # 4. start crowbar-join at the first node
         return false unless founder_api.post_upgrade
+        return false unless founder_api.join_and_chef
 
         # 5. upgrade the rest of nodes in the same cluster
         NodeObject.find(
@@ -297,6 +298,7 @@ module Api
 
           # start crowbar-join
           return false unless node_api.post_upgrade
+          return false unless node_api.join_and_chef
 
           # remove pre-upgrade attribute:
           # - after chef-client run because pacemaker is already running
@@ -368,8 +370,11 @@ module Api
         return false unless delete_pacemaker_resources drbd_master
 
         # Execute post-upgrade actions after the node has been upgraded, rebooted
-        # and the existing cluster has been cleaned up by deleting most of resources
+        # and the existing cluster has been cleaned up by deleting most of resources:
+        # - start pacemaker and sync DRBD devices
         return false unless node_api.post_upgrade
+        # - initiate the first chef-client run
+        return false unless node_api.join_and_chef
 
         # FIXME: Delete router namespaces on non-upgraded node
 

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -294,6 +294,7 @@ describe Api::Upgrade do
         and_return(true)
       allow(Api::Upgrade).to receive(:delete_pacemaker_resources).and_return(true)
       allow_any_instance_of(Api::Node).to receive(:post_upgrade).and_return(true)
+      allow_any_instance_of(Api::Node).to receive(:join_and_chef).and_return(true)
 
       expect(subject.class.nodes).to be true
     end


### PR DESCRIPTION
The DRBD-sync actions in post-upgrade script could take lot of time,
let's decouple them from crowbar_join (and chef-client) runs.