### PR TITLE
Backup errors

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -373,7 +373,14 @@ class Api::UpgradeController < ApiController
         false,
         admin_backup: @backup.errors.full_messages.first
       )
-      render json: { error: @backup.errors.full_messages.first }, status: :unprocessable_entity
+      render json: {
+        errors: {
+          admin_backup: {
+            data: @backup.errors.full_messages,
+            help: I18n.t("api.upgrade.adminbackup.help.default")
+          }
+        }
+      }, status: :unprocessable_entity
     end
   rescue Crowbar::Error::StartStepRunningError,
          Crowbar::Error::StartStepOrderError,

--- a/crowbar_framework/app/models/api/backup.rb
+++ b/crowbar_framework/app/models/api/backup.rb
@@ -174,6 +174,9 @@ class Api::Backup < ActiveRecord::Base
     self.version = ENV["CROWBAR_VERSION"]
     self.size = path.size
     self.migration_level = ActiveRecord::Migrator.current_version
+  rescue StandardError => e
+    errors.add(:base, I18n.t("backups.index.create_backup_failed", msg: e.message))
+    false
   end
 
   def save_archive

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -745,6 +745,7 @@ en:
       multiple_restore: 'Restore process is already running'
       version_conflict: 'Restoring from different Crowbar version is not allowed'
       restore_successful: 'Successfully restored Crowbar'
+      create_backup_failed: 'Creating backup failed: %{msg}'
     validation:
       hostnames_not_identical: 'Hostnames not identical'
       version_too_low: 'Backup version too low'


### PR DESCRIPTION
Currently any error/exception during backup creation propagates up the stack and causes 500 response with not explanation plus traceback in the logs. In the UI this triggers generic error message:
![zrzut ekranu z 2017-01-09 14-11-06](https://cloud.githubusercontent.com/assets/2458112/21767687/c29d29ec-d675-11e6-8064-c206a0bfe270.png)

With these changes, failure during backup creation will look like this:
![zrzut ekranu z 2017-01-09 13-58-49](https://cloud.githubusercontent.com/assets/2458112/21767333/c8acd028-d673-11e6-997a-6ec41cee9820.png)
