### PR TITLE
[3.0] fix hound complaints

### DIFF
--- a/crowbar_framework/lib/crowbar/error/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/error/upgrade_status.rb
@@ -17,25 +17,25 @@
 module Crowbar
   module Error
     class StartStepExistenceError < StandardError
-      def initialize(step_name="")
+      def initialize(step_name = "")
         super("The step #{step_name} doesn't exist")
       end
     end
 
     class StartStepRunningError < StandardError
-      def initialize(step_name="")
+      def initialize(step_name = "")
         super("The step #{step_name} has already been started")
       end
     end
 
     class StartStepOrderError < StandardError
-      def initialize(step_name="")
+      def initialize(step_name = "")
         super("Start of step #{step_name} requested in the wrong order")
       end
     end
 
     class EndStepRunningError < StandardError
-      def initialize(step_name="")
+      def initialize(step_name = "")
         super("Step #{step_name} cannot be finished, as it is not running")
       end
     end

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -120,7 +120,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :upgrade_prepare
-      expect{subject.end_step}.to raise_error(Crowbar::Error::EndStepRunningError)
+      expect { subject.end_step }.to raise_error(Crowbar::Error::EndStepRunningError)
     end
 
     it "does not allow to end step when it was started by another object" do
@@ -134,14 +134,16 @@ describe Crowbar::UpgradeStatus do
 
     it "does not to stop the first step without starting it" do
       expect(subject.current_step).to eql :upgrade_prechecks
-      expect{subject.end_step}.to raise_error(Crowbar::Error::EndStepRunningError)
+      expect { subject.end_step }.to raise_error(Crowbar::Error::EndStepRunningError)
     end
 
     it "prevents starting a step while it is already running" do
       expect(subject.current_step).to eql :upgrade_prechecks
       expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.current_step_state[:status]).to eql :running
-      expect{subject.start_step(:upgrade_prechecks)}.to raise_error(Crowbar::Error::StartStepRunningError)
+      expect { subject.start_step(:upgrade_prechecks) }.to raise_error(
+        Crowbar::Error::StartStepRunningError
+      )
       expect(subject.current_step_state[:status]).to eql :running
       expect(subject.current_step).to eql :upgrade_prechecks
     end
@@ -152,7 +154,9 @@ describe Crowbar::UpgradeStatus do
       expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.current_step_state[:status]).to eql :running
       other_status.load
-      expect{other_status.start_step(:upgrade_prechecks)}.to raise_error(Crowbar::Error::StartStepRunningError)
+      expect { other_status.start_step(:upgrade_prechecks) }.to raise_error(
+        Crowbar::Error::StartStepRunningError
+      )
     end
 
     it "goes through the steps and returns finish when finished" do
@@ -187,7 +191,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :finished
       expect(subject.finished?).to be true
-      expect{subject.end_step}.to raise_error(Crowbar::Error::EndStepRunningError)
+      expect { subject.end_step }.to raise_error(Crowbar::Error::EndStepRunningError)
     end
 
     it "allows repeating some steps" do
@@ -196,7 +200,9 @@ describe Crowbar::UpgradeStatus do
       expect(subject.running?(:upgrade_prechecks)).to be false
       expect(subject.current_step).to eql :upgrade_prepare
       expect(subject.start_step(:upgrade_prechecks)).to be true
-      expect{subject.start_step(:upgrade_prechecks)}.to raise_error(Crowbar::Error::StartStepRunningError)
+      expect { subject.start_step(:upgrade_prechecks) }.to raise_error(
+        Crowbar::Error::StartStepRunningError
+      )
       expect(subject.running?(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.start_step(:upgrade_prepare)).to be true
@@ -212,22 +218,40 @@ describe Crowbar::UpgradeStatus do
     end
 
     it "prevents repeating steps that do not allow repetition" do
-      expect{subject.start_step(:upgrade_prepare)}.to raise_error(Crowbar::Error::StartStepOrderError)
-      expect{subject.start_step(:admin_backup)}.to raise_error(Crowbar::Error::StartStepOrderError)
-      expect{subject.start_step(:admin_upgrade)}.to raise_error(Crowbar::Error::StartStepOrderError)
-      expect{subject.start_step(:database)}.to raise_error(Crowbar::Error::StartStepOrderError)
-      expect{subject.start_step(:nodes_services)}.to raise_error(Crowbar::Error::StartStepOrderError)
-      expect{subject.start_step(:nodes_db_dump)}.to raise_error(Crowbar::Error::StartStepOrderError)
-      expect{subject.start_step(:nodes_upgrade)}.to raise_error(Crowbar::Error::StartStepOrderError)
+      expect { subject.start_step(:upgrade_prepare) }.to raise_error(
+        Crowbar::Error::StartStepOrderError
+      )
+      expect { subject.start_step(:admin_backup) }.to raise_error(
+        Crowbar::Error::StartStepOrderError
+      )
+      expect { subject.start_step(:admin_upgrade) }.to raise_error(
+        Crowbar::Error::StartStepOrderError
+      )
+      expect { subject.start_step(:database) }.to raise_error(
+        Crowbar::Error::StartStepOrderError
+      )
+      expect { subject.start_step(:nodes_services) }.to raise_error(
+        Crowbar::Error::StartStepOrderError
+      )
+      expect { subject.start_step(:nodes_db_dump) }.to raise_error(
+        Crowbar::Error::StartStepOrderError
+      )
+      expect { subject.start_step(:nodes_upgrade) }.to raise_error(
+        Crowbar::Error::StartStepOrderError
+      )
     end
 
     it "prevents repeating steps when it's too late or too early" do
       expect(subject.start_step(:upgrade_prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.start_step(:upgrade_prepare)).to be true
-      expect{subject.start_step(:upgrade_prechecks)}.to raise_error(Crowbar::Error::StartStepOrderError)
+      expect { subject.start_step(:upgrade_prechecks) }.to raise_error(
+        Crowbar::Error::StartStepOrderError
+      )
       expect(subject.current_step).to eql :upgrade_prepare
-      expect{subject.start_step(:admin_repo_checks)}.to raise_error(Crowbar::Error::StartStepOrderError)
+      expect { subject.start_step(:admin_repo_checks) }.to raise_error(
+        Crowbar::Error::StartStepOrderError
+      )
     end
   end
 end


### PR DESCRIPTION
(cherry picked from commit 1055d79e3f705bd5dc1c411ab5a8f01d4e7ec343)


Hound was not configured correctly on the `stable/3.0` branch, so some violations that came to daylight in https://github.com/crowbar/crowbar-core/pull/847 need to be backported