### PR TITLE
upgrade: Fix handling of multiple zypper prompts

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -162,18 +162,23 @@ module Api
             }
           end
 
-          unless zypper_stream["prompt"].nil?
+          prompt = zypper_stream["prompt"]
+          unless prompt.nil?
+            # keep only first prompt for easier formatting
+            prompt = prompt.first if prompt.is_a?(Array)
+
             upgrade_status.end_step(
               false,
               repocheck_crowbar: {
-                data: zypper_stream["prompt"]["text"],
+                data: prompt["text"],
                 help: "Make sure you complete the required action and try again."
               }
             )
+
             return {
               status: :service_unavailable,
               error: I18n.t(
-                "api.crowbar.zypper_prompt", zypper_prompt_text: zypper_stream["prompt"]["text"]
+                "api.crowbar.zypper_prompt", zypper_prompt_text: prompt["text"]
               )
             }
           end


### PR DESCRIPTION
There can be more than one `<prompt>` element in zypper xml output.
In such cases, `Hash.from_xml()` returns array of hashes instead of
a hash for those subtrees.

In this particular case, the simplest solution is to show only first
prompt as the user needs to complete the actions in sequence anyway
when running it in the terminal.