### PR TITLE
upgrade:Track the sub steps and nodes status in the progress library

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -278,28 +278,26 @@ module Api
 
       # Orchestrate the upgrade of the nodes
       def nodes
-        # check for current global status
-        # 1. TODO: return if upgrade has finished
-        # 2. TODO: find the next big step
-        next_step = "controllers"
+        # FIXME: start the 'nodes' step
 
-        if next_step == "controllers"
+        status = ::Crowbar::UpgradeStatus.new
+        substep = status.current_substep
 
-          # TODO: Save the "current_step" to global status
-          if upgrade_controller_nodes
-            # upgrading controller nodes succeeded, we can continue with computes
-            next_step = "computes"
-          else
-            # upgrading controller nodes has failed, exiting
-            # leaving next_step as "controllers", so we continue from correct point on retry
-            return false
-          end
+        if substep.nil? || substep.empty?
+          substep = "controllers"
+          status.save_substep(substep)
         end
 
-        if next_step == "computes"
-          # TODO: Save the "current_step" to global status
-          upgrade_compute_nodes
+        if substep == "controllers"
+          return false unless upgrade_controller_nodes
+          substep = "computes"
+          status.save_substep(substep)
         end
+
+        if substep == "computes"
+          return false unless upgrade_compute_nodes
+        end
+        # FIXME: mark the whole step as done
         true
       end
 

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -88,7 +88,7 @@ describe Api::UpgradeController, type: :request do
         exit_code: 0
       )
       allow(Api::Upgrade).to receive(:upgrade_controller_nodes).and_return(true)
-      allow_any_instance_of(Api::Node).to receive(:upgrade).and_return(true)
+      allow(Api::Upgrade).to receive(:upgrade_compute_nodes).and_return(true)
 
       post "/api/upgrade/nodes", {}, headers
       expect(response).to have_http_status(:ok)
@@ -101,7 +101,6 @@ describe Api::UpgradeController, type: :request do
         exit_code: 1
       )
       allow(Api::Upgrade).to receive(:upgrade_controller_nodes).and_return(false)
-      allow_any_instance_of(Api::Node).to receive(:upgrade).and_return(true)
 
       post "/api/upgrade/nodes", {}, headers
       expect(response).to have_http_status(:unprocessable_entity)

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -340,6 +340,11 @@ describe Api::Upgrade do
     it "successfully upgrades nodes with DRBD backend" do
       allow(NodeObject).to(
         receive(:find).
+        with("state:crowbar_upgrade AND NOT run_list_map:ceph_*").
+        and_return([NodeObject.find_node_by_name("testing.crowbar.com")])
+      )
+      allow(NodeObject).to(
+        receive(:find).
         with("drbd_rsc:*").
         and_return([NodeObject.find_node_by_name("testing.crowbar.com")])
       )
@@ -354,6 +359,7 @@ describe Api::Upgrade do
         "AND (roles:database-server OR roles:rabbitmq-server)").
         and_return([NodeObject.find_node_by_name("testing.crowbar.com")])
       )
+      allow_any_instance_of(Api::Node).to receive(:upgraded?).and_return(false)
       allow_any_instance_of(NodeObject).to receive(:run_ssh_cmd).and_return(
         stdout: "",
         stderr: "",
@@ -370,6 +376,7 @@ describe Api::Upgrade do
       allow_any_instance_of(Api::Node).to receive(:post_upgrade).and_return(true)
       allow_any_instance_of(Api::Node).to receive(:router_migration).and_return(true)
       allow_any_instance_of(Api::Node).to receive(:join_and_chef).and_return(true)
+      allow_any_instance_of(Api::Node).to receive(:save_node_state).and_return(true)
 
       expect(subject.class.nodes).to be true
     end


### PR DESCRIPTION
This is not extended to the upgrade of compute nodes, as relevant PR is not merged yet. I think it could be solved as a followup.