### PR TITLE
[3.0] show sanity check errors in the json response

### DIFF
--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -194,7 +194,9 @@ class ApplicationController < ActionController::Base
         redirect_to sanity_path
       end
       format.json do
-        render json: { error: I18n.t("error.before_install") }, status: :unprocessable_entity
+        render json: {
+          error: Rails.cache.fetch(:sanity_check_errors)
+        }, status: :unprocessable_entity
       end
     end
   end


### PR DESCRIPTION
if you don't have an UI which lists you the sanity errors, it is very
difficult from the back end to determine what went wrong