### PR TITLE
upgrade: set status and restrict api for noderepochecks and service shutdown

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -246,6 +246,17 @@ class Api::UpgradeController < ApiController
   '
   def noderepocheck
     render json: Api::Upgrade.noderepocheck
+  rescue Crowbar::Error::StartStepRunningError,
+         Crowbar::Error::StartStepOrderError,
+         Crowbar::Error::EndStepRunningError => e
+    render json: {
+      errors: {
+        nodes_repo_checks: {
+          data: e.message,
+          help: I18n.t("api.upgrade.noderepocheck.help.default")
+        }
+      }
+    }, status: :unprocessable_entity
   end
 
   api :GET, "/api/upgrade/adminrepocheck",

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -116,6 +116,17 @@ class Api::UpgradeController < ApiController
         }
       }, status: stop_services[:status]
     end
+  rescue Crowbar::Error::StartStepRunningError,
+         Crowbar::Error::StartStepOrderError,
+         Crowbar::Error::EndStepRunningError => e
+    render json: {
+      errors: {
+        nodes_services: {
+          data: e.message,
+          help: I18n.t("api.upgrade.services.help.default")
+        }
+      }
+    }, status: :unprocessable_entity
   end
 
   api :POST, "/api/upgrade/nodes", "Initiate the upgrade of all nodes"

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1111,17 +1111,19 @@ class NodeObject < ChefObject
   end
 
   def shutdown_services_before_upgrade
+    cmd = [200, ""]
     if @node.roles.include?("pacemaker-cluster-member")
       # For all nodes in cluster, set the pre-upgrade attribute
-      ssh_cmd("crm node attribute $(hostname) set pre-upgrade true")
+      cmd = ssh_cmd("crm node attribute $(hostname) set pre-upgrade true")
       # Shutdown of services could be done from the founder node
       if @node["pacemaker"] && @node["pacemaker"]["founder"]
-        ssh_cmd("/usr/sbin/crowbar-shutdown-services-before-upgrade.sh")
+        cmd = ssh_cmd("/usr/sbin/crowbar-shutdown-services-before-upgrade.sh")
       end
     else
       # For non clustered nodes, we need to shutdown the services at each node
-      ssh_cmd("/usr/sbin/crowbar-shutdown-services-before-upgrade.sh")
+      cmd = ssh_cmd("/usr/sbin/crowbar-shutdown-services-before-upgrade.sh")
     end
+    cmd
   end
 
   def net_rpc_cmd(cmd)

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -808,6 +808,9 @@ en:
         failed: 'Node upgrade failed'
         help:
           default: 'Refer to the error message in the response'
+      noderepocheck:
+        help:
+          default: 'Refer to the error message in the response'
       cancel:
         help:
           default: 'Refer to the error message in the response'

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -124,8 +124,14 @@ describe Api::Upgrade do
       )
       allow_any_instance_of(NodeObject).to(
         receive(:shutdown_services_before_upgrade).
-        and_return(true)
+        and_return([200, "Some Error"])
       )
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:nodes_services).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :end_step
+      ).and_return(true)
 
       expect(subject.class.services).to eq(
         status: :ok,


### PR DESCRIPTION
## Depends on
~~https://github.com/crowbar/crowbar-core/pull/830~~ https://github.com/crowbar/crowbar-core/pull/847

@jsuchome I thought about doing the node upgrade status as well, but I'd like to wait for the implementation to be done before setting the status, because there are many different cases for setting the status as I saw in the code, and I am not sure if the model will still change, so I kept it untouched for now.