### PR TITLE
network: Enable rx/tx offloading by default (bsc#1015266)

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -376,8 +376,8 @@ Nic.nics.each do |nic|
   end
 
   unless nic.kind_of?(Nic::Vlan) or nic.kind_of?(Nic::Bond)
-    nic.rx_offloading = node["network"]["enable_rx_offloading"] || false
-    nic.tx_offloading = node["network"]["enable_tx_offloading"] || false
+    nic.rx_offloading = node["network"]["enable_rx_offloading"] || true
+    nic.tx_offloading = node["network"]["enable_tx_offloading"] || true
   end
 
   if ifs[nic.name]["mtu"]
@@ -478,8 +478,8 @@ when "rhel"
 when "suse"
 
   ethtool_options = []
-  ethtool_options << "rx off" unless node["network"]["enable_rx_offloading"] || false
-  ethtool_options << "tx off" unless node["network"]["enable_tx_offloading"] || false
+  ethtool_options << "rx off" unless node["network"]["enable_rx_offloading"] || true
+  ethtool_options << "tx off" unless node["network"]["enable_tx_offloading"] || true
   ethtool_options = ethtool_options.join(" ")
 
   Nic.nics.each do |nic|

--- a/chef/data_bags/crowbar/template-network.json
+++ b/chef/data_bags/crowbar/template-network.json
@@ -4,8 +4,8 @@
   "attributes": {
     "network": {
       "start_up_delay": 30,
-      "enable_rx_offloading": false,
-      "enable_tx_offloading": false,
+      "enable_rx_offloading": true,
+      "enable_tx_offloading": true,
       "mode": "single",
       "teaming": {
         "mode": 1


### PR DESCRIPTION
This was disabled for bsc#910298 which mentioned a "wellknown vlan
offloading bug". However, with the newer kernel that we have now, this
should hopefully be better.

https://bugzilla.suse.com/show_bug.cgi?id=1015266