### PR TITLE
[3.0] upgrade: restrict cancelation of the upgrade

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -58,20 +58,36 @@ class Api::UpgradeController < ApiController
   end
 
   def cancel
-    cancel_upgrade = Api::Upgrade.cancel
-
-    if cancel_upgrade[:status] == :ok
+    if Api::Upgrade.cancel
       head :ok
     else
       render json: {
         errors: {
           cancel: {
-            data: cancel_upgrade[:message],
+            data: I18n.t("api.upgrade.cancel.failed"),
             help: I18n.t("api.upgrade.cancel.help.default")
           }
         }
-      }, status: cancel_upgrade[:status]
+      }, status: :unprocessable_entity
     end
+  rescue Crowbar::Error::UpgradeCancelError => e
+    render json: {
+      errors: {
+        cancel: {
+          data: e.message,
+          help: I18n.t("api.upgrade.cancel.help.not_allowed")
+        }
+      }
+    }, status: :locked
+  rescue StandardError => e
+    render json: {
+      errors: {
+        cancel: {
+          data: e.message,
+          help: I18n.t("api.upgrade.cancel.help.default")
+        }
+      }
+    }, status: :unprocessable_entity
   end
 
   def adminrepocheck

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -808,8 +808,10 @@ en:
         help:
           default: 'Refer to the error message in the response'
       cancel:
+        failed: 'Failed to cancel the upgrade; please look at the server logs'
         help:
           default: 'Refer to the error message in the response'
+          not_allowed: 'Not possible to cancel the upgrade process at this stage'
 
   # Global
   overview: 'Overview'

--- a/crowbar_framework/lib/crowbar/error.rb
+++ b/crowbar_framework/lib/crowbar/error.rb
@@ -1,6 +1,5 @@
 #
-# Copyright 2011-2013, Dell
-# Copyright 2013-2015, SUSE LINUX GmbH
+# Copyright 2016, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,18 +15,8 @@
 #
 
 module Crowbar
-  autoload :Backup,
-    File.expand_path("../crowbar/backup", __FILE__)
-
-  autoload :Error,
-    File.expand_path("../crowbar/error", __FILE__)
-
-  autoload :Installer,
-    File.expand_path("../installer.rb", __FILE__)
-
-  autoload :Migrate,
-    File.expand_path("../migrate.rb", __FILE__)
-
-  autoload :Upgrade,
-    File.expand_path("../upgrade.rb", __FILE__)
+  module Error
+    autoload :UpgradeCancelError,
+      File.expand_path("../error/upgrade_cancel", __FILE__)
+  end
 end

--- a/crowbar_framework/lib/crowbar/error/upgrade_cancel.rb
+++ b/crowbar_framework/lib/crowbar/error/upgrade_cancel.rb
@@ -1,6 +1,5 @@
 #
-# Copyright 2011-2013, Dell
-# Copyright 2013-2015, SUSE LINUX GmbH
+# Copyright 2016, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,18 +15,11 @@
 #
 
 module Crowbar
-  autoload :Backup,
-    File.expand_path("../crowbar/backup", __FILE__)
-
-  autoload :Error,
-    File.expand_path("../crowbar/error", __FILE__)
-
-  autoload :Installer,
-    File.expand_path("../installer.rb", __FILE__)
-
-  autoload :Migrate,
-    File.expand_path("../migrate.rb", __FILE__)
-
-  autoload :Upgrade,
-    File.expand_path("../upgrade.rb", __FILE__)
+  module Error
+    class UpgradeCancelError < StandardError
+      def initialize(step_name = "")
+        super("Not possible to cancel the upgrade at the step #{step_name}")
+      end
+    end
+  end
 end

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -138,6 +138,16 @@ module Crowbar
       current_step == upgrade_steps_6_7.last
     end
 
+    def cancel_allowed?
+      [
+        :upgrade_prechecks,
+        :upgrade_prepare,
+        :admin_backup,
+        :admin_repo_checks,
+        :admin_upgrade
+      ].include?(current_step) && !running?(:admin_upgrade)
+    end
+
     def save_current_node(node_data = {})
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
         progress[:current_node] = node_data

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -89,6 +89,12 @@ describe Api::UpgradeController, type: :request do
       allow_any_instance_of(CrowbarService).to receive(
         :revert_nodes_from_crowbar_upgrade
       ).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :initialize_state
+      ).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :cancel_allowed?
+      ).and_return(true)
 
       post "/api/upgrade/cancel", {}, headers
       expect(response).to have_http_status(:ok)

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -1,4 +1,5 @@
 require "spec_helper"
+require "crowbar/error/upgrade_cancel"
 
 describe Api::Upgrade do
   let!(:upgrade_prechecks) do
@@ -226,22 +227,91 @@ describe Api::Upgrade do
       allow_any_instance_of(CrowbarService).to receive(
         :revert_nodes_from_crowbar_upgrade
       ).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :initialize_state
+      ).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :cancel_allowed?
+      ).and_return(true)
 
-      expect(subject.class.cancel).to eq(
-        status: :ok,
-        message: ""
-      )
+      expect(subject.class.cancel).to be true
     end
 
     it "fails to cancel the upgrade" do
       allow_any_instance_of(CrowbarService).to receive(
         :revert_nodes_from_crowbar_upgrade
       ).and_raise("Some Error")
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:current_step).and_return(:database)
 
-      expect(subject.class.cancel).to eq(
-        status: :unprocessable_entity,
-        message: "Some Error"
-      )
+      expect { subject.class.cancel }.to raise_error(Crowbar::Error::UpgradeCancelError)
+    end
+
+    it "is allowed to cancel the upgrade" do
+      allow_any_instance_of(CrowbarService).to receive(
+        :revert_nodes_from_crowbar_upgrade
+      ).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :save
+      ).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :running?
+      ).with(:admin_upgrade).and_return(false)
+      [
+        :upgrade_prechecks,
+        :upgrade_prepare,
+        :admin_backup,
+        :admin_repo_checks,
+        :admin_upgrade
+      ].each do |allowed_step|
+        allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+          :current_step
+        ).and_return(allowed_step)
+
+        expect(subject.class.cancel).to be true
+      end
+    end
+
+    it "is not allowed to cancel the upgrade" do
+      allow_any_instance_of(CrowbarService).to receive(
+        :revert_nodes_from_crowbar_upgrade
+      ).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :save
+      ).and_return(true)
+      [
+        :admin_upgrade,
+        :database,
+        :nodes_repo_checks,
+        :nodes_services,
+        :nodes_db_dump,
+        :nodes_upgrade,
+        :finished
+      ].each do |allowed_step|
+        if allowed_step == :admin_upgrade
+          allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+            :running?
+          ).with(:admin_upgrade).and_return(true)
+        end
+        allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+          :current_step
+        ).and_return(allowed_step)
+
+        expect { subject.class.cancel }.to raise_error(Crowbar::Error::UpgradeCancelError)
+      end
+    end
+
+    it "is not allowed to cancel the upgrade while admin_upgrade is running" do
+      allow_any_instance_of(CrowbarService).to receive(
+        :revert_nodes_from_crowbar_upgrade
+      ).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :current_step
+      ).and_return(:admin_upgrade)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
+        :running?
+      ).and_return(true)
+
+      expect { subject.class.cancel }.to raise_error(Crowbar::Error::UpgradeCancelError)
     end
   end
 


### PR DESCRIPTION
after certain steps it shouldn't be allowed to cancel the upgrade
anymore

(cherry picked from commit 1630d09592d85a9cb0bcc028a92ac17fc95a68dc)

Backport https://github.com/crowbar/crowbar-core/pull/881