### PR TITLE
Start moving away from search queries to static config items for cookbooks

### DIFF
--- a/chef/cookbooks/barclamp/recipes/default.rb
+++ b/chef/cookbooks/barclamp/recipes/default.rb
@@ -17,3 +17,4 @@ class Chef::Recipe
   include BarclampLibrary
 end
 
+Barclamp::Config.node = node

--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -35,17 +35,12 @@ new_repos = Provisioner::Repositories.get_repos(
 )
 
 # Find out the location of the base system repository
-provisioner_instance = CrowbarHelper.get_proposal_instance(node, "provisioner", "default")
-provisioner = node_search_with_cache("roles:provisioner-server", provisioner_instance).first
-admin_ip = Barclamp::Inventory.get_network_by_type(provisioner, "admin").address
+provisioner_config = Barclamp::Config.load("core", "provisioner")
 
-web_port = provisioner[:provisioner][:web_port]
-provisioner_web = "http://#{admin_ip}:#{web_port}"
-
-web_path = "#{provisioner_web}/#{node[:platform]}-#{node[:platform_version]}/#{arch}"
+web_path = "#{provisioner_config["root_url"]}/#{node[:platform]}-#{node[:platform_version]}/#{arch}"
 old_install_url = "#{web_path}/install"
 
-web_path = "#{provisioner_web}/#{node[:target_platform]}/#{arch}"
+web_path = "#{provisioner_config["root_url"]}/#{node[:target_platform]}/#{arch}"
 new_install_url = "#{web_path}/install"
 
 # try to create an alias for new base repo from the original base repo

