### PR TITLE
upgrade: Fix services shutdown

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -230,6 +230,7 @@ module Api
           msg = e.message
           Rails.logger.error msg
           ::Crowbar::UpgradeStatus.new.end_step(false, nodes_services: msg)
+          return
         end
 
         # Initiate the services shutdown for all nodes


### PR DESCRIPTION
When the prepare failed it makes no sense to continue with the code
below so return and exit in this case.