### PR TITLE
upgrade: enable ptf repo during the noderepochecks (bsc#1015827)

### DIFF
--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -175,13 +175,19 @@ module Api
         features = []
         features.push(addon)
         architectures = node_architectures
+        platform = Api::Upgrade.target_platform(platform_exception: addon)
+
+        # as the ptf repo is not registered as a feature we need to enable it manually
+        provisioner_service = ProvisionerService.new(Rails.logger)
+        architectures.values.flatten.uniq.each do |architecture|
+          provisioner_service.enable_repository(platform, architecture, "ptf")
+        end
 
         {}.tap do |ret|
           ret[addon] = {
             "available" => true,
             "repos" => {}
           }
-          platform = Api::Upgrade.target_platform(platform_exception: addon)
 
           features.each do |feature|
             if architectures[feature]

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -192,6 +192,7 @@ describe Api::UpgradeController, type: :request do
       end
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
+      allow_any_instance_of(ProvisionerService).to receive(:enable_repository).and_return(true)
 
       get "/api/upgrade/noderepocheck", {}, headers
       expect(response).to have_http_status(:ok)

--- a/crowbar_framework/spec/models/api/node_spec.rb
+++ b/crowbar_framework/spec/models/api/node_spec.rb
@@ -92,6 +92,7 @@ describe Api::Node do
           "os", "suse-12.2", "x86_64"
         ).and_return([true, {}])
       )
+      allow_any_instance_of(ProvisionerService).to receive(:enable_repository).and_return(true)
 
       os_repo_fixture = node_repocheck.tap do |k|
         k.delete("ceph")
@@ -103,6 +104,7 @@ describe Api::Node do
     end
 
     it "finds the os and addon repositories required to upgrade the nodes" do
+      allow_any_instance_of(ProvisionerService).to receive(:enable_repository).and_return(true)
       ["os", "ceph", "ha", "openstack"].each do |feature|
         allow(::Crowbar::Repository).to(
           receive(:provided_and_enabled_with_repolist).with(
@@ -119,6 +121,7 @@ describe Api::Node do
 
   context "with a failed nodes repocheck" do
     it "doesn't find the repositories required to upgrade the nodes" do
+      allow_any_instance_of(ProvisionerService).to receive(:enable_repository).and_return(true)
       expected = {}
       got = {}
 
@@ -141,6 +144,7 @@ describe Api::Node do
           "ceph", "suse-12.2", "x86_64"
         ).and_return([true, {}])
       )
+      allow_any_instance_of(ProvisionerService).to receive(:enable_repository).and_return(true)
 
       expected = node_repocheck.tap do |k|
         k.delete("os")
@@ -158,6 +162,7 @@ describe Api::Node do
           "openstack" => ["x86_64"]
         )
       )
+      allow_any_instance_of(ProvisionerService).to receive(:enable_repository).and_return(true)
 
       expected = node_repocheck.tap do |k|
         k.delete("os")

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -161,6 +161,7 @@ describe Api::Upgrade do
       end
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
+      allow_any_instance_of(ProvisionerService).to receive(:enable_repository).and_return(true)
 
       expect(subject.class.noderepocheck).to eq(os_repo_fixture)
     end
@@ -187,6 +188,7 @@ describe Api::Upgrade do
       )
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
+      allow_any_instance_of(ProvisionerService).to receive(:enable_repository).and_return(true)
 
       expected = node_repocheck.tap do |k|
         k.delete("ceph")


### PR DESCRIPTION
the ptf repo is not tracked under any feature so we need to enable
it by hand.

enabling it as a feature would not make sense as it may not be
available, and the api response would show it as missing and
make the repocheck appear as failed. Also conceptually the ptf
repo does not seem to be a feature.