--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -37,10 +37,10 @@ new_repos = Provisioner::Repositories.get_repos(
 # Find out the location of the base system repository
 provisioner_config = Barclamp::Config.load("core", "provisioner")
 
-web_path = "#{provisioner_config["root_url"]}/#{node[:platform]}-#{node[:platform_version]}/#{arch}"
+web_path = "#{provisioner_config['root_url']}/#{node[:platform]}-#{node[:platform_version]}/#{arch}"
 old_install_url = "#{web_path}/install"
 
-web_path = "#{provisioner_config["root_url"]}/#{node[:target_platform]}/#{arch}"
+web_path = "#{provisioner_config['root_url']}/#{node[:target_platform]}/#{arch}"
 new_install_url = "#{web_path}/install"
 
 # try to create an alias for new base repo from the original base repo

--- a/chef/cookbooks/logging/recipes/client.rb
+++ b/chef/cookbooks/logging/recipes/client.rb
@@ -18,13 +18,8 @@ return if node[:platform_family] == "windows"
 
 include_recipe "logging::common"
 
-servers = node_search_with_cache("roles:logging-server")
-
-if servers.nil?
-  servers = []
-else
-  servers = servers.map { |x| Chef::Recipe::Barclamp::Inventory.get_network_by_type(x, "admin").address }
-end
+logging_config = Barclamp::Config.load("core", "logging")
+servers = logging_config["servers"] || []
 
 # We can't be server and client, so remove server file if we were server before
 # No restart notification, as this file can only exist if the node moves from

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -428,7 +428,7 @@ provisioner_config = Barclamp::Config.load("core", "provisioner")
 provisioner_address = provisioner_config["server"]
 
 if provisioner_address
-  Chef::Log.info("Checking we can ping #{provisioner_address}; " +
+  Chef::Log.info("Checking we can ping #{provisioner_address}; " \
                  "will wait up to 60 seconds")
   60.times do
     break if ::Kernel.system("ping -c 1 -w 1 -q #{provisioner_address} > /dev/null")

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -90,8 +90,6 @@ execute "enable netfilter for bridges" do
   subscribes :run, resources(cookbook_file: "modprobe-bridge.conf"), :delayed
 end
 
-provisioner_instance = CrowbarHelper.get_proposal_instance(node, "provisioner", "default")
-provisioner = node_search_with_cache("roles:provisioner-server", provisioner_instance).first
 conduit_map = Barclamp::Inventory.build_node_map(node)
 Chef::Log.debug("Conduit mapping for this node:  #{conduit_map.inspect}")
 route_pref = 10000
@@ -426,12 +424,17 @@ if ["delete","reset"].member?(node["state"])
 end
 
 # Wait for the administrative network to come back up.
-Chef::Log.info("Checking we can ping #{provisioner.address.addr}; " +
-               "will wait up to 60 seconds") if provisioner
-60.times do
-  break if ::Kernel.system("ping -c 1 -w 1 -q #{provisioner.address.addr} > /dev/null")
-  sleep 1
-end if provisioner
+provisioner_config = Barclamp::Config.load("core", "provisioner")
+provisioner_address = provisioner_config["server"]
+
+if provisioner_address
+  Chef::Log.info("Checking we can ping #{provisioner_address}; " +
+                 "will wait up to 60 seconds")
+  60.times do
+    break if ::Kernel.system("ping -c 1 -w 1 -q #{provisioner_address} > /dev/null")
+    sleep 1
+  end
+end
 
 node.set["crowbar_wall"] ||= Mash.new
 node.set["crowbar_wall"]["network"] ||= Mash.new

--- a/chef/cookbooks/ntp/recipes/default.rb
+++ b/chef/cookbooks/ntp/recipes/default.rb
@@ -72,10 +72,10 @@ else
     mode 0644
     source "ntp.conf.erb"
     variables(ntp_servers: ntp_servers,
-            admin_interface: local_admin_address,
-            is_server: is_server,
-            fudgevalue: 10,
-            driftfile: driftfile)
+              admin_interface: local_admin_address,
+              is_server: is_server,
+              fudgevalue: 10,
+              driftfile: driftfile)
     notifies :restart, "service[ntp]"
   end
 

--- a/chef/cookbooks/ntp/recipes/default.rb
+++ b/chef/cookbooks/ntp/recipes/default.rb
@@ -15,17 +15,17 @@
 # limitations under the License.
 #
 
+local_admin_address = Barclamp::Inventory.get_network_by_type(node, "admin").address
+
 unless Chef::Config[:solo]
-  servers = node_search_with_cache("roles:ntp-server")
+  ntp_config = Barclamp::Config.load("core", "ntp")
+  # duplicate as we may modify it later on to remove our address and to include external servers
+  ntp_servers = ntp_config["servers"].dup || []
 else
-  servers = []
+  ntp_servers = []
 end
-ntp_servers = []
-servers.each do |n|
-  next if n.name == node.name
-  n_admin_net = Barclamp::Inventory.get_network_by_type(n, "admin")
-  ntp_servers.push n_admin_net.address
-end
+
+ntp_servers.reject! { |n| n == local_admin_address }
 if node["roles"].include?("ntp-server")
   ntp_servers += node[:ntp][:external_servers]
   is_server = true
@@ -66,15 +66,13 @@ else
 
   user "ntp"
 
-  admin_interface = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
-
   template "/etc/ntp.conf" do
     owner "root"
     group "root"
     mode 0644
     source "ntp.conf.erb"
     variables(ntp_servers: ntp_servers,
-            admin_interface: admin_interface,
+            admin_interface: local_admin_address,
             is_server: is_server,
             fudgevalue: 10,
             driftfile: driftfile)

--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -220,9 +220,8 @@ if node[:platform_family] == "suse" && !node.roles.include?("provisioner-server"
   admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner_server_node, "admin").address
   web_port = provisioner_server_node[:provisioner][:web_port]
 
-  ntp_instance = CrowbarHelper.get_proposal_instance(node, "ntp", "default")
-  ntp_servers = node_search_with_cache("roles:ntp-server", ntp_instance)
-  ntp_servers_ips = ntp_servers.map { |n| Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address }
+  ntp_config = Barclamp::Config.load("core", "ntp")
+  ntp_servers = ntp_config["servers"] || []
 
   template "/usr/sbin/crowbar_join" do
     mode 0o755
@@ -231,7 +230,7 @@ if node[:platform_family] == "suse" && !node.roles.include?("provisioner-server"
     source "crowbar_join.suse.sh.erb"
     variables(admin_ip: admin_ip,
               web_port: web_port,
-              ntp_servers_ips: ntp_servers_ips,
+              ntp_servers_ips: ntp_servers,
               target_platform_version: node["platform_version"] )
   end
 

--- a/chef/cookbooks/provisioner/recipes/dhcp_update.rb
+++ b/chef/cookbooks/provisioner/recipes/dhcp_update.rb
@@ -1,12 +1,8 @@
 admin_ip = Barclamp::Inventory.get_network_by_type(node, "admin").address
 
-dns_instance = CrowbarHelper.get_proposal_instance(node, "dns", "default")
-dns_servers = node_search_with_cache("roles:dns-server", dns_instance).map do |n|
-  Barclamp::Inventory.get_network_by_type(n, "admin").address
-end
-dns_servers.sort!
-dns_servers.concat(node[:dns][:nameservers]) unless node[:dns].nil?
-dns_servers = admin_ip if dns_servers.empty?
+dns_config = Barclamp::Config.load("core", "dns")
+dns_servers = dns_config["servers"] || []
+dns_servers = [admin_ip] if dns_servers.empty?
 
 domain_name = node[:dns].nil? ? node[:domain] : (node[:dns][:domain] || node[:domain])
 

--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -477,9 +477,8 @@ node[:provisioner][:supported_oses].each do |os, arches|
       # Add base OS install repo for suse
       node.set[:provisioner][:repositories][os][arch]["base"] = { "baseurl=#{install_url}" => true }
 
-      ntp_instance = CrowbarHelper.get_proposal_instance(node, "ntp", "default")
-      ntp_servers = node_search_with_cache("roles:ntp-server", ntp_instance)
-      ntp_servers_ips = ntp_servers.map { |n| Chef::Recipe::Barclamp::Inventory.get_network_by_type(n, "admin").address }
+      ntp_config = Barclamp::Config.load("core", "ntp")
+      ntp_servers = ntp_config["servers"] || []
 
       target_platform_distro = os.gsub(/-.*$/, "")
       target_platform_version = os.gsub(/^.*-/, "")
@@ -491,7 +490,7 @@ node[:provisioner][:supported_oses].each do |os, arches|
         source "crowbar_join.suse.sh.erb"
         variables(admin_ip: admin_ip,
                   web_port: web_port,
-                  ntp_servers_ips: ntp_servers_ips,
+                  ntp_servers_ips: ntp_servers,
                   platform: target_platform_distro,
                   target_platform_version: target_platform_version)
       end
@@ -519,7 +518,7 @@ node[:provisioner][:supported_oses].each do |os, arches|
         variables(admin_ip: admin_ip,
                   admin_broadcast: admin_net.broadcast,
                   web_port: web_port,
-                  ntp_servers_ips: ntp_servers_ips,
+                  ntp_servers_ips: ntp_servers,
                   os: os,
                   arch: arch,
                   crowbar_key: crowbar_key,

--- a/chef/cookbooks/repos/recipes/default.rb
+++ b/chef/cookbooks/repos/recipes/default.rb
@@ -15,10 +15,15 @@
 
 return if node[:platform_family] == "suse" || node[:platform_family] == "windows"
 
+# we still need to search for the provisioner node to get access to the
+# repositories, which are attributes set from the cookbook
+
 # no need to have a fallback as this recipe is run as part of the provisioner-base role
 provisioner_instance = CrowbarHelper.get_proposal_instance(node, "provisioner")
 provisioners = node_search_with_cache("roles:provisioner-server", provisioner_instance)
 provisioner = provisioners.first if provisioners
+
+provisioner_config = Barclamp::Config.load("core", "provisioner")
 
 os_token = "#{node[:platform]}-#{node[:platform_version]}"
 arch = node[:kernel][:machine]
@@ -27,10 +32,7 @@ file "/tmp/.repo_update" do
   action :nothing
 end
 
-if provisioner and !CrowbarHelper.in_sledgehammer?(node)
-  web_port = provisioner["provisioner"]["web_port"]
-  address = Chef::Recipe::Barclamp::Inventory.get_network_by_type(provisioner, "admin").address
-
+if provisioner && !provisioner_config.empty? && !CrowbarHelper.in_sledgehammer?(node)
   case node[:platform_family]
   when "debian"
     repositories = provisioner["provisioner"]["repositories"][os_token][arch]
@@ -86,7 +88,7 @@ if provisioner and !CrowbarHelper.in_sledgehammer?(node)
 
   if node[:platform_family] != "suse" && node[:platform_family] != "windows"
     template "/etc/gemrc" do
-      variables(admin_ip: address, web_port: web_port)
+      variables(root_url: provisioner_config["root_url"])
       mode "0644"
     end
   end

--- a/chef/cookbooks/repos/templates/default/gemrc.erb
+++ b/chef/cookbooks/repos/templates/default/gemrc.erb
@@ -1,3 +1,3 @@
 :sources:
-- http://<%=@admin_ip%>:<%=@web_port%>/gemsite/
+- <%= @root_url %>/gemsite/
 gem: --no-ri --no-rdoc --bindir /usr/local/bin

--- a/chef/cookbooks/uwsgi/providers/default.rb
+++ b/chef/cookbooks/uwsgi/providers/default.rb
@@ -4,7 +4,7 @@ action :enable do
   package "python-dev"
 
   provisioner_config = BarclampLibrary::Barclamp::Config.load("core", "provisioner")
-  index_url = "#{provisioner_config["root_url"]}/files/pip_cache/simple/"
+  index_url = "#{provisioner_config['root_url']}/files/pip_cache/simple/"
 
   execute "pip install --index-url #{index_url} uwsgi" do
     not_if "pip freeze 2>&1 | grep -i uwsgi"

--- a/chef/cookbooks/uwsgi/providers/default.rb
+++ b/chef/cookbooks/uwsgi/providers/default.rb
@@ -4,8 +4,9 @@ action :enable do
   package "python-dev"
 
   provisioner_config = BarclampLibrary::Barclamp::Config.load("core", "provisioner")
+  index_url = "#{provisioner_config["root_url"]}/files/pip_cache/simple/"
 
-  execute "pip install --index-url #{provisioner_config["root_url"]}/files/pip_cache/simple/ uwsgi" do
+  execute "pip install --index-url #{index_url} uwsgi" do
     not_if "pip freeze 2>&1 | grep -i uwsgi"
   end
 

--- a/chef/cookbooks/uwsgi/providers/default.rb
+++ b/chef/cookbooks/uwsgi/providers/default.rb
@@ -3,15 +3,9 @@ action :enable do
   package "python-pip"
   package "python-dev"
 
-  provisioner_instance = CrowbarHelper.get_proposal_instance(node, "provisioner", "default")
-  provisioner = CrowbarUtilsSearch.node_search_with_cache(node,
-                                                          "roles:provisioner-server",
-                                                          "uwsgi",
-                                                          provisioner_instance).first
-  proxy_addr = provisioner[:fqdn]
-  proxy_port = provisioner[:provisioner][:web_port]
+  provisioner_config = BarclampLibrary::Barclamp::Config.load("core", "provisioner")
 
-  execute "pip install --index-url http://#{proxy_addr}:#{proxy_port}/files/pip_cache/simple/ uwsgi" do
+  execute "pip install --index-url #{provisioner_config["root_url"]}/files/pip_cache/simple/ uwsgi" do
     not_if "pip freeze 2>&1 | grep -i uwsgi"
   end
 

--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -147,7 +147,15 @@ class DnsService < ServiceObject
         server_nodes = server_nodes_names.map { |n| NodeObject.find_node_by_name n }
       end
 
-      addresses = server_nodes.map { |n| n.get_network_by_type("admin")["address"] }.sort
+      addresses = server_nodes.map do |n|
+        admin_net = n.get_network_by_type("admin")
+        # admin_net may be nil in the bootstrap case, because admin server only
+        # gets its IP on hardware-installing, which is after this is first
+        # called
+        admin_net["address"] unless admin_net.nil?
+      end
+      addresses.sort!.compact!
+
       addresses.concat(role.default_attributes["dns"]["nameservers"] || [])
       addresses = addresses.flatten.compact
 

--- a/crowbar_framework/app/models/logging_service.rb
+++ b/crowbar_framework/app/models/logging_service.rb
@@ -86,7 +86,14 @@ class LoggingService < ServiceObject
       server_nodes_names = role.override_attributes["logging"]["elements"]["logging-server"]
       server_nodes = server_nodes_names.map { |n| NodeObject.find_node_by_name n }
 
-      addresses = server_nodes.map { |n| n.get_network_by_type("admin")["address"] }.sort
+      addresses = server_nodes.map do |n|
+        admin_net = n.get_network_by_type("admin")
+        # admin_net may be nil in the bootstrap case, because admin server only
+        # gets its IP on hardware-installing, which is after this is first
+        # called
+        admin_net["address"] unless admin_net.nil?
+      end
+      addresses.sort!.compact!
 
       config = { servers: addresses }
     end

--- a/crowbar_framework/app/models/logging_service.rb
+++ b/crowbar_framework/app/models/logging_service.rb
@@ -70,5 +70,28 @@ class LoggingService < ServiceObject
     @logger.debug("Logging transition: leaving: #{name} for #{state}")
     [200, { name: name }]
   end
-end
 
+  def apply_role_pre_chef_call(old_role, role, all_nodes)
+    @logger.debug("Logging apply_role_pre_chef_call: entering #{all_nodes.inspect}")
+
+    save_config_to_databag(old_role, role)
+
+    @logger.debug("Logging apply_role_pre_chef_call: leaving")
+  end
+
+  def save_config_to_databag(old_role, role)
+    if role.nil?
+      config = nil
+    else
+      server_nodes_names = role.override_attributes["logging"]["elements"]["logging-server"]
+      server_nodes = server_nodes_names.map { |n| NodeObject.find_node_by_name n }
+
+      addresses = server_nodes.map { |n| n.get_network_by_type("admin")["address"] }.sort
+
+      config = { servers: addresses }
+    end
+
+    instance = Crowbar::DataBagConfig.instance_from_role(old_role, role)
+    Crowbar::DataBagConfig.save("core", instance, @bc_name, config)
+  end
+end

--- a/crowbar_framework/app/models/ntp_service.rb
+++ b/crowbar_framework/app/models/ntp_service.rb
@@ -86,7 +86,14 @@ class NtpService < ServiceObject
       server_nodes_names = role.override_attributes["ntp"]["elements"]["ntp-server"]
       server_nodes = server_nodes_names.map { |n| NodeObject.find_node_by_name n }
 
-      addresses = server_nodes.map { |n| n.get_network_by_type("admin")["address"] }.sort
+      addresses = server_nodes.map do |n|
+        admin_net = n.get_network_by_type("admin")
+        # admin_net may be nil in the bootstrap case, because admin server only
+        # gets its IP on hardware-installing, which is after this is first
+        # called
+        admin_net["address"] unless admin_net.nil?
+      end
+      addresses.sort!.compact!
 
       config = { servers: addresses }
     end

--- a/crowbar_framework/app/models/provisioner_service.rb
+++ b/crowbar_framework/app/models/provisioner_service.rb
@@ -144,9 +144,17 @@ class ProvisionerService < ServiceObject
     else
       server_nodes_names = role.override_attributes["provisioner"]["elements"]["provisioner-server"]
       server_node = NodeObject.find_node_by_name(server_nodes_names.first)
+      admin_net = server_node.get_network_by_type("admin")
 
       protocol = "http"
-      server_address = server_node.get_network_by_type("admin")["address"]
+      server_address = if admin_net.nil?
+        # admin_net may be nil in the bootstrap case, because admin server only
+        # gets its IP on hardware-installing, which is after this is first
+        # called
+        "127.0.0.1"
+      else
+        server_node.get_network_by_type("admin")["address"]
+      end
       port = role.default_attributes["provisioner"]["web_port"]
       url = "#{protocol}://#{server_address}:#{port}"
 

--- a/crowbar_framework/lib/crowbar/data_bag_config.rb
+++ b/crowbar_framework/lib/crowbar/data_bag_config.rb
@@ -1,0 +1,71 @@
+#
+# Copyright 2016, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  class DataBagConfig
+    class << self
+      def instance_from_role(old_role, role)
+        if (role || old_role).nil?
+          "default"
+        else
+          (role || old_role).inst
+        end
+      end
+
+      def save(group, instance, barclamp, config)
+        with_lock "config-#{group}" do
+          data_bag_item = databag_config(group)
+          data_bag_item[instance] ||= {}
+          if data_bag_item[instance][barclamp] != config
+            if config.nil?
+              data_bag_item[instance].delete(barclamp)
+            else
+              data_bag_item[instance][barclamp] = config
+            end
+            data_bag_item.save
+          end
+        end
+      end
+
+      private
+
+      def databag_config(group)
+        data_bag_name = "crowbar-config"
+
+        ::Chef::DataBagItem.load(data_bag_name, group)
+      rescue Net::HTTPServerException
+        begin
+          ::Chef::DataBag.load(data_bag_name)
+        rescue Net::HTTPServerException
+          db = ::Chef::DataBag.new
+          db.name data_bag_name
+          db.save
+        end
+
+        item = ::Chef::DataBagItem.new
+        item.data_bag data_bag_name
+        item["id"] = group
+        item
+      end
+
+      def with_lock(name)
+        Crowbar::Lock::LocalBlocking.new(name: name).with_lock do
+          yield
+        end
+      end
+    end
+  end
+end

--- a/crowbar_framework/lib/crowbar/data_bag_config.rb
+++ b/crowbar_framework/lib/crowbar/data_bag_config.rb
@@ -40,6 +40,11 @@ module Crowbar
         end
       end
 
+      def load(group, instance, barclamp)
+        data_bag_item = databag_config(group)
+        data_bag_item.fetch(instance, {}).fetch(barclamp, {})
+      end
+
       private
 
       def databag_config(group)


### PR DESCRIPTION
The static config items are actually data bag items (for now).

The main benefits are:

- performance improvement (as a search query can be expensive)
- going in the direction of not depending on centralized chef-server
- in some cases, simplification of the cookbooks

The rake task will be used from barclamp_install.rb so that the config items get regenerated when the code is updated (so that there's no need to reapply a barclamp to get an up-to-date config item with the new fields).

~~Marking as WIP as I'd like to gather feedback; but this seems to work quite well.~~