### PR TITLE
[stable/3.0] upgrade: Save the upgrade errors in consistent format

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -154,7 +154,7 @@ module Api
             end.flatten.compact.join(", ")
             ::Crowbar::UpgradeStatus.new.end_step(
               false,
-              adminrepocheck: {
+              repocheck_crowbar: {
                 data: "Missing repositories: #{missing_repos}",
                 help: "Fix the repository setup for the Admin server before " \
                   "you continue with the upgrade"
@@ -312,7 +312,7 @@ module Api
         message = e.message
         ::Crowbar::UpgradeStatus.new.end_step(
           false,
-          prepare_nodes_for_crowbar_upgrade: {
+          prepare: {
             data: message,
             help: "Check /var/log/crowbar/production.log at admin server."
           }

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -152,9 +152,13 @@ module Api
               missing_repo_arch = v[:repos].keys.first.to_sym
               v[:repos][missing_repo_arch][:missing]
             end.flatten.compact.join(", ")
-            upgrade_status.end_step(
+            ::Crowbar::UpgradeStatus.new.end_step(
               false,
-              adminrepocheck: "Missing repositories: #{missing_repos}"
+              adminrepocheck: {
+                data: "Missing repositories: #{missing_repos}",
+                help: "Fix the repository setup for the Admin server before " \
+                  "you continue with the upgrade"
+              }
             )
           else
             upgrade_status.end_step
@@ -308,7 +312,10 @@ module Api
         message = e.message
         ::Crowbar::UpgradeStatus.new.end_step(
           false,
-          prepare_nodes_for_crowbar_upgrade: message
+          prepare_nodes_for_crowbar_upgrade: {
+            data: message,
+            help: "Check /var/log/crowbar/production.log at admin server."
+          }
         )
         Rails.logger.error message
 


### PR DESCRIPTION
When the synchronous API call fails, it returns the error in a form
of 'data' and 'help' touple. We should save it the same way in the
progress file, especially because for aynchronous format, the content
of progress file is returned by the status API call.

(cherry picked from commit 44f7a55da5b79412480846d5de80603b3ab21559)

Backport of https://github.com/crowbar/crowbar-core/pull/972