### PR TITLE
upgrade: Remove possibly existing failed indication on start

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-router-migration.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-router-migration.sh.erb
@@ -22,6 +22,7 @@ echo "Executing $BASH_SOURCE"
 set -x
 
 mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-router-migration-failed
 
 set +x
 source /root/.openrc


### PR DESCRIPTION
It's needed so the next invocation does not exit with failure automatically.

This script is bit tricky, because we're explicitely removing the file after the execution, but I think we're missing the failed case. Other solution would be to ensure we delete both indications from `evacuate_network_node`