### PR TITLE
upgrade: Enable running prechecks also out of order

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -29,7 +29,7 @@ module Api
       def checks
         upgrade_status = ::Crowbar::UpgradeStatus.new
         # the check for current_step means to allow running the step at any point in time
-        upgrade_status.start_step(:prechecks)
+        upgrade_status.start_step(:prechecks) if upgrade_status.current_step == :prechecks
 
         {}.tap do |ret|
           network = ::Crowbar::Sanity.check


### PR DESCRIPTION
This was (partially) removed by https://github.com/crowbar/crowbar-core/commit/f88889317a7937150f4d8cce2aceb60a7c946319

Ideally, we should not need it and user should not be allowed to run the prechecks later when some other steps have already been run. But UI might need to do it in some special cases