### PR TITLE
upgrade: Fix arguments for upgrade_next_cluster_node

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -357,7 +357,7 @@ module Api
         ::Node.find(
           "pacemaker_config_environment:#{cluster_env}"
         ).each do |node|
-          upgrade_next_cluster_node node.name, founder.name
+          upgrade_next_cluster_node node, founder
         end
       end
 


### PR DESCRIPTION
It takes the node objects, not the names