### PR TITLE
[3.0] upgrade: make step name consistent

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -115,7 +115,7 @@ class Api::UpgradeController < ApiController
          Crowbar::Error::EndStepRunningError => e
     render json: {
       errors: {
-        adminbackup: {
+        admin_backup: {
           data: e.message,
           help: I18n.t("api.upgrade.adminbackup.help.default")
         }


### PR DESCRIPTION
in the upgrade_status library the step has an underscore