### PR TITLE
ohai: common ohai attribute for libvirt guest uuid

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/linux/crowbar_libvirt.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/linux/crowbar_libvirt.rb
@@ -1,0 +1,21 @@
+provides "crowbar_ohai"
+
+require_plugin "kernel"
+require_plugin "dmi"
+require_plugin "linux::s390x"
+
+libvirt_uuid = nil
+
+if kernel[:machine] == "s390x"
+  if s390x[:system][:manufacturer] == "KVM"
+    libvirt_uuid = s390x[:system][:uuid]
+  end
+else
+  manufacturer = dmi[:system] ? dmi[:system][:manufacturer] : "unknown"
+  if ["Bochs", "QEMU"].include? manufacturer
+    libvirt_uuid = dmi[:system][:uuid]
+  end
+end
+
+crowbar_ohai[:libvirt] = {}
+crowbar_ohai[:libvirt][:guest_uuid] = libvirt_uuid


### PR DESCRIPTION
This adds a new attribute node[:crowbar_ohai][:libvirt][:guest_uuid]
which contains the UUID of the libvirt instance that the node is running
in. The purpose is to have a common place for this attribute independent
of the node's architecture (currently x86 ist storing this somewhere in
the "dmi" subtree and s390x in "s390x").

(cherry picked from commit 7548957de6b76c2760b76a72bd8bbfe2f48e738c)