### PR TITLE
Do router migration back to founder node

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -122,6 +122,14 @@ template "/usr/sbin/crowbar-delete-pacemaker-resources.sh" do
   )
 end
 
+template "/usr/sbin/crowbar-router-migration.sh" do
+  source "crowbar-router-migration.sh.erb"
+  mode "0755"
+  owner "root"
+  group "root"
+  action :create
+end
+
 has_drbd = use_ha && node.fetch("drbd", {}).fetch("rsc", {}).any?
 
 template "/usr/sbin/crowbar-post-upgrade.sh" do

--- a/chef/cookbooks/crowbar/templates/default/crowbar-router-migration.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-router-migration.sh.erb
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# This script migrates all neutron routers to the node where the script is
+# executed. As part of the upgrade, the founder node disbanded all routers
+# to other nodes. After the founder is upgraded, all routers have to come
+# back.
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+echo "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+
+if [[ -f $UPGRADEDIR/crowbar-router-migration-ok ]] ; then
+    echo "router migration actions were already successfully executed"
+    exit 0
+fi
+
+set +x
+source /root/.openrc
+set -x
+
+upgraded_agent=$(neutron agent-list --binary neutron-l3-agent --host $(hostname) -f value -c id)
+routers=$(neutron router-list -f value -c id)
+for router in $routers; do
+    agent=$(neutron l3-agent-list-hosting-router $router -f value -c id)
+    old_host=$(neutron agent-show $agent -f value -c host)
+
+    # delete old router assignment to agent
+    neutron l3-agent-router-remove $agent $router
+
+    # assign router to agent in upgraded node
+    neutron l3-agent-router-add $upgraded_agent $router
+
+    # delete old routers namespaces. Unassignment didn't delete the namespaces
+    ssh $old_host ip netns delete qrouter-$router
+
+done
+
+touch $UPGRADEDIR/crowbar-router-migration-ok

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -48,6 +48,14 @@ module Api
       false
     end
 
+    def router_migration
+      if execute_and_wait_for_finish("/usr/sbin/crowbar-router-migration.sh", 600)
+        save_node_state("Router migration was successful.")
+        return true
+      end
+      false
+    end
+
     # Execute post upgrade actions: prepare drbd and start pacemaker
     def post_upgrade
       if execute_and_wait_for_finish("/usr/sbin/crowbar-post-upgrade.sh", 600)

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -294,6 +294,7 @@ describe Api::Upgrade do
         and_return(true)
       allow(Api::Upgrade).to receive(:delete_pacemaker_resources).and_return(true)
       allow_any_instance_of(Api::Node).to receive(:post_upgrade).and_return(true)
+      allow_any_instance_of(Api::Node).to receive(:router_migration).and_return(true)
       allow_any_instance_of(Api::Node).to receive(:join_and_chef).and_return(true)
 
       expect(subject.class.nodes).to be true


### PR DESCRIPTION
As part of the founder upgrade, we moved all routers to a different node
in order to keep connectivity to the VMs. Once the founder node has been
upgraded it is safe to move back the routers.

**Requires:** https://github.com/crowbar/crowbar-openstack/pull/619