### PR TITLE
upgrade: Handle asynchronous case of (bsc#1018110)

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -16,6 +16,7 @@
 
 class Api::UpgradeController < ApiController
   skip_before_filter :upgrade
+  before_filter :async_save_fail
 
   api :GET, "/api/upgrade", "Show the Upgrade progress"
   header "Accept", "application/vnd.crowbar.v2.0+json", required: true
@@ -539,5 +540,18 @@ class Api::UpgradeController < ApiController
 
   def backup_params
     params.require(:backup).permit(:name)
+  end
+
+  def async_save_fail
+    error = Api::Error.find_by(error: "Crowbar::Error::SaveUpgradeStatusError")
+    return unless error
+    render json: {
+      errors: {
+        error.caller => {
+          data: error.message,
+          help: I18n.t("api.upgrade.#{error.caller}.help.default")
+        }
+      }
+    }, status: :unprocessable_entity
   end
 end

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -180,6 +180,20 @@ module Crowbar
       true
     rescue StandardError => e
       @logger.error("Exception during saving the status file: #{e.message}")
+      # clear old errors to make sure there is only one type of that error present
+      # this is necessary to query for such an error through the :async_save_fail before_filter
+      # in the UpgradeController
+      error = Api::Error.find_by(
+        error: "Crowbar::Error::SaveUpgradeStatusError",
+        caller: current_step
+      )
+      error.delete if error
+      # mark the error to be able to determine this specific failure during the upgrade
+      Api::Error.create(
+        error: "Crowbar::Error::SaveUpgradeStatusError",
+        message: e.message,
+        caller: current_step
+      )
       raise ::Crowbar::Error::SaveUpgradeStatusError.new(e.message)
     end
 


### PR DESCRIPTION
mark an error during save and perform a query during the status
api call to see if an error exists

### not tested yet

@skazi0 this would need to be tested in combination with the UI polling i guess.