### PR TITLE
delayed_job: create a folder to store pid's

### DIFF
--- a/crowbar_framework/config/puma.rb
+++ b/crowbar_framework/config/puma.rb
@@ -41,7 +41,6 @@ on_worker_boot do
 end
 
 [
-  "tmp/pids",
   "tmp/sessions",
   "tmp/sockets",
   "tmp/cache"

--- a/crowbar_framework/tmp/pids/.gitignore
+++ b/crowbar_framework/tmp/pids/.gitignore
@@ -1,3 +1,2 @@
 *
 !.gitignore
-!/pids


### PR DESCRIPTION
this folder is usually created by puma, but it needs to be available
even before puma because delayed_job runs as a separate process