### PR TITLE
show sanity check errors in the json response

### DIFF
--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -195,7 +195,9 @@ class ApplicationController < ActionController::Base
         redirect_to sanity_path
       end
       format.json do
-        render json: { error: I18n.t("error.before_install") }, status: :unprocessable_entity
+        render json: {
+          error: Rails.cache.fetch(:sanity_check_errors)
+        }, status: :unprocessable_entity
       end
     end
   end


### PR DESCRIPTION
if you don't have an UI which lists you the sanity errors, it is very
difficult from the back end to determine what went wrong

(cherry picked from commit d80b3c12421bd91f4d0e92ee3d510806c8e4b254)

Forwardport https://github.com/crowbar/crowbar-core/pull/886