### PR TITLE
upgrade: Let the progress library track substeps and current node

### DIFF
--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -2,6 +2,8 @@
   "current_step": "upgrade_prechecks",
   "current_substep":null,
   "current_node":null,
+  "remaining_nodes": null,
+  "upgraded_nodes": null,
   "steps":{
     "upgrade_prechecks":{
       "status":"pending"


### PR DESCRIPTION
We need this for detailed information during the last part of upgrade,
upgrading cloud nodes.

(cherry picked from commit 6befd7c2e3bcd372fc3835a8d3e9ed3cd2bbddb9)

Backport of https://github.com/crowbar/crowbar-core/pull/897