### PR TITLE
[3.0] proposal: Fix wrong return on proposal reset (bsc#1014835)

### DIFF
--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -248,7 +248,7 @@ en:
       unknown_remotes: 'Unable to find any cluster with remote nodes named'
       unsaved_changes: 'You might have unsaved changes; do you really want to switch to another page?'
       proposal_reset: 'Failed to save proposal reset state'
-      nodes_reset: 'Failed to reset all related nodes'
+      nodes_reset: 'Failed to reset nodes: %{nodes}'
 
   docs:
     index:


### PR DESCRIPTION
The barclamp controller expects an array as return value.

(cherry picked from commit c9298fc6197a8a84d7c6e2c01e51db0d7048f5b0)

Backport of #885 