### PR TITLE
upgrade: don't lock the progress file when reading only the status

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -20,7 +20,11 @@ module Api
   class Upgrade < Tableless
     class << self
       def status
-        ::Crowbar::UpgradeStatus.new.progress
+        ::Crowbar::UpgradeStatus.new(
+          Rails.logger,
+          "/var/lib/crowbar/upgrade/6-to-7-progress.yml",
+          false
+        ).progress
       end
 
       def checks

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -31,10 +31,12 @@ module Crowbar
     # external applications and different crowbar versions.
     def initialize(
       logger = Rails.logger,
-      yaml_file = "/var/lib/crowbar/upgrade/6-to-7-progress.yml"
+      yaml_file = "/var/lib/crowbar/upgrade/6-to-7-progress.yml",
+      lock = true
     )
       @logger = logger
       @progress_file_path = Pathname.new(yaml_file)
+      @lock = lock
       load
     end
 
@@ -65,7 +67,11 @@ module Crowbar
     end
 
     def load!
-      ::Crowbar::Lock::LocalBlocking.with_lock(shared: true, logger: @logger, path: lock_path) do
+      if @lock
+        ::Crowbar::Lock::LocalBlocking.with_lock(shared: true, logger: @logger, path: lock_path) do
+          @progress = YAML.load(progress_file_path.read)
+        end
+      else
         @progress = YAML.load(progress_file_path.read)
       end
     end


### PR DESCRIPTION
during the upgrade we will use a lot of polling to /api/upgrade
for the status, therefore we need as minimal impact/cost as
necessary