### PR TITLE
[3.0] upgrade: restrict api access through the status library

### DIFF
--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -42,6 +42,16 @@ class Api::CrowbarController < ApiController
     else
       render json: Api::Crowbar.upgrade
     end
+  rescue Crowbar::Error::StartStepRunningError,
+         Crowbar::Error::StartStepOrderError => e
+    render json: {
+      errors: {
+        admin_upgrade: {
+          data: e.message,
+          help: I18n.t("api.crowbar.upgrade.help.default")
+        }
+      }
+    }, status: :unprocessable_entity
   end
 
   def maintenance

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -36,6 +36,16 @@ class Api::UpgradeController < ApiController
         }
       }, status: :unprocessable_entity
     end
+  rescue Crowbar::Error::StartStepRunningError,
+         Crowbar::Error::StartStepOrderError => e
+    render json: {
+      errors: {
+        upgrade_prepare: {
+          data: e.message,
+          help: I18n.t("api.upgrade.prepare.help.default")
+        }
+      }
+    }, status: :unprocessable_entity
   end
 
   def prechecks
@@ -72,6 +82,17 @@ class Api::UpgradeController < ApiController
     else
       render json: check
     end
+  rescue Crowbar::Error::StartStepRunningError,
+         Crowbar::Error::StartStepOrderError,
+         Crowbar::Error::EndStepRunningError => e
+    render json: {
+      errors: {
+        admin_repo_checks: {
+          data: e.message,
+          help: I18n.t("api.upgrade.adminrepocheck.help.default")
+        }
+      }
+    }, status: :unprocessable_entity
   end
 
   def adminbackup
@@ -89,6 +110,17 @@ class Api::UpgradeController < ApiController
       )
       render json: { error: @backup.errors.full_messages.first }, status: :unprocessable_entity
     end
+  rescue Crowbar::Error::StartStepRunningError,
+         Crowbar::Error::StartStepOrderError,
+         Crowbar::Error::EndStepRunningError => e
+    render json: {
+      errors: {
+        adminbackup: {
+          data: e.message,
+          help: I18n.t("api.upgrade.adminbackup.help.default")
+        }
+      }
+    }, status: :unprocessable_entity
   ensure
     @backup.cleanup unless @backup.nil?
   end

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -801,6 +801,12 @@ en:
       prepare:
         help:
           default: 'Refer to the error message in the response'
+      adminbackup:
+        help:
+          default: 'Refer to the error message in the response'
+      adminrepocheck:
+        help:
+          default: 'Refer to the error message in the response'
       cancel:
         help:
           default: 'Refer to the error message in the response'

--- a/crowbar_framework/lib/crowbar/error/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/error/upgrade_status.rb
@@ -1,0 +1,37 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module Error
+    class StartStepRunningError < StandardError
+      def initialize(step_name="")
+        super("The step #{step_name} has already been started")
+      end
+    end
+
+    class StartStepOrderError < StandardError
+      def initialize(step_name="")
+        super("Start of step #{step_name} requested in the wrong order")
+      end
+    end
+
+    class EndStepRunningError < StandardError
+      def initialize(step_name="")
+        super("Step #{step_name} cannot be finished, as it is not running")
+      end
+    end
+  end
+end

--- a/crowbar_framework/lib/crowbar/error/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/error/upgrade_status.rb
@@ -16,6 +16,12 @@
 
 module Crowbar
   module Error
+    class StartStepExistenceError < StandardError
+      def initialize(step_name="")
+        super("The step #{step_name} doesn't exist")
+      end
+    end
+
     class StartStepRunningError < StandardError
       def initialize(step_name="")
         super("The step #{step_name} has already been started")

--- a/crowbar_framework/lib/crowbar/lock.rb
+++ b/crowbar_framework/lib/crowbar/lock.rb
@@ -21,9 +21,9 @@ module Crowbar
     attr_reader :path, :name, :file
 
     def initialize(options = {})
-      @logger = options.fetch :logger, Rails.logger
+      @logger = options[:logger] || Rails.logger
       @name = options.fetch :name, "default.lock"
