### PR TITLE
upgrade: Remove the indication of previous script failure

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-post-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-post-upgrade.sh.erb
@@ -12,6 +12,7 @@ echo "Executing $BASH_SOURCE"
 set -x
 
 mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-post-upgrade-failed
 
 if [[ -f $UPGRADEDIR/crowbar-post-upgrade-ok ]] ; then
     echo "Post upgrade actions were already successfully executed"

--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -12,6 +12,7 @@ echo "Executing $BASH_SOURCE"
 set -x
 
 mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-pre-upgrade-failed
 
 if [[ -f $UPGRADEDIR/crowbar-pre-upgrade-ok ]] ; then
     echo "Pre upgrade actions were already successfully executed"

--- a/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.erb
@@ -15,6 +15,11 @@ UPGRADEDIR=/var/lib/crowbar/upgrade
 RUNDIR=/var/run/crowbar/
 RUNFILE=$RUNDIR/node-upgrading
 
+mkdir -p $UPGRADEDIR
+mkdir -p $RUNDIR
+
+rm -f $UPGRADEDIR/crowbar-upgrade-os-failed
+
 cleanup()
 {
     echo "cleaning up after interrupt or exit"
@@ -27,9 +32,6 @@ cleanup()
 
 initiate_node_upgrade()
 {
-    mkdir -p $UPGRADEDIR
-    mkdir -p $RUNDIR
-
     if [[ -f $RUNFILE ]] ; then
         echo "Exit: Upgrade is already running..."
         exit 1


### PR DESCRIPTION
To enable running scripts again after the failure, we need
to remove failure indications when executing the script.