### PR TITLE
Fix link to crowbar_batch executable in documentation 

### DIFF
--- a/crowbar_framework/public/docs/batch.md
+++ b/crowbar_framework/public/docs/batch.md
@@ -1,7 +1,7 @@
 # `crowbar-batch`
 
 This is the documentation for the
-[`crowbar batch`](../bin/crowbar_batch) subcommand.
+[`crowbar batch`](../../../bin/crowbar_batch) subcommand.
 
 ## Description
 


### PR DESCRIPTION
The URL in [crowbar batch doc](https://github.com/crowbar/crowbar-core/blob/master/crowbar_framework/public/docs/batch.md) is broken now