### PR TITLE
upgrade: fix adminrepochecks on missing repositories

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -155,9 +155,10 @@ module Api
 
           if ret.any? { |_k, v| !v[:available] }
             missing_repos = ret.collect do |k, v|
+              next if v[:repos].empty?
               missing_repo_arch = v[:repos].keys.first.to_sym
               v[:repos][missing_repo_arch][:missing]
-            end.flatten.join(", ")
+            end.flatten.compact.join(", ")
             upgrade_status.end_step(
               false,
               adminrepocheck: "Missing repositories: #{missing_repos}"

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -223,6 +223,41 @@ describe Api::Upgrade do
         eq(crowbar_repocheck)
       )
     end
+
+    it "has only one repository that is not available" do
+      allow(Api::Upgrade).to(
+        receive(:repo_version_available?).with(
+          Hash.from_xml(crowbar_repocheck_zypper)["stream"]["product_list"]["product"],
+          "SLES",
+          "12.3"
+        ).and_return(false)
+      )
+      allow(Api::Upgrade).to(
+        receive(:repo_version_available?).with(
+          Hash.from_xml(crowbar_repocheck_zypper)["stream"]["product_list"]["product"],
+          "suse-openstack-cloud",
+          "8"
+        ).and_return(true)
+      )
+      allow(Api::Upgrade).to(
+        receive(:admin_architecture).and_return("x86_64")
+      )
+      allow_any_instance_of(Kernel).to(
+        receive(:`).with(
+          "sudo /usr/bin/zypper-retry --xmlout products"
+        ).and_return(crowbar_repocheck_zypper)
+      )
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:admin_repo_checks).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :end_step
+      ).and_return(true)
+
+      expect(subject.class.adminrepocheck.deep_stringify_keys).to_not(
+        eq(crowbar_repocheck.merge(subject.class.adminrepocheck[:os]))
+      )
+    end
   end
 
   context "with a locked zypper" do


### PR DESCRIPTION
when just one product has missing repositories and another one
shows empty (successful) repochecks, we need to skip trying to
parse the missing repositories when there aren't any.

fixes: NoMethodError (undefined method `to_sym' for nil:NilClass)
(cherry picked from commit 55489c0ba1e5eb9aacde1f461e7fbbdffe637f8f)

forwardport of https://github.com/crowbar/crowbar-core/pull/874