### PR TITLE
[upgrade] Use block-migration when needed

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -122,12 +122,17 @@ Barclamp::Inventory.list_networks(node).each do |network|
   bridges_to_reset << network.bridge_name
 end
 
+nova = search(:node, "run_list_map:nova-controller").first
+
 template "/usr/sbin/crowbar-evacuate-host.sh" do
   source "crowbar-evacuate-host.sh.erb"
   mode "0755"
   owner "root"
   group "root"
   action :create
+  variables(
+    needs_block_migrate: nova[:nova][:use_shared_instance_storage] ? false : true
+  )
   only_if { roles.include? "nova-controller" }
 end
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
@@ -27,7 +27,12 @@ set -x
 
 nova service-disable "$host" nova-compute
 
-if ! nova host-evacuate-live "$host"; then
+<% if @needs_block_migrate %>
+blockmigrate="--block-migrate"
+<% else %>
+blockmigrate=""
+<% end %>
+if ! nova host-evacuate-live "$host" $blockmigrate; then
     echo "Live migration of instances from host $host has failed!"
     touch $UPGRADEDIR/crowbar-evacuate-host-failed
     exit 2


### PR DESCRIPTION
When nova is deployed without shared storage we need to use
--block-migrate for live migrating instances away from compute nodes.