### PR TITLE
update database configuration

### DIFF
--- a/crowbar_framework/config/database.yml
+++ b/crowbar_framework/config/database.yml
@@ -16,23 +16,29 @@
 #
 
 default: &default
+  adapter: postgresql
+  host: localhost
+  port: 5432
+  database: crowbar_production
+  pool: 5
+  username: crowbar
+  password: crowbar
+
+sqlite: &sqlite
   adapter: sqlite3
+  database: db/test.sqlite3
   pool: 5
   timeout: 5000
   options: "PRAGMA journal_mode=WAL;"
 
 development:
   <<: *default
-  database: db/development.sqlite3
 
 test:
-  <<: *default
-  database: db/test.sqlite3
+  <<: *sqlite
 
 cucumber:
-  <<: *default
-  database: db/test.sqlite3
+  <<: *sqlite
 
 production:
   <<: *default
-  database: db/production.sqlite3


### PR DESCRIPTION
in a fresh cloud setup this file gets overwritten by crowbar-init's
chef recipe, there is a template for that file.

nevertheless it should reflect the adapter that we have nowadays
which is postgres.

the other benefit of this patch is that when we use a development
environment the file gets overwritten by guard and the values are
still the correct defaults as we use from crowbar-init's template.

## obsoletes
https://github.com/crowbar/crowbar-init/pull/55 and https://github.com/SUSE-Cloud/automation/pull/1489