### PR TITLE
Make applying proposal slightly faster

### DIFF
--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -625,7 +625,8 @@ class BarclampController < ApplicationController
           @proposal["attributes"][params[:barclamp]] = JSON.parse(params[:proposal_attributes])
           @proposal["deployment"][params[:barclamp]] = JSON.parse(params[:proposal_deployment])
           @service_object.save_proposal!(@proposal)
-          answer = @service_object.proposal_commit(params[:name])
+          # validation already happened on save
+          answer = @service_object.proposal_commit(params[:name], validate: false, validate_after_save: false)
           flash[:alert] = answer[1] if answer[0] >= 400
           flash[:notice] = answer[1] if answer[0] >= 300 and answer[0] < 400
           flash[:notice] = t("barclamp.proposal_show.commit_proposal_success") if answer[0] == 200

--- a/crowbar_framework/app/controllers/barclamp_controller.rb
+++ b/crowbar_framework/app/controllers/barclamp_controller.rb
@@ -626,7 +626,9 @@ class BarclampController < ApplicationController
           @proposal["deployment"][params[:barclamp]] = JSON.parse(params[:proposal_deployment])
           @service_object.save_proposal!(@proposal)
           # validation already happened on save
-          answer = @service_object.proposal_commit(params[:name], validate: false, validate_after_save: false)
+          answer = @service_object.proposal_commit(params[:name],
+                                                   validate: false,
+                                                   validate_after_save: false)
           flash[:alert] = answer[1] if answer[0] >= 400
           flash[:notice] = answer[1] if answer[0] >= 300 and answer[0] < 400
           flash[:notice] = t("barclamp.proposal_show.commit_proposal_success") if answer[0] == 200

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -45,7 +45,12 @@ class CrowbarService < ServiceObject
   # Unfortunatelly we need to explicitely look at crowbar-status of the proposal
   # because apply_role from this model ignores errors from superclass's apply_role.
   def commit_and_check_proposal
-    answer = proposal_commit("default", in_queue: false, validate: false, validate_after_save: false)
+    answer = proposal_commit(
+      "default",
+      in_queue: false,
+      validate: false,
+      validate_after_save: false
+    )
     # check if error message is saved in one of the nodes
     if answer.first != 200
       found_errors = []

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -45,7 +45,7 @@ class CrowbarService < ServiceObject
   # Unfortunatelly we need to explicitely look at crowbar-status of the proposal
   # because apply_role from this model ignores errors from superclass's apply_role.
   def commit_and_check_proposal
-    answer = proposal_commit("default", false, false)
+    answer = proposal_commit("default", in_queue: false, validate_after_save: false)
     # check if error message is saved in one of the nodes
     if answer.first != 200
       found_errors = []
@@ -352,7 +352,7 @@ class CrowbarService < ServiceObject
     proposal.raw_data["deployment"]["crowbar"]["elements"]["crowbar-upgrade"] = nodes_to_upgrade
     proposal.save
     # commit the proposal so chef recipe get executed
-    proposal_commit("default", false, false)
+    proposal_commit("default", in_queue: false, validate_after_save: false)
   end
 
   def disable_non_core_proposals
@@ -454,7 +454,7 @@ class CrowbarService < ServiceObject
 
     # commit current proposal (with the crowbar-upgrade role still assigned to nodes),
     # so the recipe is executed when nodes have 'ready' state
-    proposal_commit("default", false, false)
+    proposal_commit("default", in_queue: false, validate_after_save: false)
     # now remove the nodes from upgrade role
     proposal["deployment"]["crowbar"]["elements"]["crowbar-upgrade"] = []
     proposal.save
@@ -531,7 +531,7 @@ class CrowbarService < ServiceObject
             else
               unless answer[1].include?(id)
                 @logger.debug("Crowbar apply_role: #{k}.#{id} wasn't active: Activating")
-                answer = service.proposal_commit(id, false, false)
+                answer = service.proposal_commit(id, in_queue: false, validate_after_save: false)
                 if answer[0] != 200
                   answer[1] = "Failed to commit proposal '#{id}' for '#{k}' " +
                               "(The error message was: #{answer[1].strip})"

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -45,7 +45,7 @@ class CrowbarService < ServiceObject
   # Unfortunatelly we need to explicitely look at crowbar-status of the proposal
   # because apply_role from this model ignores errors from superclass's apply_role.
   def commit_and_check_proposal
-    answer = proposal_commit("default", in_queue: false, validate_after_save: false)
+    answer = proposal_commit("default", in_queue: false, validate: false, validate_after_save: false)
     # check if error message is saved in one of the nodes
     if answer.first != 200
       found_errors = []
@@ -454,7 +454,7 @@ class CrowbarService < ServiceObject
 
     # commit current proposal (with the crowbar-upgrade role still assigned to nodes),
     # so the recipe is executed when nodes have 'ready' state
-    proposal_commit("default", in_queue: false, validate_after_save: false)
+    proposal_commit("default", in_queue: false, validate: false, validate_after_save: false)
     # now remove the nodes from upgrade role
     proposal["deployment"]["crowbar"]["elements"]["crowbar-upgrade"] = []
     proposal.save

--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -122,8 +122,10 @@ class NetworkService < ServiceObject
 
     if type == :node
       # Save the information.
