### PR TITLE
[3.0] only allow requests to the upgrade api during the upgrade

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -15,6 +15,8 @@
 #
 
 class Api::UpgradeController < ApiController
+  skip_before_filter :upgrade
+
   def show
     render json: Api::Upgrade.status
   end

--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -33,6 +33,9 @@ class ApplicationController < ActionController::Base
     Crowbar::Installer.successful? || \
     Rails.env.test?
   }
+  before_filter :upgrade, if: proc {
+    File.exist?("/var/lib/crowbar/upgrade/6-to-7-progress.yml")
+  }
   before_filter :sanity_checks, unless: proc {
     Rails.env.test? || \
     Rails.cache.fetch(:sanity_check_errors).empty?
@@ -192,6 +195,18 @@ class ApplicationController < ActionController::Base
       end
       format.json do
         render json: { error: I18n.t("error.before_install") }, status: :unprocessable_entity
+      end
+    end
+  end
+
+  def upgrade
+    respond_to do |format|
+      format.html do
+        # redirect to the upgrade ui wizard
+        redirect_to "/upgrade"
+      end
+      format.json do
+        render json: { error: I18n.t("error.during_upgrade") }, status: :service_unavailable
       end
     end
   end

--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -201,12 +201,15 @@ class ApplicationController < ActionController::Base
 
   def upgrade
     respond_to do |format|
-      format.html do
-        # redirect to the upgrade ui wizard
-        redirect_to "/upgrade"
-      end
       format.json do
-        render json: { error: I18n.t("error.during_upgrade") }, status: :service_unavailable
+        if request.post?
+          render json: { error: I18n.t("error.during_upgrade") }, status: :service_unavailable
+        else
+          return
+        end
+      end
+      format.html do
+        render "errors/during_upgrade", status: :service_unavailable
       end
     end
   end

--- a/crowbar_framework/app/views/errors/during_upgrade.html.haml
+++ b/crowbar_framework/app/views/errors/during_upgrade.html.haml
@@ -1,0 +1,28 @@
+.navbar.navbar-inverse.navbar-fixed-top
+  .container
+    .navbar-header
+      %button.navbar-toggle
+        %span.sr-only
+          Navigation
+        %span.icon-bar
+        %span.icon-bar
+        %span.icon-bar
+      %a{ href: "/" }
+        .navbar-brand
+          %span.title
+            Crowbar
+    .collapse.navbar-collapse.navbar-right
+      %ul.nav.navbar-nav
+        %li
+          %a{ href: "/upgrade" }
+            Go to upgrade wizard
+
+.panel.panel-default.panel-warning
+  .panel-heading
+    The requested service is temporarily unavailable
+
+  .panel-body
+    %p
+      You are currently upgrading your deployment and therefore access to the Crowbar UI is
+      restricted to the <a href="/upgrade">upgrade wizard</a>.
+      Please finish the upgrade first.

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -890,6 +890,7 @@ en:
     chef_server_down: 'Chef server is not available'
     param_missing: 'A required parameter is missing'
     before_install: 'This API is not available before installation'
+    during_upgrade: 'This API is not available during upgrade'
 
   state:
     unknown: 'Unknown'

--- a/crowbar_framework/spec/controllers/machines_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/machines_controller_spec.rb
@@ -25,6 +25,9 @@ describe MachinesController do
   describe "GET index" do
     before do
       allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:exist?).with(
+        "/var/lib/crowbar/upgrade/6-to-7-progress.yml"
+      ).and_return(false)
     end
 
     it "is successful" do


### PR DESCRIPTION
backport of https://github.com/crowbar/crowbar-core/pull/861

NOTE: the difference to the original commit is that i dropped the check for `/var/lib/crowbar/upgrade/6-to-7-upgraded-ok`