### PR TITLE
upgrade: Map features to repository names

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -252,33 +252,41 @@ class Api::UpgradeController < ApiController
   api_version "2.0"
   example '
   {
-    "ceph": {
-      "available": false,
-      "repos": {}
-    },
     "ha": {
-      "available": false,
-      "repos": {}
+      "available": true,
+      "repos": [
+        "SLE12-SP2-HA-Pool",
+        "SLE12-SP2-HA-Updates"
+      ],
+      "errors": {
+      }
     },
     "os": {
-      "available": true,
-      "repos": {}
-    },
-    "openstack": {
       "available": false,
-      "repos": {
+      "repos": [
+        "SLES12-SP2-Pool",
+        "SLES12-SP2-Updates"
+      ],
+      "errors": {
         "missing": {
           "x86_64": [
-            "SUSE-OpenStack-Cloud-8-Pool",
-            "SUSE-OpenStack-Cloud-8-Updates"
+            "SLES12-SP2-Pool"
           ]
         },
         "inactive": {
           "x86_64": [
-            "SUSE-OpenStack-Cloud-8-Pool",
-            "SUSE-OpenStack-Cloud-8-Updates"
+            "SLES12-SP2-Pool"
           ]
         }
+      }
+    },
+    "openstack": {
+      "available": true,
+      "repos": [
+        "SUSE-OpenStack-Cloud-7-Pool",
+        "SUSE-OpenStack-Cloud-7-Updates"
+      ],
+      "errors": {
       }
     }
   }
@@ -311,7 +319,11 @@ class Api::UpgradeController < ApiController
     },
     "openstack": {
       "available": false,
-      "repos": {
+      "repos": [
+        "SUSE-OpenStack-Cloud-8-Pool",
+        "SUSE-OpenStack-Cloud-8-Updates"
+      ],
+      "errors":
         "x86_64": {
           "missing": [
             "SUSE-OpenStack-Cloud-8-Pool",

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -179,7 +179,8 @@ module Api
         {}.tap do |ret|
           ret[addon] = {
             "available" => true,
-            "repos" => {}
+            "repos" => ::Crowbar::Repository.feature_repository_map(platform)[addon],
+            "errors" => {}
           }
 
           features.each do |feature|
@@ -194,7 +195,7 @@ module Api
                   feature, platform, architecture
                 )
                 ret[addon]["available"] &&= available
-                ret[addon]["repos"].deep_merge!(repolist.deep_stringify_keys)
+                ret[addon]["errors"].deep_merge!(repolist.deep_stringify_keys)
               end
             else
               ret[addon]["available"] = false

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -187,26 +187,38 @@ module Api
           os_available = repo_version_available?(products, "SLES", "12.3")
           ret[:os] = {
             available: os_available,
-            repos: {}
+            repos: [
+              "SLES12-SP3-Pool",
+              "SLES12-SP3-Updates"
+            ],
+            errors: {}
           }
-          ret[:os][:repos][admin_architecture.to_sym] = {
-            missing: ["SLES-12-SP3-Pool", "SLES12-SP3-Updates"]
-          } unless os_available
+          unless os_available
+            ret[:os][:errors][admin_architecture.to_sym] = {
+              missing: ret[:os][:repos]
+            }
+          end
 
           cloud_available = repo_version_available?(products, "suse-openstack-cloud", "8")
           ret[:openstack] = {
             available: cloud_available,
-            repos: {}
+            repos: [
+              "SUSE-OpenStack-Cloud-8-Pool",
+              "SUSE-OpenStack-Cloud-8-Updates"
+            ],
+            errors: {}
           }
-          ret[:openstack][:repos][admin_architecture.to_sym] = {
-            missing: ["SUSE-OpenStack-Cloud-8-Pool", "SUSE-OpenStack-Cloud-8-Updates"]
-          } unless cloud_available
+          unless cloud_available
+            ret[:openstack][:errors][admin_architecture.to_sym] = {
+              missing: ret[:openstack][:repos]
+            }
+          end
 
           if ret.any? { |_k, v| !v[:available] }
             missing_repos = ret.collect do |k, v|
-              next if v[:repos].empty?
-              missing_repo_arch = v[:repos].keys.first.to_sym
-              v[:repos][missing_repo_arch][:missing]
+              next if v[:errors].empty?
+              missing_repo_arch = v[:errors].keys.first.to_sym
+              v[:errors][missing_repo_arch][:missing]
             end.flatten.compact.join(", ")
             ::Crowbar::UpgradeStatus.new.end_step(
               false,

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -200,8 +200,25 @@ describe Api::UpgradeController, type: :request do
 
       get "/api/upgrade/noderepocheck", {}, headers
       expect(response).to have_http_status(:ok)
-      expect(response.body).to eq(
-        "{\"os\":{\"available\":true,\"repos\":{}},\"openstack\":{\"available\":true,\"repos\":{}}}"
+      expect(JSON.parse(response.body)).to eq(
+        "os" => {
+          "available" => true,
+          "repos" => [
+            "SLES12-SP2-Pool",
+            "SLES12-SP2-Updates"
+          ],
+          "errors" => {
+          }
+        },
+        "openstack" => {
+          "available" => true,
+          "repos" => [
+            "SUSE-OpenStack-Cloud-7-Pool",
+            "SUSE-OpenStack-Cloud-7-Updates"
+          ],
+          "errors" => {
+          }
+        }
       )
     end
 

--- a/crowbar_framework/spec/fixtures/crowbar_repocheck.json
+++ b/crowbar_framework/spec/fixtures/crowbar_repocheck.json
@@ -1,10 +1,18 @@
 {
   "os":{
     "available":true,
-    "repos": {}
+    "repos":[
+      "SLES12-SP3-Pool",
+      "SLES12-SP3-Updates"
+    ],
+    "errors":{}
   },
   "openstack":{
     "available":true,
-    "repos": {}
+    "repos":[
+      "SUSE-OpenStack-Cloud-8-Pool",
+      "SUSE-OpenStack-Cloud-8-Updates"
+    ],
+    "errors":{}
   }
 }

--- a/crowbar_framework/spec/fixtures/node_repocheck.json
+++ b/crowbar_framework/spec/fixtures/node_repocheck.json
@@ -1,18 +1,38 @@
 {
-  "os": {
-    "available": true,
-    "repos": {}
-  },
   "ceph": {
     "available": true,
-    "repos": {}
+    "repos": [
+      "SUSE-Enterprise-Storage-4-Pool",
+      "SUSE-Enterprise-Storage-4-Updates"
+    ],
+    "errors": {
+    }
   },
   "ha": {
     "available": true,
-    "repos": {}
+    "repos": [
+      "SLE12-SP2-HA-Pool",
+      "SLE12-SP2-HA-Updates"
+    ],
+    "errors": {
+    }
+  },
+  "os": {
+    "available": true,
+    "repos": [
+      "SLES12-SP2-Pool",
+      "SLES12-SP2-Updates"
+    ],
+    "errors": {
+    }
   },
   "openstack": {
     "available": true,
-    "repos": {}
+    "repos": [
+      "SUSE-OpenStack-Cloud-7-Pool",
+      "SUSE-OpenStack-Cloud-7-Updates"
+    ],
+    "errors": {
+    }
   }
 }

--- a/crowbar_framework/spec/fixtures/node_repocheck_missing.json
+++ b/crowbar_framework/spec/fixtures/node_repocheck_missing.json
@@ -1,7 +1,11 @@
 {
   "os": {
     "available": false,
-    "repos": {
+    "repos": [
+      "SLES12-SP2-Pool",
+      "SLES12-SP2-Updates"
+    ],
+    "errors": {
       "missing": {
         "x86_64": [
           "SLES12-SP2-Pool",
@@ -18,7 +22,11 @@
   },
   "openstack": {
     "available": false,
-    "repos": {
+    "repos": [
+      "SUSE-OpenStack-Cloud-7-Pool",
+      "SUSE-OpenStack-Cloud-7-Updates"
+    ],
+    "errors": {
       "missing": {
         "x86_64": [
           "Cloud",


### PR DESCRIPTION
this is useful information for any client (UI/crowbarctl)

### crowbarctl
```bash
root@crowbar:/opt/dell/crowbar_framework # crowbarctl upgrade repocheck nodes
+----------------------------------+--------------------------------+
| Status                           | Value                          |
+----------------------------------+--------------------------------+
| ha.available                     | true                           |
| ha.repos                         | SLE12-SP2-HA-Pool              |
|                                  | SLE12-SP2-HA-Updates           |
| os.available                     | false                          |
| os.repos                         | SLES12-SP2-Pool                |
|                                  | SLES12-SP2-Updates             |
|                                  | SLES12-SP2-Pool                |
| os.errors.missing.x86_64         | SLES12-SP2-Pool                |
| os.errors.inactive.x86_64        | SLES12-SP2-Pool                |
| openstack.available              | true                           |
| openstack.repos                  | SUSE-OpenStack-Cloud-7-Pool    |
|                                  | SUSE-OpenStack-Cloud-7-Updates |
+----------------------------------+--------------------------------+
```

### Raw json
```json
{
  "ha": {
    "available": true,
    "repos": [
      "SLE12-SP2-HA-Pool",
      "SLE12-SP2-HA-Updates"
    ],
    "missing_repos": {
    }
  },
  "os": {
    "available": false,
    "repos": [
      "SLES12-SP2-Pool",
      "SLES12-SP2-Updates"
    ],
    "errors": {
      "missing": {
        "x86_64": [
          "SLES12-SP2-Pool"
        ]
      },
      "inactive": {
        "x86_64": [
          "SLES12-SP2-Pool"
        ]
      }
    }
  },
  "openstack": {
    "available": true,
    "repos": [
      "SUSE-OpenStack-Cloud-7-Pool",
      "SUSE-OpenStack-Cloud-7-Updates"
    ],
    "missing_repos": {
    }
  }
}
```
