### PR TITLE
provisioner: Cache chef_client_runs (bsc#1013556)

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -528,13 +528,8 @@ class NodeObject < ChefObject
     return "unknown" if (@node.nil? or @role.nil?)
     if self.crowbar["state"] === "ready" and @node["ohai_time"]
       since_last = Time.now.to_i-@node["ohai_time"].to_i
-      crowbar_proposal = Proposal.where(barclamp: "provisioner").first
-      max_last = if crowbar_proposal
-        # time from proposal + 5 min buffer time
-        crowbar_proposal.properties["attributes"]["provisioner"]["chef_client_runs"] + 300
-      else
-        1200 # 20min
-      end
+      max_last = @node.default_attrs["provisioner"]["chef_client_runs"] || 900
+      max_last += 300 # time + 5 min buffer time
       return "noupdate" if since_last > max_last
     end
     return self.crowbar["state"] || "unknown"

--- a/crowbar_framework/spec/fixtures/offline_chef/node_admin.crowbar.com.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/node_admin.crowbar.com.json
@@ -67,6 +67,9 @@
     },
     "crowbar": {
       "admin_node": true
+    },
+    "provisioner": {
+      "chef_client_runs": 900
     }
   },
   "json_class": "Chef::Node",


### PR DESCRIPTION
To avoid heavy spamming of the log due to the regular database queries
let's cache the value till it changes.