### PR TITLE
puma: Start puma worker killer via puma

### DIFF
--- a/crowbar_framework/config/initializers/puma_worker_killer.rb
+++ b/crowbar_framework/config/initializers/puma_worker_killer.rb
@@ -6,4 +6,3 @@ PumaWorkerKiller.config do |config|
   config.rolling_restart_frequency = 60 * 60 * 12 # 12 hours in seconds
   config.reaper_status_logs = true # enable logging
 end
-PumaWorkerKiller.start

--- a/crowbar_framework/config/puma.rb
+++ b/crowbar_framework/config/puma.rb
@@ -31,6 +31,10 @@ state_path File.join(ROOT, "tmp", "pids", "puma.state")
 
 bind "tcp://#{LISTEN}:#{PORT}"
 
+before_fork do
+  PumaWorkerKiller.start
+end
+
 on_worker_boot do
   ::ActiveSupport.on_load(:active_record) do
     config = Rails.application.config.database_configuration[Rails.env]


### PR DESCRIPTION
We switched recently to puma 2.16 which gives us the possibility to
start the PumaWorkerKiller directly via puma. This change has the
advantage that puma is aware of the restart.