### PR TITLE
node: Rename update state to confupdate

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -18,6 +18,7 @@
 source "https://rubygems.org"
 
 gem "rails", "~> 4.2.2"
+gem "rake", "< 12.0.0"
 gem "haml-rails", "~> 0.9.0"
 gem "sass-rails", "~> 5.0.3"
 gem "puma", "~> 2.16.0"

--- a/crowbar_framework/app/controllers/machines_controller.rb
+++ b/crowbar_framework/app/controllers/machines_controller.rb
@@ -28,7 +28,7 @@ class MachinesController < BarclampController
                   :identify,
                   :delete,
                   :reinstall,
-                  :update,
+                  :confupdate,
                   :reset,
                   :shutdown,
                   :reboot,
@@ -113,7 +113,7 @@ class MachinesController < BarclampController
   end
 
   [
-    :update,
+    :confupdate,
     :identify
   ].each do |action|
     add_help(action, [:id], [:post])

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -1003,7 +1003,7 @@ class Node < ChefObject
     cb = CrowbarService.new Rails.logger
     result = cb.transition "default", @node.name, state
 
-    if %w(reset reinstall update).include? state
+    if %w(reset reinstall confupdate).include? state
       # wait with reboot for the finish of configuration update by local chef-client
       # (so dhcp & PXE config is prepared when node is rebooted)
       begin
@@ -1074,12 +1074,12 @@ class Node < ChefObject
       "reboot",
       "reset",
       "shutdown",
-      "update"
+      "confupdate"
     ]
   end
 
-  def update
-    set_state("update")
+  def confupdate
+    set_state("confupdate")
   end
 
   def delete

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -1003,7 +1003,7 @@ class Node < ChefObject
     cb = CrowbarService.new Rails.logger
     result = cb.transition "default", @node.name, state
 
-    if %w(reset reinstall confupdate).include? state
+    if ["reset", "reinstall", "confupdate"].include? state
       # wait with reboot for the finish of configuration update by local chef-client
       # (so dhcp & PXE config is prepared when node is rebooted)
       begin

--- a/crowbar_framework/spec/controllers/machines_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/machines_controller_spec.rb
@@ -172,7 +172,7 @@ describe MachinesController do
   end
 
   [
-    :update,
+    :confupdate,
     :identify
   ].each do |action|
     describe "POST #{action}" do

--- a/crowbar_framework/spec/controllers/nodes_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/nodes_controller_spec.rb
@@ -227,7 +227,7 @@ describe NodesController do
     end
 
     it "sets the machine state" do
-      ["reinstall", "reset", "update", "delete"].each do |action|
+      ["reinstall", "reset", "confupdate", "delete"].each do |action|
         post :hit, req: action, id: "testing"
         expect(response).to redirect_to(node_url("testing"))
       end

--- a/updates/control.sh
+++ b/updates/control.sh
@@ -306,7 +306,7 @@ hwupdate () {
 case $DHCP_STATE in
     reset|discovery) discover && hardware_install;;
     hwinstall) hardware_install;;
-    update) hwupdate;;
+    confupdate) hwupdate;;
 esac 2>&1 | tee -a /var/log/crowbar/sledgehammer/$HOSTNAME.log
 [[ $DHCP_STATE = 'debug' ]] && exit
 reboot_system


### PR DESCRIPTION
The update state conflicts with the ActiveRecord update methods. To
avoid any confusion about the state lets rename it.

Splitted out of #920 