### PR TITLE
bsc#998598: Move uid/gid lower to avoid collision

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -58,8 +58,8 @@
         <username>glance</username>
         <user_password>!</user_password>
         <encrypted config:type="boolean">true</encrypted>
-        <uid>483</uid>
-        <gid>483</gid>
+        <uid>200</uid>
+        <gid>200</gid>
         <home>/var/lib/glance</home>
         <shell>/sbin/nologin</shell>
       </user>
@@ -67,8 +67,8 @@
         <username>qemu</username>
         <user_password>!</user_password>
         <encrypted config:type="boolean">true</encrypted>
-        <uid>484</uid>
-        <gid>484</gid>
+        <uid>201</uid>
+        <gid>201</gid>
         <home>/</home>
         <shell>/sbin/nologin</shell>
       </user>
@@ -76,19 +76,19 @@
   <groups config:type="list">
     <!-- for making HA on shared NFS backend storage work -->
     <group>
-      <gid>483</gid>
+      <gid>200</gid>
       <groupname>glance</groupname>
       <group_password>x</group_password>
       <userlist>glance</userlist>
     </group>
     <group>
-      <gid>484</gid>
+      <gid>201</gid>
       <groupname>qemu</groupname>
       <group_password>x</group_password>
       <userlist/>
     </group>
     <group>
-      <gid>485</gid>
+      <gid>202</gid>
       <groupname>kvm</groupname>
       <group_password>x</group_password>
       <userlist>qemu</userlist>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -220,17 +220,15 @@ else
     BOOTDEV="$NIC_CANDIDATES"
 fi
 
-
 # Setup groups and users
 # ---------------
 
 # for making HA on shared NFS backend storage work
-add_group qemu 484
-add_group kvm 485
-add_user qemu 484 kvm
-add_group glance 483
-add_user glance 483 glance
-
+add_group glance 200
+add_user glance 200 glance
+add_group qemu 201
+add_user qemu 201 kvm
+add_group kvm 202
 
 # Check that we're really on the admin network
 # --------------------------------------------


### PR DESCRIPTION
For certain service users we fix their uid/gid combination to ensure
that the combination is consistent across multiple nodes. This is
necessary for interoperability with NFS for instance. By moving the
fixed uid/gid combinations to lower values we avoid (until there are
several hundred more service users in a default SLES installation)
collisions with the OS.