### PR TITLE
upgrade: Reset the errors hash once the step was started

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -99,6 +99,7 @@ module Crowbar
         end
         progress[:current_step] = step_name
         progress[:steps][step_name][:status] = :running
+        progress[:steps][step_name][:errors] = {}
         save
       end
     end


### PR DESCRIPTION
After the failure, the step could be started again. While
it is in the 'running' state, there's no point in showing
the errors from the previous execution.