### PR TITLE
upgrade: Raise and catch upgrade specific Exceptions during upgrade

### DIFF
--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -155,7 +155,7 @@ module Api
 
     def raise_upgrade_error(message = "")
       Rails.logger.error(message)
-      raise message
+      raise ::Crowbar::Error::UpgradeError.new(message)
     end
 
     class << self

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -316,7 +316,7 @@ module Api
         if substep == "computes"
           upgrade_all_compute_nodes
         end
-        status.end_step
+        ::Crowbar::UpgradeStatus.new.end_step
       rescue ::Crowbar::Error::UpgradeError => e
         ::Crowbar::UpgradeStatus.new.end_step(
           false,

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -317,11 +317,19 @@ module Api
           upgrade_all_compute_nodes
         end
         status.end_step
-      rescue StandardError => e
+      rescue ::Crowbar::Error::UpgradeError => e
         ::Crowbar::UpgradeStatus.new.end_step(
           false,
           nodes_upgrade: e.message
         )
+      rescue StandardError => e
+        # end the step even for non-upgrade error, so we are not stuck with 'running'
+        ::Crowbar::UpgradeStatus.new.end_step(
+          false,
+          nodes_upgrade: "Crowbar has failed. " \
+            "Check /var/log/crowbar/production.log for details."
+        )
+        raise e
       end
       handle_asynchronously :nodes
 
@@ -581,7 +589,7 @@ module Api
 
       def raise_upgrade_error(message = "")
         Rails.logger.error(message)
-        raise message
+        raise ::Crowbar::Error::UpgradeError.new(message)
       end
 
       # Take a list of nodes and execute given script at each node in the background

--- a/crowbar_framework/lib/crowbar/error/upgrade_error.rb
+++ b/crowbar_framework/lib/crowbar/error/upgrade_error.rb
@@ -1,0 +1,21 @@
+#
+# Copyright 2017, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+module Crowbar
+  module Error
+    class UpgradeError < StandardError
+    end
+  end
+end


### PR DESCRIPTION
Also, end the upgrade step for non-upgrade error, so it is not
stuck as running.

This should fix  https://bugzilla.suse.com/show_bug.cgi?id=1019179

Requires https://github.com/crowbar/crowbar-core/pull/968