### PR TITLE
upgrade: after failure and restart of failed step, continue from the same point

### DIFF
--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -102,6 +102,12 @@ module Api
 
     # Reboot the node and wait until it comes back online
     def reboot_and_wait
+      rebooted_file = "/var/lib/crowbar/upgrade/crowbar-node-rebooted-ok"
+      if @node.file_exist? rebooted_file
+        Rails.logger.info("Node was already rebooted after the package upgrade.")
+        return true
+      end
+
       ssh_status = @node.ssh_cmd("/sbin/reboot")
       if ssh_status[0] != 200
         raise_upgrade_error("Failed to reboot the machine. Could not ssh.")
@@ -109,6 +115,7 @@ module Api
 
       wait_for_ssh_state(:down, "reboot")
       wait_for_ssh_state(:up, "come up")
+      @node.run_ssh_cmd("touch #{rebooted_file}")
     end
 
     def upgraded?

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -118,10 +118,6 @@ module Api
       @node.run_ssh_cmd("touch #{rebooted_file}")
     end
 
-    def upgraded?
-      @node.file_exist? "/var/lib/crowbar/upgrade/node-upgraded-ok"
-    end
-
     # Do the complete package upgrade of one node
     def upgrade
       prepare_repositories

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -343,13 +343,11 @@ module Api
         drbd_nodes = ::Node.find("drbd_rsc:*")
         return upgrade_drbd_clusters unless drbd_nodes.empty?
 
-        founder = ::Node.find(
-          "state:crowbar_upgrade AND pacemaker_founder:true"
-        ).first
+        founder = ::Node.find("pacemaker_founder:true").first
         cluster_env = founder[:pacemaker][:config][:environment]
 
         non_founder = ::Node.find(
-          "state:crowbar_upgrade AND pacemaker_founder:false AND " \
+          "pacemaker_founder:false AND " \
           "pacemaker_config_environment:#{cluster_env}"
         ).first
 
@@ -357,7 +355,7 @@ module Api
 
         # upgrade the rest of nodes in the same cluster
         ::Node.find(
-          "state:crowbar_upgrade AND pacemaker_config_environment:#{cluster_env}"
+          "pacemaker_config_environment:#{cluster_env}"
         ).each do |node|
           upgrade_next_cluster_node node.name, founder.name
         end
@@ -411,7 +409,7 @@ module Api
 
       def upgrade_drbd_clusters
         ::Node.find(
-          "state:crowbar_upgrade AND pacemaker_founder:true"
+          "pacemaker_founder:true AND drbd_rsc:*"
         ).each do |founder|
           cluster_env = founder[:pacemaker][:config][:environment]
           upgrade_drbd_cluster cluster_env
@@ -423,7 +421,6 @@ module Api
                            "in cluster \"#{cluster}\"")
 
         drbd_nodes = ::Node.find(
-          "state:crowbar_upgrade AND "\
           "pacemaker_config_environment:#{cluster} AND " \
           "(roles:database-server OR roles:rabbitmq-server)"
         )

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -912,7 +912,7 @@ class Node < ChefObject
         end
       end
     rescue Timeout::Error
-      raise "Possible error during execution of #{script}." \
+      raise "Possible error during execution of #{script} at #{@node.name}. " \
             "Action did not finish after #{seconds} seconds."
     end
   end

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -363,7 +363,8 @@ describe Api::Upgrade do
         "AND (roles:database-server OR roles:rabbitmq-server)").
         and_return([drbd_master, drbd_slave])
       )
-      allow_any_instance_of(Api::Node).to receive(:upgraded?).and_return(false)
+      allow_any_instance_of(Node).to receive(:upgraded?).and_return(false)
+      allow_any_instance_of(Node).to receive(:upgrading?).and_return(false)
 
       allow(drbd_slave).to receive(:run_ssh_cmd).and_return(
         stdout: "",

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -354,14 +354,13 @@ describe Api::Upgrade do
       )
       allow(Node).to(
         receive(:find).
-        with("state:crowbar_upgrade AND pacemaker_founder:true").
+        with("pacemaker_founder:true AND drbd_rsc:*").
         and_return([Node.find_node_by_name("testing.crowbar.com")])
       )
       allow(Node).to(
         receive(:find).
-        with("state:crowbar_upgrade AND "\
-             "pacemaker_config_environment:data AND " \
-             "(roles:database-server OR roles:rabbitmq-server)").
+        with("pacemaker_config_environment:data "\
+        "AND (roles:database-server OR roles:rabbitmq-server)").
         and_return([drbd_master, drbd_slave])
       )
       allow_any_instance_of(Api::Node).to receive(:upgraded?).and_return(false)


### PR DESCRIPTION
- for DRBD - slave node gets changed, so if first node upgrade failed, next attempt will pick the other one as first ... this means e.g. that router migration will be done again, but from another node... - should be fixed by 4th commit

- most of the upgrade scripts are skipped when there's attempt to run them second time, but `reboot_and_wait` is not ... and after reboot, who starts the pacemaker if initial crowbar_join was already done (and thus is now skipped?) - should be fixed by 3rd commit 