### PR TITLE
upgrade: Ensure cinder controller runs shutdown of services as last node

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-delete-cinder-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-delete-cinder-services-before-upgrade.sh.erb
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# This script deletes existing cinder services from the database. This is necessary when upgrading to Newton.
+# They will be recreated automatically once upgraded and started.
+#
+# The script should be run only from cinder-controller.
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+echo "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+
+if [[ -f $UPGRADEDIR/crowbar-delete-cinder-services-before-upgrade-ok ]] ; then
+    echo "Services shutdown was already successfully executed"
+    exit 0
+fi
+
+# all cinder services must be stopped before deleting
+while cinder-manage service list 2>/dev/null | grep -q ":-)"; do
+  echo "Some cinder services are still running"
+  sleep 5
+done
+
+for service in cinder-volume cinder-scheduler; do
+    hosts=$(cinder-manage service list | grep $service | tr -s ' ' | cut -d ' ' -f 2)
+    for host in $hosts; do
+        cinder-manage service remove $service $host 2>/dev/null
+    done
+done
+
+touch $UPGRADEDIR/crowbar-delete-cinder-services-before-upgrade-ok

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -1,9 +1,10 @@
 #!/bin/bash
 #
-# This script starts the upgrade of the node server to the latest version of
-# system and Cloud product.
+# This script stops unnecessary OpenStack services on the nodes before we dive
+# deeper into the real upgrade.
 
 LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
 mkdir -p "`dirname "$LOGFILE"`"
 exec >>"$LOGFILE" 2>&1
 
@@ -28,7 +29,9 @@ done
 <% end %>
 
 # stop cinder-volume at all nodes so the service could be removed from the database later
-/etc/init.d/openstack-cinder-volume stop
+if test -e /etc/init.d/openstack-cinder-volume; then
+    /etc/init.d/openstack-cinder-volume stop
+fi
 
 <% else %>
 
@@ -45,23 +48,6 @@ do
     if test -e $i; then
         $i stop
     fi
-done
-
-<% end %>
-
-<% if @cinder_controller && (!@use_ha || @cluster_founder) %>
-
-# all cinder services must be stopped
-while cinder-manage service list 2>/dev/null | grep -q ":-)"; do
-  echo "Some cinder services are still running"
-  sleep 5
-done
-
-for service in cinder-volume cinder-scheduler; do
-    hosts=$(cinder-manage service list | grep $service | tr -s ' ' | cut -d ' ' -f 2)
-    for host in $hosts; do
-        cinder-manage service remove $service $host 2>/dev/null
-    done
 done
 
 <% end %>

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1110,7 +1110,7 @@ class NodeObject < ChefObject
       # For all nodes in cluster, set the pre-upgrade attribute
       ssh_cmd("crm node attribute $(hostname) set pre-upgrade true")
     end
-    # For all nodes, we need to shutdown the services at each node
+    # Initiate the shutdown of services at each node
     ssh_cmd("/usr/sbin/crowbar-shutdown-services-before-upgrade.sh")
   end
 

--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -1094,7 +1094,7 @@ class NodeObject < ChefObject
             break
           end
           if file_exist? failed_file
-            raise "Execution of script #{script} at node #{@node.name} has failed"
+            raise "Execution of script #{script} at node #{@node.name} has failed."
           end
           sleep(5)
         end

--- a/crowbar_framework/spec/fixtures/offline_chef/node_testing.crowbar.com.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/node_testing.crowbar.com.json
@@ -25,7 +25,9 @@
 
   },
   "default": {
-
+    "roles": [
+      "cinder-controller"
+    ]
   },
   "json_class": "Chef::Node",
   "automatic": {

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -118,6 +118,9 @@ describe Api::Upgrade do
 
   context "with a successful services shutdown" do
     it "prepares and shuts down services on cluster founder nodes" do
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :start_step
+      ).with(:nodes_services).and_return(true)
       allow_any_instance_of(CrowbarService).to receive(
         :prepare_nodes_for_os_upgrade
       ).and_return(true)
@@ -129,9 +132,6 @@ describe Api::Upgrade do
         receive(:shutdown_services_before_upgrade).
         and_return([200, "Some Error"])
       )
-      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
-        :start_step
-      ).with(:nodes_services).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :end_step
       ).and_return(true)


### PR DESCRIPTION
As part of services shutdown, we're deleting cinder services from database.
For that, we need them to be stopped everywhere.

Also, we need until this step finishes before continuing with next steps.