### PR TITLE
[stable/3.0] upgrade: Enable running prechecks also out of order

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -26,7 +26,7 @@ module Api
       def checks
         upgrade_status = ::Crowbar::UpgradeStatus.new
         # the check for current_step means to allow running the step at any point in time
-        upgrade_status.start_step(:prechecks)
+        upgrade_status.start_step(:prechecks) if upgrade_status.current_step == :prechecks
 
         {}.tap do |ret|
           network = ::Crowbar::Sanity.check


### PR DESCRIPTION
(cherry picked from commit 4233d8106706f7d4dcb9481064da6bb1c94af6ac)

Backport of https://github.com/crowbar/crowbar-core/pull/1007