### PR TITLE
network: Run wicked ifreload only once per chef-client run (bsc#1012587)

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -490,7 +490,7 @@ when "suse"
         interfaces: ifs,
         nic: nic
       })
-      notifies :run, "bash[wicked-ifreload-#{nic.name}]", :immediately
+      notifies :create, "ruby_block[wicked-ifreload-required]", :immediately
     end
     if ifs[nic.name]["gateway"]
       template "/etc/sysconfig/network/ifroute-#{nic.name}" do
@@ -499,23 +499,42 @@ when "suse"
                     interfaces: ifs,
                     nic: nic
                   })
-        notifies :run, "bash[wicked-ifreload-#{nic.name}]", :immediately
+        notifies :create, "ruby_block[wicked-ifreload-required]", :immediately
       end
     else
       file "/etc/sysconfig/network/ifroute-#{nic.name}" do
         action :delete
       end
     end
-    bash "wicked-ifreload-#{nic.name}" do
-      action :nothing
-      code <<-EOF
-        wicked ifcheck --changed --quiet #{nic.name}
-        rc=$?
-        if [[ $rc != 0 ]]; then
-          wicked ifreload #{nic.name}
-        fi
-      EOF
+  end
+
+  run_wicked_ifreload = false
+
+  # This, when notified by the above "ifcfg" templates, sets run_wicked_ifreload
+  # to true (which was initialized to false in the compile phase).
+  # run_wicked_ifreload is later used as a "only_if" guard for the
+  # "wicked ifreload all" call that is needs to happen when any of the config
+  # files got updated. The purpose of doing it this way (instead of notifying the
+  # "wicked-ifreload-all" resource directly), is to make sure that the
+  # ifrelaod is only run once after all ifcfg file have been update and
+  # independent of how many of them were changed.
+  ruby_block "wicked-ifreload-required" do
+    block do
+      run_wicked_ifreload = true
     end
+    action :nothing
+  end
+
+  bash "wicked-ifreload-all" do
+    action :nothing
+    code <<-EOF
+      wicked ifcheck --changed --quiet all
+      rc=$?
+      if [[ $rc != 0 ]]; then
+        wicked ifreload all
+      fi
+    EOF
+    only_if { run_wicked_ifreload }
   end
 
   # Avoid running the wicked related thing on SLE11 nodes


### PR DESCRIPTION
This reworks the fix for https://bugzilla.suse.com/show_bug.cgi?id=1011889
to ensure that wicked ifreload is only execute at most once for a single
chef-client run. Previouly it was triggered once per updated ifcfg file
and that caused problems for certain configurations. E.g. when a single
chef-client run set up an "normal" physcial interface and a vlan
interface on top of that. (Happens e.g. in "dual" network setups when
allocating a public IP and when public and admin are on different
physical interfaces.)

https://bugzilla.suse.com/show_bug.cgi?id=1012587