### PR TITLE
upgrade: Check if a feature/addon is deployed, not enabled

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -57,12 +57,14 @@ module Api
             )
           }
 
-          ceph_status = Api::Crowbar.ceph_status
-          ret[:ceph_healthy] = {
-            required: true,
-            passed: ceph_status.empty?,
-            errors: ceph_status.empty? ? {} : ceph_health_check_errors(ceph_status)
-          } if Api::Crowbar.addons.include?("ceph")
+          if Api::Crowbar.addons.include?("ceph")
+            ceph_status = Api::Crowbar.ceph_status
+            ret[:ceph_healthy] = {
+              required: true,
+              passed: ceph_status.empty?,
+              errors: ceph_status.empty? ? {} : ceph_health_check_errors(ceph_status)
+            }
+          end
 
           ha_presence = Api::Pacemaker.ha_presence_check
           ret[:ha_configured] = {
@@ -71,12 +73,14 @@ module Api
             errors: ha_presence.empty? ? {} : ha_presence_errors(ha_presence)
           }
 
-          clusters_health = Api::Pacemaker.health_report
-          ret[:clusters_healthy] = {
-            required: true,
-            passed: clusters_health.empty?,
-            errors: clusters_health.empty? ? {} : clusters_health_report_errors(clusters_health)
-          } if Api::Crowbar.addons.include?("ha")
+          if Api::Crowbar.addons.include?("ha")
+            clusters_health = Api::Pacemaker.health_report
+            ret[:clusters_healthy] = {
+              required: true,
+              passed: clusters_health.empty?,
+              errors: clusters_health.empty? ? {} : clusters_health_report_errors(clusters_health)
+            }
+          end
 
           return ret unless upgrade_status.current_step == :prechecks
 

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -89,6 +89,10 @@ describe Api::Crowbar do
           receive(:addon_installed?).with(addon).
           and_return(true)
         )
+        allow(Api::Crowbar).to(
+          receive(:addon_deployed?).with(addon).
+          and_return(true)
+        )
         allow(Api::Node).to(
           receive(:repocheck).with(addon: addon).and_return(
             addon => { "available" => true }


### PR DESCRIPTION
if we only check if it is enabled on the repository level, we will
have a false result within the repochecks in case a repository is
disabled, but necessary to have, because it has been deployed.

so if an ha repo becomes unavailable at some point during the upgrade
it will not even show up in the repochecks anymore, because it gets
disabled on the repository level once it is not available anymore.