### PR TITLE
[3.0] upgrade: Fix the API call for Crowbar::UpgradeStatus.start_step

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -76,17 +76,17 @@ class Api::UpgradeController < ApiController
 
   def adminbackup
     upgrade_status = ::Crowbar::UpgradeStatus.new
-    upgrade_status.start_step if upgrade_status.current_step == :admin_backup
+    upgrade_status.start_step(:admin_backup)
     @backup = Backup.new(backup_params)
 
     if @backup.save
-      upgrade_status.end_step if upgrade_status.current_step == :admin_backup
+      upgrade_status.end_step
       render json: @backup, status: :ok
     else
       upgrade_status.end_step(
         false,
         admin_backup: @backup.errors.full_messages.first
-      ) if upgrade_status.current_step == :admin_backup
+      )
       render json: { error: @backup.errors.full_messages.first }, status: :unprocessable_entity
     end
   ensure


### PR DESCRIPTION
start_step requires an argument (step name)


This change is already included in https://github.com/crowbar/crowbar-core/pull/830 , but we might need to merge this sooner, as the review of the other PR could take longer time. 

This Pr is fixing the bug that currently the upgrade is failing in crowbar backup step.