### PR TITLE
[3.0] gems: Allow puma ~> 2.11

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -1,6 +1,6 @@
 #
 # Copyright 2011-2013, Dell
-# Copyright 2013-2014, SUSE LINUX Products GmbH
+# Copyright 2013-2016, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ gem "rails", "~> 4.2.2"
 gem "rake", "< 12.0.0"
 gem "haml-rails", "~> 0.9.0"
 gem "sass-rails", "~> 5.0.3"
-gem "puma", "~> 2.11.3"
+gem "puma", "~> 2.11"
 gem "active_model_serializers", "~> 0.9.0"
 gem "closure-compiler", "~> 1.1.10"
 gem "dotenv", "~> 1.0.2"

--- a/crowbar_framework/config/boot.rb
+++ b/crowbar_framework/config/boot.rb
@@ -1,6 +1,6 @@
 #
 # Copyright 2011-2013, Dell
-# Copyright 2013-2014, SUSE LINUX Products GmbH
+# Copyright 2013-2016, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -36,7 +36,7 @@ else
   gem "sass-rails", version: "~> 5.0.3"
   require "sass-rails"
 
-  gem "puma", version: "~> 2.11.3"
+  gem "puma", version: "~> 2.11"
   require "puma"
 
   # general stuff


### PR DESCRIPTION
We are in the process to update puma to 2.16.0. This means that we have
to allow puma both versions for now. Once the update is completed we
have to fix the version again.

Related to #926