-      @path = options.fetch :path, Rails.root.join("tmp", @name) # full path to lockfile
+      @path = options[:path] || Rails.root.join("tmp", @name) # full path to lockfile
       @locked = false
       @file = nil
     end

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -1,3 +1,19 @@
+#
+# Copyright 2016, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 require "yaml"
 require "pathname"
 

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -17,6 +17,9 @@
 require "yaml"
 require "pathname"
 
+require_relative "lock"
+require_relative "lock/local_blocking"
+
 module Crowbar
   class UpgradeStatus
     attr_reader :progress_file_path

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -1,3 +1,6 @@
+require "yaml"
+require "pathname"
+
 module Crowbar
   class UpgradeStatus
     attr_reader :progress_file_path
@@ -35,7 +38,7 @@ module Crowbar
     end
 
     def load!
-      Crowbar::Lock::LocalBlocking.with_lock(shared: true) do
+      ::Crowbar::Lock::LocalBlocking.with_lock(shared: true) do
         @progress = YAML.load(progress_file_path.read)
       end
     end
@@ -70,7 +73,7 @@ module Crowbar
     end
 
     def end_step(success = true, errors = {})
-      Crowbar::Lock::LocalBlocking.with_lock(shared: false) do
+      ::Crowbar::Lock::LocalBlocking.with_lock(shared: false) do
         unless running?
           Rails.logger.warn("The step is not running, could not be finished")
           return false

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -19,6 +19,7 @@ require "pathname"
 
 require_relative "lock"
 require_relative "lock/local_blocking"
+require_relative "error/upgrade_status"
 
 module Crowbar
   class UpgradeStatus
@@ -80,11 +81,11 @@ module Crowbar
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
         if running? step_name
           @logger.warn("The step has already been started")
-          return false
+          raise Crowbar::Error::StartStepRunningError.new(step_name)
         end
         unless step_allowed? step_name
           @logger.warn("The start of step #{step_name} is requested in the wrong order")
-          return false
+          raise Crowbar::Error::StartStepOrderError.new(step_name)
         end
         progress[:current_step] = step_name
         progress[:steps][step_name][:status] = :running
@@ -96,7 +97,7 @@ module Crowbar
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
         unless running?
           @logger.warn("The step is not running, could not be finished")
-          return false
+          raise Crowbar::Error::EndStepRunningError.new(current_step)
         end
         progress[:steps][current_step] = {
           status: success ? :passed : :failed,

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -79,6 +79,10 @@ module Crowbar
     # 'step' is name of the step user wants to start.
     def start_step(step_name)
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
+        unless upgrade_steps_6_7.include?(step_name)
+          @logger.warn("The step #{step_name} doesn't exist")
+          raise Crowbar::Error::StartStepExistenceError.new(step_name)
+        end
         if running? step_name
           @logger.warn("The step has already been started")
           raise Crowbar::Error::StartStepRunningError.new(step_name)

--- a/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
@@ -67,6 +67,9 @@ describe Api::CrowbarController, type: :request do
         and_return(true)
       )
       allow(NodeObject).to receive(:admin_node).and_return(admin_node)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:admin_upgrade).and_return(true)
 
       post "/api/crowbar/upgrade", {}, headers
       expect(response).to have_http_status(:ok)

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -50,6 +50,9 @@ describe Api::UpgradeController, type: :request do
     end
 
     it "prepares the crowbar upgrade" do
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:upgrade_prepare).and_return(true)
       post "/api/upgrade/prepare", {}, headers
       expect(response).to have_http_status(:ok)
     end
@@ -126,6 +129,12 @@ describe Api::UpgradeController, type: :request do
       allow_any_instance_of(Backup).to receive(:path).and_return(tarball)
       allow_any_instance_of(Backup).to receive(:delete_archive).and_return(true)
       allow_any_instance_of(Backup).to receive(:create_archive).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:admin_backup).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :end_step
