### PR TITLE
[3.0] upgrade: fix adminrepochecks on missing repositories

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -148,9 +148,10 @@ module Api
 
           if ret.any? { |_k, v| !v[:available] }
             missing_repos = ret.collect do |k, v|
+              next if v[:repos].empty?
               missing_repo_arch = v[:repos].keys.first.to_sym
               v[:repos][missing_repo_arch][:missing]
-            end.flatten.join(", ")
+            end.flatten.compact.join(", ")
             upgrade_status.end_step(
               false,
               adminrepocheck: "Missing repositories: #{missing_repos}"


### PR DESCRIPTION
when just one product has missing repositories and another one
shows empty (successful) repochecks, we need to skip trying to
parse the missing repositories when there aren't any.

fixes: NoMethodError (undefined method `to_sym' for nil:NilClass)