### PR TITLE
Skip CD drives

### DIFF
--- a/updates/control.sh
+++ b/updates/control.sh
@@ -187,6 +187,7 @@ nuke_everything() {
         [[ -b /dev/$name && -w /dev/$name && $name != name ]] || continue
         [[ $name = loop* ]] && continue
         [[ $name = dm* ]] && continue
+        [[ $name = sr* ]] && continue
         if [[ $name = md* ]] ; then
             mdadm --stop /dev/$name
         fi


### PR DESCRIPTION
When running `nuke_everything()` on newly allocated node skip CD
drives that are in `/dev/sr*`.