### PR TITLE
node: Use always the full name in spec

### DIFF
--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -171,7 +171,7 @@ describe Api::UpgradeController, type: :request do
         receive(:roles).and_return(["crowbar"])
       )
       allow(Node).to(
-        receive(:all).and_return([Node.find_node_by_name("testing")])
+        receive(:all).and_return([Node.find_node_by_name("testing.crowbar.com")])
       )
       allow(Api::Upgrade).to(
         receive(:target_platform).and_return("suse-12.2")

--- a/crowbar_framework/spec/controllers/crowbar_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/crowbar_controller_spec.rb
@@ -66,32 +66,52 @@ describe CrowbarController do
 
   describe "POST transition" do
     it "does not allow invalid states" do
-      post :transition, barclamp: "crowbar", id: "default", state: "foobarz", name: "testing"
+      post :transition,
+        barclamp: "crowbar",
+        id: "default",
+        state: "foobarz",
+        name: "testing.crowbar.com"
       expect(response).to be_bad_request
     end
 
     it "does not allow upcased states" do
-      post :transition, barclamp: "crowbar", id: "default", state: "Discovering", name: "testing"
+      post :transition,
+        barclamp: "crowbar",
+        id: "default",
+        state: "Discovering",
+        name: "testing.crowbar.com"
       expect(response).to be_bad_request
     end
 
     it "transitions the node into desired state" do
       allow_any_instance_of(RoleObject).to receive(:find_roles_by_search).and_return([])
-      post :transition, barclamp: "crowbar", id: "default", state: "discovering", name: "testing"
+      post :transition,
+        barclamp: "crowbar",
+        id: "default",
+        state: "discovering",
+        name: "testing.crowbar.com"
       expect(response).to be_success
     end
 
     it "returns plain text message if transitioning fails" do
       allow_any_instance_of(CrowbarService).to receive(:transition).and_return([500, "error"])
-      post :transition, barclamp: "crowbar", id: "default", state: "discovering", name: "testing"
+      post :transition,
+        barclamp: "crowbar",
+        id: "default",
+        state: "discovering",
+        name: "testing.crowbar.com"
       expect(response).to be_server_error
       expect(response.body).to be == "error"
     end
 
     it "returns node as a hash on success when passed a name" do
       allow_any_instance_of(CrowbarService).to receive(:transition).
-        and_return([200, { name: "testing" }])
-      post :transition, barclamp: "crowbar", id: "default", state: "discovering", name: "testing"
+        and_return([200, { name: "testing.crowbar.com" }])
+      post :transition,
+        barclamp: "crowbar",
+        id: "default",
+        state: "discovering",
+        name: "testing.crowbar.com"
       expect(response).to be_success
       json = JSON.parse(response.body)
       expect(json["name"]).to be == "testing.crowbar.com"
@@ -99,8 +119,12 @@ describe CrowbarController do
 
     it "returns node as a hash on success when passed a node (backward compatibility)" do
       allow_any_instance_of(CrowbarService).to receive(:transition).
-        and_return([200, Node.find_node_by_name("testing").to_hash])
-      post :transition, barclamp: "crowbar", id: "default", state: "discovering", name: "testing"
+        and_return([200, Node.find_node_by_name("testing.crowbar.com").to_hash])
+      post :transition,
+        barclamp: "crowbar",
+        id: "default",
+        state: "discovering",
+        name: "testing.crowbar.com"
       expect(response).to be_success
       json = JSON.parse(response.body)
       expect(json["name"]).to be == "testing.crowbar.com"

--- a/crowbar_framework/spec/controllers/machines_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/machines_controller_spec.rb
@@ -88,18 +88,18 @@ describe MachinesController do
 
   describe "GET show" do
     it "is successful" do
-      get :show, name: "testing", format: "json"
+      get :show, name: "testing.crowbar.com", format: "json"
       expect(response).to have_http_status(:ok)
     end
 
     it "renders json" do
-      get :show, name: "testing", format: "json"
+      get :show, name: "testing.crowbar.com", format: "json"
       expect(JSON.parse(response.body)).to be_a(Hash)
     end
 
     context "for existent node" do
       it "fetches with name" do
-        get :show, name: "testing", format: "json"
+        get :show, name: "testing.crowbar.com", format: "json"
         json = JSON.parse(response.body)
 
         expect(json["name"]).to eq("testing.crowbar.com")
@@ -126,7 +126,7 @@ describe MachinesController do
       it "assignes role compute" do
         expect_any_instance_of(Node).to receive(:intended_role=).with("compute")
 
-        post :role, name: "testing", role: "compute", format: "json"
+        post :role, name: "testing.crowbar.com", role: "compute", format: "json"
         expect(response).to have_http_status(:ok)
       end
     end
@@ -140,7 +140,7 @@ describe MachinesController do
       allow_any_instance_of(Node).to receive(:save).and_return(false)
       expect_any_instance_of(Node).to receive(:intended_role=).with("compute")
 
-      post :role, name: "testing", role: "compute", format: "json"
+      post :role, name: "testing.crowbar.com", role: "compute", format: "json"
 
       expect(response).to have_http_status(:unprocessable_entity)
     end
@@ -151,7 +151,7 @@ describe MachinesController do
       it "renames a node to tester" do
         expect_any_instance_of(Node).to receive(:alias=).with("tester")
 
-        post :rename, name: "testing", alias: "tester", format: "json"
+        post :rename, name: "testing.crowbar.com", alias: "tester", format: "json"
         expect(response).to have_http_status(:ok)
       end
     end
@@ -165,7 +165,7 @@ describe MachinesController do
       allow_any_instance_of(Node).to receive(:save).and_return(false)
       expect_any_instance_of(Node).to receive(:alias=).with("tester")
 
-      post :rename, name: "testing", alias: "tester", format: "json"
+      post :rename, name: "testing.crowbar.com", alias: "tester", format: "json"
 
       expect(response).to have_http_status(:unprocessable_entity)
     end
@@ -180,7 +180,7 @@ describe MachinesController do
         it "invokes #{action}" do
           expect_any_instance_of(Node).to receive(action)
 
-          post action, name: "testing", format: "json"
+          post action, name: "testing.crowbar.com", format: "json"
           expect(response).to have_http_status(:ok)
         end
       end
@@ -210,13 +210,13 @@ describe MachinesController do
         it "invokes #{action}" do
           expect_any_instance_of(Node).to receive(action)
 
-          post action, name: "testing", format: "json"
+          post action, name: "testing.crowbar.com", format: "json"
           expect(response).to have_http_status(:ok)
         end
 
         it "return 403 (forbidden) http status for admin node" do
           allow_any_instance_of(Node).to receive(:admin?).and_return(true)
-          post action, name: "testing", format: "json"
+          post action, name: "testing.crowbar.com", format: "json"
           expect(response).to have_http_status(:forbidden)
         end
       end

--- a/crowbar_framework/spec/controllers/nodes_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/nodes_controller_spec.rb
@@ -56,7 +56,7 @@ describe NodesController do
   describe "POST update" do
     before do
       allow(Node).to receive(:find_node_by_public_name).and_return(nil)
-      @node = Node.find_node_by_name("admin")
+      @node = Node.find_node_by_name("admin.crowbar.com")
     end
 
     describe "coming from the allocate form" do
@@ -100,8 +100,8 @@ describe NodesController do
   end
 
   describe "POST bulk" do
-    let(:admin) { Node.find_node_by_name("admin") }
-    let(:node) { Node.find_node_by_name("testing") }
+    let(:admin) { Node.find_node_by_name("admin.crowbar.com") }
+    let(:node) { Node.find_node_by_name("testing.crowbar.com") }
 
     it "redirects to nodes list on success if return param passed" do
       post :bulk, node: { node.name => { "allocate" => true, "alias" => "newalias" } }, return: "true"
@@ -144,7 +144,7 @@ describe NodesController do
   end
 
   describe "GET families" do
-    let(:node) { Node.find_node_by_name("testing") }
+    let(:node) { Node.find_node_by_name("testing.crowbar.com") }
 
     it "is successful" do
       get :families
@@ -190,7 +190,7 @@ describe NodesController do
 
   describe "GET show" do
     it "is successful" do
-      get :show, id: "testing"
+      get :show, id: "testing.crowbar.com"
       expect(response).to be_success
     end
 
@@ -202,7 +202,7 @@ describe NodesController do
       end
 
       it "renders json" do
-        get :show, id: "testing", format: "json"
+        get :show, id: "testing.crowbar.com", format: "json"
         expect(response).to be_success
       end
     end
@@ -222,26 +222,26 @@ describe NodesController do
     end
 
     it "returns 500 for invalid action" do
-      post :hit, req: "some nonsense", id: "testing"
+      post :hit, req: "some nonsense", id: "testing.crowbar.com"
       expect(response).to be_server_error
     end
 
     it "sets the machine state" do
       ["reinstall", "reset", "confupdate", "delete"].each do |action|
-        post :hit, req: action, id: "testing"
+        post :hit, req: action, id: "testing.crowbar.com"
         expect(response).to redirect_to(node_url("testing"))
       end
 
       ["reboot", "shutdown", "poweron", "powercycle", "poweroff", "identify", "allocate"].each do |action|
         expect_any_instance_of(Node).to receive(action.to_sym)
-        post :hit, req: action, id: "testing"
+        post :hit, req: action, id: "testing.crowbar.com"
       end
     end
   end
 
   describe "POST group_change" do
     before do
-      @node = Node.find_node_by_name("testing")
+      @node = Node.find_node_by_name("testing.crowbar.com")
     end
 
     it "returns not found for nonexistent node" do
@@ -274,7 +274,7 @@ describe NodesController do
 
   describe "GET attribute" do
     before do
-      @node = Node.find_node_by_name("testing")
+      @node = Node.find_node_by_name("testing.crowbar.com")
     end
 
     # FIXME: maybe regular 404 would be better?

--- a/crowbar_framework/spec/lib/crowbar/backup/export_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/backup/export_spec.rb
@@ -121,7 +121,7 @@ describe Crowbar::Backup::Export do
   context "metadata" do
     it "exports metadata" do
       allow(Node).to receive(:admin_node).and_return(
-        Node.find_node_by_name("testing")
+        Node.find_node_by_name("testing.crowbar.com")
       )
       # we skip created_at here as it will always be different
       # so we just compare the classes

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -16,7 +16,7 @@ describe Api::Crowbar do
       )
     )
   end
