### PR TITLE
crowbar_register: handle storage-only deploys (bsc#993475)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -500,6 +500,15 @@ node[:provisioner][:supported_oses].each do |os, arches|
                                                   target_platform_version,
                                                   arch)
 
+      # Need to know if we're doing a storage-only deploy so we can tweak
+      # crowbar_register slightly (same as in update_nodes.rb)
+      storage_available = false
+      cloud_available = false
+      repos.each do |name, repo|
+        storage_available = true if name.include? "Storage"
+        cloud_available = true if name.include? "Cloud"
+      end
+
       packages = node[:provisioner][:packages][os] || []
 
       template "#{os_dir}/crowbar_register" do
@@ -516,6 +525,7 @@ node[:provisioner][:supported_oses].each do |os, arches|
                   crowbar_key: crowbar_key,
                   domain: domain_name,
                   repos: repos,
+                  is_ses: storage_available && !cloud_available,
                   packages: packages,
                   platform: target_platform_distro,
                   target_platform_version: target_platform_version)

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -331,7 +331,7 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
       packages = node[:provisioner][:packages][os] || []
 
       # Need to know if we're doing a storage-only deploy so we can tweak
-      # the autoyast profile slightly
+      # the autoyast profile slightly (same as in setup_base_images.rb)
       storage_available = false
       cloud_available = false
       repos.each do |name, repo|

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -82,7 +82,7 @@ if test -n "$SSH_CONNECTION" -a -z "$STY"; then
 fi
 
 if test $CROWBAR_FORCE -ne 1; then
-    echo    "Running this tool will alter the system for integration with SUSE OpenStack Cloud."
+    echo    "Running this tool will alter the system for integration with Crowbar."
     echo -n "Continue? [y/N]: "
     read ANSWER
     if test "x$ANSWER" != xy -a "x$ANSWER" != xY; then
@@ -324,7 +324,11 @@ zypper --non-interactive install -t pattern $PATTERNS_INSTALL
 <% if @platform == "suse" && @target_platform_version.to_f < 12.0 -%>
 zypper --non-interactive install --auto-agree-with-licenses suse-sle11-openstack-cloud-release
 <% elsif @platform == "suse" && @target_platform_version.to_f >= 12.1 -%>
+<% if @is_ses -%>
+zypper --non-interactive install --auto-agree-with-licenses ses-release supportutils-plugin-ses
+<% else -%>
 zypper --non-interactive install --auto-agree-with-licenses suse-openstack-cloud-release supportutils-plugin-suse-openstack-cloud
+<% end -%>
 <% end -%>
 zypper --non-interactive install $PACKAGES_INSTALL<%= " '#{@packages.join("' '")}'" unless @packages.empty? %>
 


### PR DESCRIPTION
For SES-only deploys, install ses-release instead of
suse-openstack-cloud-release.  Also, make the messaging slightly
more generic.

Signed-off-by: Tim Serong <tserong@suse.com>