### PR TITLE
upgrade: Save the upgrade errors in consistent format

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -175,7 +175,7 @@ module Api
             end.flatten.compact.join(", ")
             ::Crowbar::UpgradeStatus.new.end_step(
               false,
-              adminrepocheck: {
+              repocheck_crowbar: {
                 data: "Missing repositories: #{missing_repos}",
                 help: "Fix the repository setup for the Admin server before " \
                   "you continue with the upgrade"
@@ -813,7 +813,7 @@ module Api
         message = e.message
         ::Crowbar::UpgradeStatus.new.end_step(
           false,
-          prepare_nodes_for_crowbar_upgrade: {
+          prepare: {
             data: message,
             help: "Check /var/log/crowbar/production.log at admin server."
           }

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -463,9 +463,14 @@ describe Api::Upgrade do
         receive(:end_step).
         with(
           false,
-          nodes:
-          "No node with 'nova-controller' role node was found. " \
-          "Cannot proceed with upgrade of compute nodes."
+          nodes: {
+            data:
+              "No node with 'nova-controller' role node was found. " \
+              "Cannot proceed with upgrade of compute nodes.",
+            help:
+              "Check the log files at the node that has failed " \
+              "to find possible cause."
+          }
         ).
         and_return(false)
       )


### PR DESCRIPTION
When the synchronous API call fails, it saves error in a form
of 'data' and 'help' touple. We need to do it in all other cases
as well.

This should be a fix for  https://bugzilla.suse.com/show_bug.cgi?id=1019298

Here's the result of new error output, cli: http://pastebin.nue.suse.com/19090/src and json: http://pastebin.nue.suse.com/19094/src