### PR TITLE
provisioner: Fix order of creating groups and users

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -225,10 +225,10 @@ fi
 
 # for making HA on shared NFS backend storage work
 add_group glance 200
-add_user glance 200 glance
 add_group qemu 201
-add_user qemu 201 kvm
 add_group kvm 202
+add_user glance 200 glance
+add_user qemu 201 kvm
 
 # Check that we're really on the admin network
 # --------------------------------------------


### PR DESCRIPTION
The user `qemu` can not be created unless the group `kvm` was created
beforehand.

Thanks goes to Bryan Gartner <bryan.gartner@suse.com> for pointing this out.