### PR TITLE
rspec: fix unit tests

### DIFF
--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -65,6 +65,8 @@ describe Api::UpgradeController, type: :request do
       allow_any_instance_of(CrowbarService).to receive(
         :prepare_nodes_for_os_upgrade
       ).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
       post "/api/upgrade/services", {}, headers
       expect(response).to have_http_status(:ok)
@@ -183,6 +185,8 @@ describe Api::UpgradeController, type: :request do
           ).and_return([true, {}])
         )
       end
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
       get "/api/upgrade/noderepocheck", {}, headers
       expect(response).to have_http_status(:ok)

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -145,6 +145,8 @@ describe Api::Upgrade do
       allow_any_instance_of(CrowbarService).to receive(
         :prepare_nodes_for_os_upgrade
       ).and_raise("some Error")
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
       expect(subject.class.services).to eq(
         status: :unprocessable_entity,
@@ -159,6 +161,8 @@ describe Api::Upgrade do
         k.delete("ceph")
         k.delete("ha")
       end
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
       expect(subject.class.noderepocheck).to eq(os_repo_fixture)
     end
@@ -183,6 +187,8 @@ describe Api::Upgrade do
           "openstack" => ["x86_64"]
         )
       )
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
       expected = node_repocheck.tap do |k|
         k.delete("ceph")


### PR DESCRIPTION
PR #839 wasn't fully rebased at the time of merging, so another
change in the upgrade status lib requires the unit tests to be adapted