### PR TITLE
[3.0] network_service: Log backtrace in error case

### DIFF
--- a/crowbar_framework/app/models/network_service.rb
+++ b/crowbar_framework/app/models/network_service.rb
@@ -112,7 +112,7 @@ class NetworkService < ServiceObject
         db.save
       end
     rescue Exception => e
-      @logger.error("Error finding address: #{e.message}")
+      @logger.error("Error finding address: Exception #{e.message} #{e.backtrace.join("\n")}")
     ensure
       lock.release
     end
@@ -208,7 +208,7 @@ class NetworkService < ServiceObject
         db.save
       end
     rescue Exception => e
-      @logger.error("Error finding address: #{e.message}")
+      @logger.error("Error finding address: Exception #{e.message} #{e.backtrace.join("\n")}")
     ensure
       lock.release
     end
@@ -381,7 +381,7 @@ class NetworkService < ServiceObject
     begin # Rescue block
       net_info = build_net_info(network, name)
     rescue Exception => e
-      @logger.error("Error finding address: #{e.message}")
+      @logger.error("Error finding address: Exception #{e.message} #{e.backtrace.join("\n")}")
     ensure
     end
 


### PR DESCRIPTION
Logging the backtrace makes it easier to debug issues like:
Error finding address: undefined method '[]' for nil:NilClass

(cherry picked from commit c60aae23aca11a18bf10dfc0438c719d0aafd7a9)