### PR TITLE
upgrade: Explicitely start nova-compute service after the upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -212,4 +212,7 @@ template "/usr/sbin/crowbar-chef-upgraded.sh" do
   owner "root"
   group "root"
   action :create
+  variables(
+    compute_node: compute_node
+  )
 end

--- a/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
@@ -12,6 +12,7 @@ echo "Executing $BASH_SOURCE"
 set -x
 
 mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-chef-upgraded-failed
 
 if [[ -f $UPGRADEDIR/crowbar-chef-upgraded-ok ]] ; then
     echo "crowbar_join and chef-client actions were already successfully executed"
@@ -20,5 +21,18 @@ fi
 
 # Move node to ready state and execute chef-client for the first time
 crowbar_join --start
+
+<% if @compute_node %>
+<% # FIXME: manually starting nova-compute service as it might not be running (bsc#1016302) %>
+systemctl start openstack-nova-compute.service
+
+ret=$?
+if [ $ret != 0 ] ; then
+    echo "Error occured while starting openstack-nova-compute service"
+    echo $ret > $UPGRADEDIR/crowbar-chef-upgraded-failed
+    return $ret
+fi
+<% end %>
+
 
 touch $UPGRADEDIR/crowbar-chef-upgraded-ok


### PR DESCRIPTION
This is temporary workaround for bsc#1016302 (service might not
be running after initial chef-client run). It should be removed
once the proper patch is released.