### PR TITLE
upgrade: Catch status exceptions during prechecks on cloud7

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -239,6 +239,16 @@ class Api::UpgradeController < ApiController
   '
   def prechecks
     render json: Api::Upgrade.checks
+  rescue Crowbar::Error::UpgradeError,
+         StandardError => e
+    render json: {
+      errors: {
+        prechecks: {
+          data: e.message,
+          help: I18n.t("api.upgrade.prechecks.help.default")
+        }
+      }
+    }, status: :unprocessable_entity
   end
 
   api :POST, "/api/upgrade/cancel", "Cancel the upgrade process by setting the nodes back to ready"

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -28,8 +28,7 @@ module Api
       #
       def checks
         upgrade_status = ::Crowbar::UpgradeStatus.new
-        # the check for current_step means to allow running the step at any point in time
-        upgrade_status.start_step(:prechecks) if upgrade_status.current_step == :prechecks
+        upgrade_status.start_step(:prechecks)
 
         {}.tap do |ret|
           ret[:checks] = {}

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -779,6 +779,8 @@ en:
           default: 'Refer to the error message in the response'
     upgrade:
       prechecks:
+        help:
+          default: 'Refer to the error message in the response'
         network_checks:
           help:
             default: 'Examine the error messages'


### PR DESCRIPTION
if the upgrade status is called at a later step we don't want to
get a 500 error from the API, but instead render the usual json
error response