### PR TITLE
Implement (and use) a search with cached results for cookbooks

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -178,13 +178,12 @@ cluster_zone[:hosts] = Mash.new
 # As DHCP addresses can be re-used, we make sure to use the one node which is
 # the most recent; this requires two passes
 temporary_dhcp = {}
-# Get the config environment filter
-#env_filter = "dns_config_environment:#{node[:dns][:config][:environment]}"
-env_filter = "*:*" # Get all nodes for now.  This is a hack around a timing issue in ganglia.
 # Get the list of nodes
-nodes = search(:node, "#{env_filter}")
+nodes = node_search_with_cache("*:*")
+fqdns = []
 nodes.each do |n|
   n = Node.load(n.name)
+  fqdns.push(n[:fqdn])
   cname = n["crowbar"]["display"]["alias"] rescue nil
   cname = nil unless cname && ! cname.empty?
   base_name_no_net = n[:fqdn].chomp(".#{node[:dns][:domain]}")
@@ -242,8 +241,8 @@ search(:crowbar, "id:*_network").each do |network|
   next unless network.key?("allocated_by_name")
   net_name=network[:id].gsub(/_network$/, "").gsub("_","-")
   network[:allocated_by_name].each_key do |host|
-    if search(:node, "fqdn:#{host}").size > 0 or not host.match(/.#{node[:dns][:domain]}$/)
-      #this is node in crowbar terms or it not belong to our domain, so lets skip it
+    if !host.match(/.#{node[:dns][:domain]}$/) || fqdns.include?(host)
+      # this is node in crowbar terms or it not belong to our domain, so lets skip it
       next
     end
     base_name=host.chomp(".#{node[:dns][:domain]}")

--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -182,7 +182,6 @@ temporary_dhcp = {}
 nodes = node_search_with_cache("*:*")
 fqdns = []
 nodes.each do |n|
-  n = Node.load(n.name)
   fqdns.push(n[:fqdn])
   cname = n["crowbar"]["display"]["alias"] rescue nil
   cname = nil unless cname && ! cname.empty?

--- a/chef/cookbooks/logging/recipes/client.rb
+++ b/chef/cookbooks/logging/recipes/client.rb
@@ -18,8 +18,7 @@ return if node[:platform_family] == "windows"
 
 include_recipe "logging::common"
 
-env_filter = " AND environment:#{node[:logging][:config][:environment]}"
-servers = search(:node, "roles:logging\\-server#{env_filter}")
+servers = node_search_with_cache("roles:logging-server")
 
 if servers.nil?
   servers = []

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -90,7 +90,7 @@ execute "enable netfilter for bridges" do
   subscribes :run, resources(cookbook_file: "modprobe-bridge.conf"), :delayed
 end
 
-provisioner_instance = node[:provisioner][:config][:environment].gsub(/^provisioner-config-/, "") rescue "default"
+provisioner_instance = CrowbarHelper.get_proposal_instance(node, "provisioner", "default")
 provisioner = node_search_with_cache("roles:provisioner-server", provisioner_instance).first
 conduit_map = Barclamp::Inventory.build_node_map(node)
 Chef::Log.debug("Conduit mapping for this node:  #{conduit_map.inspect}")

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -90,7 +90,8 @@ execute "enable netfilter for bridges" do
   subscribes :run, resources(cookbook_file: "modprobe-bridge.conf"), :delayed
 end
 
-provisioner = search(:node, "roles:provisioner-server")[0]
+provisioner_instance = node[:provisioner][:config][:environment].gsub(/^provisioner-config-/, "") rescue "default"
+provisioner = node_search_with_cache("roles:provisioner-server", provisioner_instance).first
 conduit_map = Barclamp::Inventory.build_node_map(node)
 Chef::Log.debug("Conduit mapping for this node:  #{conduit_map.inspect}")
 route_pref = 10000

--- a/chef/cookbooks/network/recipes/switch_config.rb
+++ b/chef/cookbooks/network/recipes/switch_config.rb
@@ -50,7 +50,7 @@ admin_ip = node.address.addr
 
 switch_config={}
 
-search(:node, "*:*").each do |a_node|
+node_search_with_cache("*:*").each do |a_node|
   node_map = Chef::Recipe::Barclamp::Inventory.build_node_map(a_node)
   node_map.each do |conduit, conduit_info|
     if_list = conduit_info["if_list"]

--- a/chef/cookbooks/ntp/recipes/default.rb
+++ b/chef/cookbooks/ntp/recipes/default.rb
@@ -16,8 +16,7 @@
 #
 
 unless Chef::Config[:solo]
-  env_filter = " AND environment:#{node[:ntp][:config][:environment]}"
-  servers = search(:node, "roles:ntp\\-server#{env_filter}")
+  servers = node_search_with_cache("roles:ntp-server")
 else
   servers = []
 end

--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -220,7 +220,7 @@ if node[:platform_family] == "suse" && !node.roles.include?("provisioner-server"
   admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner_server_node, "admin").address
   web_port = provisioner_server_node[:provisioner][:web_port]
 
-  ntp_instance = node[:ntp][:config][:environment].gsub(/^ntp-config-/, "") rescue "default"
+  ntp_instance = CrowbarHelper.get_proposal_instance(node, "ntp", "default")
   ntp_servers = node_search_with_cache("roles:ntp-server", ntp_instance)
   ntp_servers_ips = ntp_servers.map { |n| Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address }
 

--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -70,7 +70,8 @@ end
 
 # Find provisioner servers and include them.
 provisioner_server_node = nil
-search(:node, "roles:provisioner-server AND provisioner_config_environment:#{node[:provisioner][:config][:environment]}") do |n|
+provisioners = node_search_with_cache("roles:provisioner-server")
+provisioners.each do |n|
   provisioner_server_node = n if provisioner_server_node.nil?
 
   pkey = n["crowbar"]["ssh"]["root_pub_key"] rescue nil
@@ -219,7 +220,8 @@ if node[:platform_family] == "suse" && !node.roles.include?("provisioner-server"
   admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner_server_node, "admin").address
   web_port = provisioner_server_node[:provisioner][:web_port]
 
-  ntp_servers = search(:node, "roles:ntp-server")
+  ntp_instance = node[:ntp][:config][:environment].gsub(/^ntp-config-/, "") rescue "default"
+  ntp_servers = node_search_with_cache("roles:ntp-server", ntp_instance)
   ntp_servers_ips = ntp_servers.map { |n| Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address }
 
   template "/usr/sbin/crowbar_join" do

--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -509,7 +509,7 @@ node[:provisioner][:supported_oses].each do |os, arches|
       # Add base OS install repo for suse
       node.set[:provisioner][:repositories][os][arch]["base"] = { "baseurl=#{admin_web}" => true }
 
-      ntp_instance = node[:ntp][:config][:environment].gsub(/^ntp-config-/, "") rescue "default"
+      ntp_instance = CrowbarHelper.get_proposal_instance(node, "ntp", "default")
       ntp_servers = node_search_with_cache("roles:ntp-server", ntp_instance)
       ntp_servers_ips = ntp_servers.map { |n| Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address }
 

--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -509,7 +509,8 @@ node[:provisioner][:supported_oses].each do |os, arches|
       # Add base OS install repo for suse
       node.set[:provisioner][:repositories][os][arch]["base"] = { "baseurl=#{admin_web}" => true }
 
-      ntp_servers = search(:node, "roles:ntp-server")
+      ntp_instance = node[:ntp][:config][:environment].gsub(/^ntp-config-/, "") rescue "default"
+      ntp_servers = node_search_with_cache("roles:ntp-server", ntp_instance)
       ntp_servers_ips = ntp_servers.map { |n| Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address }
 
       target_platform_distro = os.gsub(/-.*$/, "")

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -43,7 +43,7 @@ uefi_subdir = "efi"
 
 use_elilo = node[:platform_family] != "suse" || (node[:platform] == "suse" && node["platform_version"].to_f < 12.0)
 
-nodes = search(:node, "*:*")
+nodes = node_search_with_cache("*:*")
 if not nodes.nil? and not nodes.empty?
   nodes.map{ |n|Node.load(n.name) }.each do |mnode|
     next if mnode[:state].nil?

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -45,7 +45,7 @@ use_elilo = node[:platform_family] != "suse" || (node[:platform] == "suse" && no
 
 nodes = node_search_with_cache("*:*")
 if not nodes.nil? and not nodes.empty?
-  nodes.map{ |n|Node.load(n.name) }.each do |mnode|
+  nodes.each do |mnode|
     next if mnode[:state].nil?
 
     new_group = states[mnode[:state]]

--- a/chef/cookbooks/repos/recipes/default.rb
+++ b/chef/cookbooks/repos/recipes/default.rb
@@ -15,8 +15,8 @@
 
 return if node[:platform_family] == "suse" || node[:platform_family] == "windows"
 
-# the attribute always exist as this is run as part of the provisioner-base role
-provisioner_instance = node[:provisioner][:config][:environment].gsub(/^provisioner-config-/, "")
+# no need to have a fallback as this recipe is run as part of the provisioner-base role
+provisioner_instance = CrowbarHelper.get_proposal_instance(node, "provisioner")
 provisioners = node_search_with_cache("roles:provisioner-server", provisioner_instance)
 provisioner = provisioners.first if provisioners
 

--- a/chef/cookbooks/repos/recipes/default.rb
+++ b/chef/cookbooks/repos/recipes/default.rb
@@ -15,8 +15,11 @@
 
 return if node[:platform_family] == "suse" || node[:platform_family] == "windows"
 
-provisioners = search(:node, "roles:provisioner-server")
-provisioner = provisioners[0] if provisioners
+# the attribute always exist as this is run as part of the provisioner-base role
+provisioner_instance = node[:provisioner][:config][:environment].gsub(/^provisioner-config-/, "")
+provisioners = node_search_with_cache("roles:provisioner-server", provisioner_instance)
+provisioner = provisioners.first if provisioners
+
 os_token = "#{node[:platform]}-#{node[:platform_version]}"
 arch = node[:kernel][:machine]
 

--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -18,8 +18,8 @@
 # limitations under the License.
 #
 
-env_filter = " AND dns_config_environment:#{node[:dns][:config][:environment]}"
-nodes = search(:node, "roles:dns-server#{env_filter}")
+dns_instance = node[:dns][:config][:environment].gsub(/^dns-config-/, "")
+nodes = node_search_with_cache("roles:dns-server", dns_instance)
 
 dns_list = []
 if !nodes.nil? and !nodes.empty?

--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-dns_instance = node[:dns][:config][:environment].gsub(/^dns-config-/, "")
+dns_instance = CrowbarHelper.get_proposal_instance(node, "dns")
 nodes = node_search_with_cache("roles:dns-server", dns_instance)
 
 dns_list = []

--- a/chef/cookbooks/utils/libraries/helpers.rb
+++ b/chef/cookbooks/utils/libraries/helpers.rb
@@ -73,4 +73,13 @@ module CrowbarHelper
     states = ["ready", "readying", "recovering", "applying"]
     not states.include?(node[:state])
   end
+
+  def self.get_proposal_instance(node, barclamp, fallback = nil)
+    env = node.fetch(barclamp, {}).fetch(:config, {})[:environment]
+    if env.nil?
+      fallback
+    else
+      env.gsub(/^#{barclamp}-config-/, "")
+    end
+  end
 end

--- a/chef/cookbooks/utils/libraries/search.rb
+++ b/chef/cookbooks/utils/libraries/search.rb
@@ -56,7 +56,7 @@ class Chef
     def crowbar_filter_env(query)
       # All cookbooks encode the barclamp name as the role name prefix, thus we can
       # simply grab it from the query (e.g. BC 'keystone' for role 'keystone-server'):
-      barclamp = /^\w*:(\w*).*$/.match(query)[1]
+      barclamp = /^(roles|recipes):(\w*).*$/.match(query)[2]
 
       # There are two conventions to filter by barclamp proposal:
       #  1) Other barclamp cookbook: node[@cookbook_name][$OTHER_BC_NAME_instance]

--- a/chef/cookbooks/utils/libraries/search.rb
+++ b/chef/cookbooks/utils/libraries/search.rb
@@ -70,7 +70,8 @@ class CrowbarUtilsSearch
     def crowbar_filter_env(node, query, cookbook_name = nil, bc_instance = nil)
       # All cookbooks encode the barclamp name as the role name prefix, thus we can
       # simply grab it from the query (e.g. BC 'keystone' for role 'keystone-server'):
-      barclamp = /^(roles|recipes):(\w*).*$/.match(query)[2]
+      return nil unless query =~ /^(roles|recipes):(\w*).*$/
+      barclamp = $2
 
       # There are two conventions to filter by barclamp proposal:
       #  1) Other barclamp cookbook: node[@cookbook_name][$OTHER_BC_NAME_instance]

--- a/chef/cookbooks/utils/libraries/search.rb
+++ b/chef/cookbooks/utils/libraries/search.rb
@@ -18,19 +18,7 @@ class Chef
   class Recipe
     def search_env_filtered(type, query="*:*", sort="X_CHEF_id_CHEF_X asc",
                             start=0, rows=100, &block)
-      # All cookbooks encode the barclamp name as the role name prefix, thus we can
-      # simply grab it from the query (e.g. BC 'keystone' for role 'keystone-server'):
-      barclamp = /^\w*:(\w*).*$/.match(query)[1]
-
-      # There are two conventions to filter by barclamp proposal:
-      #  1) Other barclamp cookbook: node[@cookbook_name][$OTHER_BC_NAME_instance]
-      #  2) Same cookbook: node[@cookbook_name][:config][:environment]
-      if node[barclamp] && node[barclamp][:config] && (barclamp == cookbook_name)
-        env = node[barclamp][:config][:environment]
-      else
-        env = "#{barclamp}-config-#{node[cookbook_name]["#{barclamp}_instance"]}"
-      end
-      filtered_query = "#{query} AND #{barclamp}_config_environment:#{env}"
+      filtered_query = "#{query}#{crowbar_filter_env(query)}"
       if block
         return search(type, filtered_query, sort, start, rows, &block)
       else
@@ -47,6 +35,41 @@ class Chef
         instance = node
       end
       instance
+    end
+
+    @@node_search_cache = nil
+    @@node_search_cache_time = nil
+
+    def node_search_with_cache(query)
+      if @@node_search_cache_time != node[:ohai_time]
+        Chef::Log.info("Invalidating node search cache") if @@node_search_cache
+        @@node_search_cache = {}
+        @@node_search_cache_time = node[:ohai_time]
+      end
+
+      real_query = "#{query}#{crowbar_filter_env(query)}"
+      @@node_search_cache[real_query] ||= search(:node, real_query)
+    end
+
+    private
+
+    def crowbar_filter_env(query)
+      # All cookbooks encode the barclamp name as the role name prefix, thus we can
+      # simply grab it from the query (e.g. BC 'keystone' for role 'keystone-server'):
+      barclamp = /^\w*:(\w*).*$/.match(query)[1]
+
+      # There are two conventions to filter by barclamp proposal:
+      #  1) Other barclamp cookbook: node[@cookbook_name][$OTHER_BC_NAME_instance]
+      #  2) Same cookbook: node[@cookbook_name][:config][:environment]
+      env = if node[barclamp] && node[barclamp][:config] && (barclamp == cookbook_name)
+        node[barclamp][:config][:environment]
+      elsif !node[cookbook_name]["#{barclamp}_instance"].nil? || !node[cookbook_name]["#{barclamp}_instance"].empty?
+        "#{barclamp}-config-#{node[cookbook_name]["#{barclamp}_instance"]}"
+      end
+
+      unless env.nil?
+        " AND #{barclamp}_config_environment:#{env}"
+      end
     end
   end
 end

--- a/chef/cookbooks/uwsgi/providers/default.rb
+++ b/chef/cookbooks/uwsgi/providers/default.rb
@@ -3,7 +3,11 @@ action :enable do
   package "python-pip"
   package "python-dev"
 
-  provisioner = search(:node, "roles:provisioner-server").first
+  provisioner_instance = node[:provisioner][:config][:environment].gsub(/^provisioner-config-/, "")
+  provisioner = CrowbarUtilsSearch.node_search_with_cache(node,
+                                                          "roles:provisioner-server",
+                                                          "uwsgi",
+                                                          provisioner_instance).first
   proxy_addr = provisioner[:fqdn]
   proxy_port = provisioner[:provisioner][:web_port]
 

--- a/chef/cookbooks/uwsgi/providers/default.rb
+++ b/chef/cookbooks/uwsgi/providers/default.rb
@@ -3,7 +3,7 @@ action :enable do
   package "python-pip"
   package "python-dev"
 
-  provisioner_instance = node[:provisioner][:config][:environment].gsub(/^provisioner-config-/, "")
+  provisioner_instance = CrowbarHelper.get_proposal_instance(node, "provisioner", "default")
   provisioner = CrowbarUtilsSearch.node_search_with_cache(node,
                                                           "roles:provisioner-server",
                                                           "uwsgi",


### PR DESCRIPTION
Most of the time, we're happy with node attributes that are not older than the start of the chef-client run. So we can cache things.

Backport of https://github.com/crowbar/crowbar-core/pull/906