+      ).and_return(true)
 
       post "/api/upgrade/adminbackup", { backup: { name: "crowbar_upgrade" } }, headers
       expect(response).to have_http_status(:ok)

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -120,7 +120,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :upgrade_prepare
-      expect(subject.end_step).to be false
+      expect{subject.end_step}.to raise_error(Crowbar::Error::EndStepRunningError)
     end
 
     it "does not allow to end step when it was started by another object" do
@@ -134,14 +134,14 @@ describe Crowbar::UpgradeStatus do
 
     it "does not to stop the first step without starting it" do
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect(subject.end_step).to be false
+      expect{subject.end_step}.to raise_error(Crowbar::Error::EndStepRunningError)
     end
 
     it "prevents starting a step while it is already running" do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.current_step_state[:status]).to eql :running
-      expect(subject.start_step(:upgrade_prechecks)).to be false
+      expect{subject.start_step(:upgrade_prechecks)}.to raise_error(Crowbar::Error::StartStepRunningError)
       expect(subject.current_step_state[:status]).to eql :running
       expect(subject.current_step).to eql :upgrade_prechecks
     end
@@ -152,7 +152,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.current_step_state[:status]).to eql :running
       other_status.load
-      expect(other_status.start_step(:upgrade_prechecks)).to be false
+      expect{other_status.start_step(:upgrade_prechecks)}.to raise_error(Crowbar::Error::StartStepRunningError)
     end
 
     it "goes through the steps and returns finish when finished" do
@@ -187,7 +187,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :finished
       expect(subject.finished?).to be true
-      expect(subject.end_step).to be false
+      expect{subject.end_step}.to raise_error(Crowbar::Error::EndStepRunningError)
     end
 
     it "allows repeating some steps" do
@@ -196,28 +196,28 @@ describe Crowbar::UpgradeStatus do
       expect(subject.running?(:upgrade_prechecks)).to be false
       expect(subject.current_step).to eql :upgrade_prepare
       expect(subject.start_step(:upgrade_prechecks)).to be true
-      expect(subject.start_step(:upgrade_prechecks)).to be false
+      expect{subject.start_step(:upgrade_prechecks)}.to raise_error(Crowbar::Error::StartStepRunningError)
       expect(subject.running?(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
     end
 
     it "prevents repeating steps that do not allow repetition" do
-      expect(subject.start_step(:upgrade_prepare)).to be false
-      expect(subject.start_step(:admin_backup)).to be false
-      expect(subject.start_step(:admin_upgrade)).to be false
-      expect(subject.start_step(:database)).to be false
-      expect(subject.start_step(:nodes_services)).to be false
-      expect(subject.start_step(:nodes_db_dump)).to be false
-      expect(subject.start_step(:nodes_upgrade)).to be false
+      expect{subject.start_step(:upgrade_prepare)}.to raise_error(Crowbar::Error::StartStepOrderError)
+      expect{subject.start_step(:admin_backup)}.to raise_error(Crowbar::Error::StartStepOrderError)
+      expect{subject.start_step(:admin_upgrade)}.to raise_error(Crowbar::Error::StartStepOrderError)
+      expect{subject.start_step(:database)}.to raise_error(Crowbar::Error::StartStepOrderError)
+      expect{subject.start_step(:nodes_services)}.to raise_error(Crowbar::Error::StartStepOrderError)
+      expect{subject.start_step(:nodes_db_dump)}.to raise_error(Crowbar::Error::StartStepOrderError)
+      expect{subject.start_step(:nodes_upgrade)}.to raise_error(Crowbar::Error::StartStepOrderError)
     end
 
     it "prevents repeating steps when it's too late or too early" do
       expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.start_step(:upgrade_prepare)).to be true
-      expect(subject.start_step(:upgrade_prechecks)).to be false
+      expect{subject.start_step(:upgrade_prechecks)}.to raise_error(Crowbar::Error::StartStepOrderError)
       expect(subject.current_step).to eql :upgrade_prepare
-      expect(subject.start_step(:admin_repo_checks)).to be false
+      expect{subject.start_step(:admin_repo_checks)}.to raise_error(Crowbar::Error::StartStepOrderError)
     end
   end
 end

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -22,10 +22,10 @@ describe Crowbar::UpgradeStatus do
     File.unlink @state_file
   end
 
-  subject { Crowbar::UpgradeStatus.new(@state_file) }
+  subject { Crowbar::UpgradeStatus.new(Rails.logger, @state_file) }
 
   def new_status
-    subject.class.new(@state_file)
+    subject.class.new(Rails.logger, @state_file)
   end
 
   after do

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -51,6 +51,12 @@ describe Api::Crowbar do
         and_return(true)
       )
       allow(NodeObject).to receive(:admin_node).and_return(admin_node)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:admin_upgrade).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :end_step