-  let!(:node) { Node.find_node_by_name("testing") }
+  let!(:node) { Node.find_node_by_name("testing.crowbar.com") }
 
   before(:each) do
     allow_any_instance_of(Kernel).to(

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -59,7 +59,7 @@ describe Api::Upgrade do
       )
     )
     allow(Node).to(
-      receive(:all).and_return([Node.find_node_by_name("testing")])
+      receive(:all).and_return([Node.find_node_by_name("testing.crowbar.com")])
     )
     allow(Api::Upgrade).to(
       receive(:target_platform).and_return("suse-12.2")

--- a/crowbar_framework/spec/models/crowbar_service_spec.rb
+++ b/crowbar_framework/spec/models/crowbar_service_spec.rb
@@ -27,7 +27,7 @@ describe CrowbarService do
 
   describe "transition" do
     it "returns 404 without state" do
-      response = crowbar.transition("default", "testing", nil)
+      response = crowbar.transition("default", "testing.crowbar.com", nil)
       expect(response.first).to be == 404
     end
 
@@ -39,13 +39,13 @@ describe CrowbarService do
 
     it "returns 200 on successful transition" do
       allow(RoleObject).to receive(:find_roles_by_search).and_return([])
-      response = crowbar.transition("default", "testing", "a state")
+      response = crowbar.transition("default", "testing.crowbar.com", "a state")
       expect(response.first).to be == 200
     end
 
     describe "to another state" do
       before do
-        @node = Node.find_node_by_name("testing")
+        @node = Node.find_node_by_name("testing.crowbar.com")
       end
 
       it "sets the state debug and state" do
@@ -71,7 +71,7 @@ describe CrowbarService do
 
     describe "to discovering" do
       before do
-        @node = Node.find_node_by_name("testing")
+        @node = Node.find_node_by_name("testing.crowbar.com")
       end
 
       it "adds role to the node if admin" do
@@ -88,43 +88,43 @@ describe CrowbarService do
 
       it "check that the node is initially not allocated" do
         allow(Node).to receive(:find_node_by_name).and_return(@node)
-        crowbar.transition("default", "testing", "discovering")
+        crowbar.transition("default", "testing.crowbar.com", "discovering")
         expect(@node.allocated?).to be false
       end
     end
 
     describe "to hardware-installing" do
       before do
-        @node = Node.find_node_by_name("testing")
+        @node = Node.find_node_by_name("testing.crowbar.com")
       end
 
       it "forces nodes transition to a given state" do
         allow(Node).to receive(:find_node_by_name).and_return(@node)
-        crowbar.transition("default", "testing", "hardware-installing")
+        crowbar.transition("default", "testing.crowbar.com", "hardware-installing")
         expect(@node.state).to be == "hardware-installing"
       end
     end
 
     describe "to hardware-updating" do
       before do
-        @node = Node.find_node_by_name("testing")
+        @node = Node.find_node_by_name("testing.crowbar.com")
       end
 
       it "forces nodes transition to a given state" do
         allow(Node).to receive(:find_node_by_name).and_return(@node)
-        crowbar.transition("default", "testing", "hardware-updating")
+        crowbar.transition("default", "testing.crowbar.com", "hardware-updating")
         expect(@node.state).to be == "hardware-updating"
       end
     end
 
     describe "to update" do
       before do
-        @node = Node.find_node_by_name("testing")
+        @node = Node.find_node_by_name("testing.crowbar.com")
       end
 
       it "forces nodes transition to a given state" do
         allow(Node).to receive(:find_node_by_name).and_return(@node)
-        crowbar.transition("default", "testing", "update")
+        crowbar.transition("default", "testing.crowbar.com", "update")
         expect(@node.state).to be == "update"
       end
     end


### PR DESCRIPTION
This commit unifies the way how we search and use the name in the spec
tests.