-      node.crowbar["crowbar"]["network"][network] = net_info
-      node.save
+      if node.crowbar["crowbar"]["network"][network] != net_info
+        node.crowbar["crowbar"]["network"][network] = net_info
+        node.save
+      end
     end
 
     @logger.info("Network allocate ip for #{type}: Assigned: #{name} #{network} #{range} #{net_info["address"]}")

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -547,7 +547,12 @@ class ServiceObject
   # XXX: this is where proposal gets copied into a role, scheduling / ops order
   # is computed (in apply_role) and chef client gets called on the nodes.
   # Hopefully, this will get moved into a background job.
-  def proposal_commit(inst, in_queue = false, validate_after_save = true)
+  def proposal_commit(inst, options = {})
+    options.reverse_merge!(
+      in_queue: false,
+      validate_after_save: true
+    )
+
     prop = Proposal.where(barclamp: @bc_name, name: inst).first
 
     if prop.nil?
@@ -559,8 +564,8 @@ class ServiceObject
       begin
         # Put mark on the wall
         prop["deployment"][@bc_name]["crowbar-committing"] = true
-        save_proposal!(prop, validate_after_save: validate_after_save)
-        response = active_update(prop.raw_data, inst, in_queue)
+        save_proposal!(prop, validate_after_save: options[:validate_after_save])
+        response = active_update(prop.raw_data, inst, options[:in_queue])
       rescue Chef::Exceptions::ValidationFailed => e
         @logger.error ([e.message] + e.backtrace).join("\n")
         response = [400, "Failed to validate proposal: #{e.message}"]

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -565,7 +565,9 @@ class ServiceObject
       begin
         # Put mark on the wall
         prop["deployment"][@bc_name]["crowbar-committing"] = true
-        save_proposal!(prop, validate: options[:validate], validate_after_save: options[:validate_after_save])
+        save_proposal!(prop,
+                       validate: options[:validate],
+                       validate_after_save: options[:validate_after_save])
         response = active_update(prop.raw_data, inst, options[:in_queue])
       rescue Chef::Exceptions::ValidationFailed => e
         @logger.error ([e.message] + e.backtrace).join("\n")

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -535,10 +535,10 @@ class ServiceObject
   # FIXME: most of these can be validations on the model itself,
   # preferrably refactored into Validator classes.
   def save_proposal!(prop, options = {})
-    options.reverse_merge!(validate_after_save: true)
+    options.reverse_merge!(validate: true, validate_after_save: true)
     clean_proposal(prop.raw_data)
-    validate_proposal(prop.raw_data)
-    validate_proposal_elements(prop.elements)
+    validate_proposal(prop.raw_data) if options[:validate]
+    validate_proposal_elements(prop.elements) if options[:validate]
     prop.latest_applied = false
     prop.save
     validate_proposal_after_save(prop.raw_data) if options[:validate_after_save]
@@ -550,6 +550,7 @@ class ServiceObject
   def proposal_commit(inst, options = {})
     options.reverse_merge!(
       in_queue: false,
+      validate: true,
       validate_after_save: true
     )
 
@@ -564,7 +565,7 @@ class ServiceObject
       begin
         # Put mark on the wall
         prop["deployment"][@bc_name]["crowbar-committing"] = true
-        save_proposal!(prop, validate_after_save: options[:validate_after_save])
+        save_proposal!(prop, validate: options[:validate], validate_after_save: options[:validate_after_save])
         response = active_update(prop.raw_data, inst, options[:in_queue])
       rescue Chef::Exceptions::ValidationFailed => e
         @logger.error ([e.message] + e.backtrace).join("\n")

--- a/crowbar_framework/lib/crowbar/deployment_queue.rb
+++ b/crowbar_framework/lib/crowbar/deployment_queue.rb
@@ -202,8 +202,7 @@ module Crowbar
       service = eval("#{bc.camelize}Service.new logger")
 
       # This will call apply_role and chef-client.
-      # Params: (inst, in_queue, validate_after_save)
-      status, message = service.proposal_commit(inst, true, false)
+      status, message = service.proposal_commit(inst, in_queue: true, validate_after_save: false)
 
       logger.debug("process queue: committed item #{bc}:#{inst}: results = #{message.inspect}")
 

--- a/crowbar_framework/lib/crowbar/deployment_queue.rb
+++ b/crowbar_framework/lib/crowbar/deployment_queue.rb
@@ -202,7 +202,12 @@ module Crowbar
       service = eval("#{bc.camelize}Service.new logger")
 
       # This will call apply_role and chef-client.
-      status, message = service.proposal_commit(inst, in_queue: true, validate: false, validate_after_save: false)
+      status, message = service.proposal_commit(
+        inst,
+        in_queue: true,
+        validate: false,
+        validate_after_save: false
+      )
 
       logger.debug("process queue: committed item #{bc}:#{inst}: results = #{message.inspect}")
 

--- a/crowbar_framework/lib/crowbar/deployment_queue.rb
+++ b/crowbar_framework/lib/crowbar/deployment_queue.rb
@@ -202,7 +202,7 @@ module Crowbar
       service = eval("#{bc.camelize}Service.new logger")
 
       # This will call apply_role and chef-client.
-      status, message = service.proposal_commit(inst, in_queue: true, validate_after_save: false)
+      status, message = service.proposal_commit(inst, in_queue: true, validate: false, validate_after_save: false)
 
       logger.debug("process queue: committed item #{bc}:#{inst}: results = #{message.inspect}")
 


### PR DESCRIPTION
When there are many nodes in a proposal, things can start to be slow. Part of it can easily be avoided (by not reloading nodes all the time and skipping useless bits).

Backport of https://github.com/crowbar/crowbar-core/pull/959

(I dropped the backport of https://github.com/crowbar/crowbar-core/pull/896 as it's a bit too intrusive)