### PR TITLE
upgrade: Non-requried precheck errors in status

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -98,9 +98,7 @@ module Api
           #     another_error: { ... },
           #     maintenance_updates_installed: { data: "987", ... }
           # }
-          errors = ret.select { |_k, v| v[:required] && v[:errors].any? }.
-                   map { |_k, v| v[:errors] }.
-                   reduce({}, :merge)
+          errors = ret.map { |_k, v| v[:errors] }.reduce({}, :merge)
 
           if errors.any?
             upgrade_status.end_step(false, errors)


### PR DESCRIPTION
The errors coming from prechecks which were `required: false` were
not stored in the status file. This change removes the filtering so
that all of the errors are stored.