### PR TITLE
[3.0] travis: Use rake < 12.0.0

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -18,6 +18,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.2"
+gem "rake", "< 12.0.0"
 gem "haml-rails", "~> 0.9.0"
 gem "sass-rails", "~> 5.0.3"
 gem "puma", "~> 2.11.3"


### PR DESCRIPTION
Rake 12.0.0 got released on Dec 6 but our rspec version still uses
removed code.