### PR TITLE
[stable/3.0] Use crowbar-pacemaker provider for apache service for HA

### DIFF
--- a/chef/cookbooks/apache2/attributes/default.rb
+++ b/chef/cookbooks/apache2/attributes/default.rb
@@ -117,3 +117,5 @@ default[:apache][:worker][:minsparethreads] = 64
 default[:apache][:worker][:maxsparethreads] = 192
 default[:apache][:worker][:threadsperchild] = 64
 default[:apache][:worker][:maxrequestsperchild] = 0
+
+default[:apache][:ha][:enabled] = false

--- a/chef/cookbooks/apache2/recipes/default.rb
+++ b/chef/cookbooks/apache2/recipes/default.rb
@@ -65,6 +65,7 @@ service "apache2" do
     "default" => { "default" => [:restart, :reload] }
   )
   action :enable
+  provider Chef::Provider::CrowbarPacemakerService if node[:apache][:ha][:enabled]
 end
 
 if platform_family?("rhel", "fedora", "arch")


### PR DESCRIPTION
apache is utilized by various OpenStack services, e.g. horizon.
Just like other services, we should let it be handled by Pacemkaer
when it is part of HA configuration.


This is an alternative to https://github.com/crowbar/crowbar-ha/pull/176