### PR TITLE
crowbar: Fix crash when displaying chef log on error

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1302,7 +1302,7 @@ class ServiceObject
       bad_nodes.each do |node|
         pre_cached_nodes[node] ||= NodeObject.find_node_by_name(node)
         node_alias = pre_cached_nodes[node].alias
-        message += "#{node_alias}: #{node}\n"
+        message += "#{node_alias} (#{node}):\n"
         message += get_log_lines(node)
       end
       update_proposal_status(inst, "failed", message)

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1300,6 +1300,7 @@ class ServiceObject
 
       message = "Failed to apply the proposal to:\n"
       bad_nodes.each do |node|
+        pre_cached_nodes[node] ||= NodeObject.find_node_by_name(node)
         node_alias = pre_cached_nodes[node].alias
         message += "#{node_alias}: #{node}\n"
         message += get_log_lines(node)


### PR DESCRIPTION
The node is not necessarily cached.