+      ).and_return(true)
 
       expect(subject.class.upgrade!).to eq(
         status: :ok,

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -100,6 +100,12 @@ describe Api::Upgrade do
           "sudo /usr/bin/zypper-retry --xmlout products"
         ).and_return(crowbar_repocheck_zypper)
       )
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:admin_repo_checks).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :end_step
+      ).and_return(true)
 
       expect(subject.class.adminrepocheck.deep_stringify_keys).to_not(
         eq(crowbar_repocheck)
@@ -117,6 +123,12 @@ describe Api::Upgrade do
           "sudo /usr/bin/zypper-retry --xmlout products"
         ).and_return(crowbar_repocheck_zypper_locked)
       )
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:admin_repo_checks).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :end_step
+      ).and_return(true)
 
       check = subject.class.adminrepocheck
       expect(check[:status]).to eq(:service_unavailable)
@@ -136,6 +148,12 @@ describe Api::Upgrade do
           "sudo /usr/bin/zypper-retry --xmlout products"
         ).and_return(crowbar_repocheck_zypper_prompt)
       )
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:admin_repo_checks).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :end_step
+      ).and_return(true)
 
       check = subject.class.adminrepocheck
       expect(check[:status]).to eq(:service_unavailable)
@@ -155,6 +173,12 @@ describe Api::Upgrade do
           "sudo /usr/bin/zypper-retry --xmlout products"
         ).and_return(crowbar_repocheck_zypper)
       )
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:admin_repo_checks).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :end_step
+      ).and_return(true)
 
       expect(subject.class.adminrepocheck.deep_stringify_keys).to(
         eq(crowbar_repocheck)
@@ -217,6 +241,9 @@ describe Api::Upgrade do
       allow_any_instance_of(CrowbarService).to receive(
         :prepare_nodes_for_crowbar_upgrade
       ).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:upgrade_prepare).and_return(true)
 
       expect(subject.class.prepare(background: true)).to be true
     end
@@ -224,6 +251,12 @@ describe Api::Upgrade do
     it "succeeds to spawn the prepare in the foreground" do
       allow_any_instance_of(CrowbarService).to receive(
         :prepare_nodes_for_crowbar_upgrade
+      ).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:upgrade_prepare).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :end_step
       ).and_return(true)
 
       expect(subject.class.prepare).to be true
@@ -233,6 +266,12 @@ describe Api::Upgrade do
       allow_any_instance_of(CrowbarService).to receive(
         :prepare_nodes_for_crowbar_upgrade
       ).and_raise("Some error")
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:upgrade_prepare).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :end_step
+      ).and_return(true)
 
       expect(subject.class.prepare).to be false
     end

--- a/crowbar_framework/spec/spec_helper.rb
+++ b/crowbar_framework/spec/spec_helper.rb
@@ -109,6 +109,9 @@ RSpec.configure do |config|
       receive(:updates_status).
       and_return(passed: true, errors: [])
     )
+    allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:lock_path).and_return(
+      Tempfile.open("upgrade_status_spec.lock").path
+    )
   end
 
   config.append_before(:each) do


### PR DESCRIPTION
there is also a backport of https://github.com/crowbar/crowbar-core/pull/772 in here

and it needs a forward port of the other commits about the api restriction