### PR TITLE
upgrade: set the status when there are some zypper errors

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -96,7 +96,12 @@ class Api::UpgradeController < ApiController
 
     if check.key?(:error)
       render json: {
-        error: check[:error]
+        errors: {
+          repocheck_crowbar: {
+            data: check[:error],
+            help: I18n.t("api.upgrade.adminrepocheck.help.default")
+          }
+        }
       }, status: check[:status]
     else
       render json: check

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -109,6 +109,13 @@ module Api
 
         {}.tap do |ret|
           if zypper_stream["message"] =~ /^System management is locked/
+            upgrade_status.end_step(
+              false,
+              repocheck_crowbar: {
+                data: zypper_stream["message"],
+                help: "Make sure zypper is not running and try again."
+              }
+            )
             return {
               status: :service_unavailable,
               error: I18n.t(
@@ -118,6 +125,13 @@ module Api
           end
 
           unless zypper_stream["prompt"].nil?
+            upgrade_status.end_step(
+              false,
+              repocheck_crowbar: {
+                data: zypper_stream["prompt"]["text"],
+                help: "Make sure you complete the required action and try again."
+              }
+            )
             return {
               status: :service_unavailable,
               error: I18n.t(


### PR DESCRIPTION
(cherry picked from commit 60e9f5cba0dd0cbff687c5724d44ee6952ed9e06)

backport of https://github.com/crowbar/crowbar-core/pull/988