### PR TITLE
upgrade: Remove unsupported cinder services right before the upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -77,6 +77,7 @@ end
 
 # Find out now if we have HA setup and pass that info to the script
 use_ha = node["run_list_map"].key? "pacemaker-cluster-member"
+cinder_controller = node["run_list_map"].key? "cinder-controller"
 
 template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   source "crowbar-shutdown-services-before-upgrade.sh.erb"
@@ -85,6 +86,7 @@ template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   group "root"
   action :create
   variables(
+    cinder_controller: cinder_controller,
     use_ha: use_ha
   )
 end

--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -87,6 +87,7 @@ template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   action :create
   variables(
     cinder_controller: cinder_controller,
+    cluster_founder: use_ha && (node["pacemaker"]["founder"] || false),
     use_ha: use_ha
   )
 end

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -41,3 +41,20 @@ do
 done
 
 <% end %>
+
+<% if @cinder_controller %>
+
+# all cinder services must be stopped
+while cinder-manage service list 2>/dev/null | grep -q ":-)"; do
+  echo "Some cinder services are still running"
+  sleep 5
+done
+
+for service in cinder-volume cinder-scheduler; do
+    hosts=$(cinder-manage service list | grep $service | tr -s ' ' | cut -d ' ' -f 2)
+    for host in $hosts; do
+        cinder-manage service remove $service $host 2>/dev/null
+    done
+done
+
+<% end %>

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -12,6 +12,8 @@ echo "Executing $BASH_SOURCE"
 set -x
 
 <% if @use_ha %>
+
+<% if @cluster_founder %>
 echo "Stopping pacemaker resources..."
 
 exclude="postgresql|vip|rabbitmq|keystone|neutron|haproxy"
@@ -22,6 +24,11 @@ for type in clone ms primitive; do
         crm --force --wait resource stop $resource
     done
 done
+
+<% end %>
+
+# stop cinder-volume at all nodes so the service could be removed from the database later
+/etc/init.d/openstack-cinder-volume stop
 
 <% else %>
 
@@ -42,7 +49,7 @@ done
 
 <% end %>
 
-<% if @cinder_controller %>
+<% if @cinder_controller && (!@use_ha || @cluster_founder) %>
 
 # all cinder services must be stopped
 while cinder-manage service list 2>/dev/null | grep -q ":-)"; do

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1111,19 +1111,12 @@ class NodeObject < ChefObject
   end
 
   def shutdown_services_before_upgrade
-    cmd = [200, ""]
     if @node.roles.include?("pacemaker-cluster-member")
       # For all nodes in cluster, set the pre-upgrade attribute
-      cmd = ssh_cmd("crm node attribute $(hostname) set pre-upgrade true")
-      # Shutdown of services could be done from the founder node
-      if @node["pacemaker"] && @node["pacemaker"]["founder"]
-        cmd = ssh_cmd("/usr/sbin/crowbar-shutdown-services-before-upgrade.sh")
-      end
-    else
-      # For non clustered nodes, we need to shutdown the services at each node
-      cmd = ssh_cmd("/usr/sbin/crowbar-shutdown-services-before-upgrade.sh")
+      ssh_cmd("crm node attribute $(hostname) set pre-upgrade true")
     end
-    cmd
+    # For all nodes, we need to shutdown the services at each node
+    ssh_cmd("/usr/sbin/crowbar-shutdown-services-before-upgrade.sh")
   end
 
   def net_rpc_cmd(cmd)


### PR DESCRIPTION
See Known Issues at http://docs.openstack.org/releasenotes/cinder/newton.html#id4

Cinder services are now automatically downgrading RPC messages to be understood
by the oldest version of a service among all the deployment. Disabled and dead
services are also taken into account. It is important to keep service list up to date,
without old, unused records. This can be done using cinder-manage service remove command.