### PR TITLE
apache2: Do not define apache2 service twice (bsc#1021106)

### DIFF
--- a/chef/cookbooks/apache2/definitions/apache_conf.rb
+++ b/chef/cookbooks/apache2/definitions/apache_conf.rb
@@ -35,7 +35,7 @@ define :apache_conf do
   template mod_conf do
     source "mods/#{params[:name]}.conf.erb"
     cookbook "apache2"
-    notifies :reload, resources(service: "apache2")
+    notifies :reload, "service[apache2]"
     mode 0644
   end
 end

--- a/chef/cookbooks/apache2/definitions/apache_module.rb
+++ b/chef/cookbooks/apache2/definitions/apache_module.rb
@@ -27,7 +27,7 @@ define :apache_module, enable: true, conf: false do
   if params[:enable]
     execute "a2enmod #{params[:name]}" do
       command "/usr/sbin/a2enmod #{params[:name]}"
-      notifies :reload, resources(service: "apache2")
+      notifies :reload, "service[apache2]"
       if node[:platform_family] == "suse"
         not_if "/usr/sbin/a2enmod -q #{params[:name]}"
       else
@@ -40,7 +40,7 @@ define :apache_module, enable: true, conf: false do
   else
     execute "a2dismod #{params[:name]}" do
       command "/usr/sbin/a2dismod #{params[:name]}"
-      notifies :reload, resources(service: "apache2")
+      notifies :reload, "service[apache2]"
       if node[:platform_family] == "suse"
         only_if "/usr/sbin/a2enmod -q #{params[:name]}"
       else

--- a/chef/cookbooks/apache2/definitions/apache_site.rb
+++ b/chef/cookbooks/apache2/definitions/apache_site.rb
@@ -23,14 +23,14 @@ define :apache_site, enable: true do
     if not params[:enable]
       file "#{node[:apache][:dir]}/vhosts.d/#{params[:name]}" do
         action :delete
-        notifies :reload, resources(service: "apache2"), :immediately
+        notifies :reload, "service[apache2]", :immediately
       end
     end
   else
     if params[:enable]
       execute "a2ensite #{params[:name]}" do
         command "/usr/sbin/a2ensite #{params[:name]}"
-        notifies :reload, resources(service: "apache2"), :immediately
+        notifies :reload, "service[apache2]", :immediately
         not_if do
           ::File.symlink?("#{node[:apache][:dir]}/sites-enabled/#{params[:name]}") or
             ::File.symlink?("#{node[:apache][:dir]}/sites-enabled/000-#{params[:name]}")
@@ -40,7 +40,7 @@ define :apache_site, enable: true do
     else
       execute "a2dissite #{params[:name]}" do
         command "/usr/sbin/a2dissite #{params[:name]}"
-        notifies :reload, resources(service: "apache2"), :immediately
+        notifies :reload, "service[apache2]", :immediately
         only_if do ::File.symlink?("#{node[:apache][:dir]}/sites-enabled/#{params[:name]}") end
       end
     end

--- a/chef/cookbooks/apache2/definitions/web_app.rb
+++ b/chef/cookbooks/apache2/definitions/web_app.rb
@@ -44,7 +44,7 @@ define :web_app, template: "web_app.conf.erb" do
       params: params
     )
     if ::File.exists?(vhost_conf)
-      notifies :reload, resources(service: "apache2"), :delayed
+      notifies :reload, "service[apache2]", :delayed
     end
   end
 

--- a/chef/cookbooks/apache2/recipes/default.rb
+++ b/chef/cookbooks/apache2/recipes/default.rb
@@ -29,44 +29,6 @@ package "apache2" do
   action :install
 end
 
-service "apache2" do
-  case node[:platform_family]
-  when "rhel", "fedora"
-    service_name "httpd"
-    # If restarted/reloaded too quickly httpd has a habit of failing.
-    # This may happen with multiple recipes notifying apache to restart - like
-    # during the initial bootstrap.
-    restart_command "/sbin/service httpd restart && sleep 1"
-    reload_command "/sbin/service httpd graceful && sleep 1"
-  when "suse"
-    service_name "apache2"
-    restart_command "/sbin/service apache2 restart && sleep 1"
-    reload_command "/sbin/service apache2 reload && sleep 1"
-  when "debian"
-    service_name "apache2"
-    restart_command "/usr/sbin/invoke-rc.d apache2 restart && sleep 1"
-    reload_command "/usr/sbin/invoke-rc.d apache2 reload && sleep 1"
-    if node[:platform] == "ubuntu"
-      restart_command "service apache2 restart && sleep 1"
-      reload_command "service apache2 graceful && sleep 1"
-    end
-  when "arch"
-    service_name "httpd"
-  end
-  supports value_for_platform(
-    "debian" => { "4.0" => [:restart, :reload], "default" => [:restart, :reload, :status] },
-    "ubuntu" => { "default" => [:restart, :reload, :status] },
-    "centos" => { "default" => [:restart, :reload, :status] },
-    "redhat" => { "default" => [:restart, :reload, :status] },
-    "fedora" => { "default" => [:restart, :reload, :status] },
-    "suse" => { "default" => [:restart, :reload, :status] },
-    "opensuse" => { "default" => [:restart, :reload, :status] },
-    "arch" => { "default" => [:restart, :reload, :status] },
-    "default" => { "default" => [:restart, :reload] }
-  )
-  action :enable
-end
-
 if platform_family?("rhel", "fedora", "arch")
   directory node[:apache][:log_dir] do
     mode 0755
@@ -159,7 +121,7 @@ unless node[:platform_family] == "suse"
     owner "root"
     group "root"
     mode 0644
-    notifies :reload, resources(service: "apache2")
+    notifies :reload, "service[apache2]"
   end
 
   template "security" do
@@ -169,7 +131,7 @@ unless node[:platform_family] == "suse"
     group "root"
     mode 0644
     backup false
-    notifies :reload, resources(service: "apache2")
+    notifies :reload, "service[apache2]"
   end
 
   template "charset" do
@@ -179,7 +141,7 @@ unless node[:platform_family] == "suse"
     group "root"
     mode 0644
     backup false
-    notifies :reload, resources(service: "apache2")
+    notifies :reload, "service[apache2]"
   end
 
   template "#{node[:apache][:dir]}/sites-available/default" do
@@ -187,7 +149,7 @@ unless node[:platform_family] == "suse"
     owner "root"
     group "root"
     mode 0644
-    notifies :reload, resources(service: "apache2")
+    notifies :reload, "service[apache2]"
   end
 end
 
@@ -198,7 +160,7 @@ template "#{node[:apache][:dir]}/ports.conf" do
   owner "root"
   variables apache_listen_ports: node[:apache][:listen_ports]
   mode 0644
-  notifies :reload, resources(service: "apache2")
+  notifies :reload, "service[apache2]"
 end
 
 # leave the default module list untouched for now on SUSE
@@ -222,6 +184,40 @@ unless node[:platform_family] == "suse"
 end
 
 service "apache2" do
-  action :start
+  case node[:platform_family]
+  when "rhel", "fedora"
+    service_name "httpd"
+    # If restarted/reloaded too quickly httpd has a habit of failing.
+    # This may happen with multiple recipes notifying apache to restart - like
+    # during the initial bootstrap.
+    restart_command "/sbin/service httpd restart && sleep 1"
+    reload_command "/sbin/service httpd graceful && sleep 1"
+  when "suse"
+    service_name "apache2"
+    restart_command "/sbin/service apache2 restart && sleep 1"
+    reload_command "/sbin/service apache2 reload && sleep 1"
+  when "debian"
+    service_name "apache2"
+    restart_command "/usr/sbin/invoke-rc.d apache2 restart && sleep 1"
+    reload_command "/usr/sbin/invoke-rc.d apache2 reload && sleep 1"
+    if node[:platform] == "ubuntu"
+      restart_command "service apache2 restart && sleep 1"
+      reload_command "service apache2 graceful && sleep 1"
+    end
+  when "arch"
+    service_name "httpd"
+  end
+  supports value_for_platform(
+    "debian" => { "4.0" => [:restart, :reload], "default" => [:restart, :reload, :status] },
+    "ubuntu" => { "default" => [:restart, :reload, :status] },
+    "centos" => { "default" => [:restart, :reload, :status] },
+    "redhat" => { "default" => [:restart, :reload, :status] },
+    "fedora" => { "default" => [:restart, :reload, :status] },
+    "suse" => { "default" => [:restart, :reload, :status] },
+    "opensuse" => { "default" => [:restart, :reload, :status] },
+    "arch" => { "default" => [:restart, :reload, :status] },
+    "default" => { "default" => [:restart, :reload] }
+  )
+  action [:enable, :start]
   ignore_failure true
 end


### PR DESCRIPTION
This causes the magic to override the LWRP in crowbar-pacemaker to not
fully work, as it only overrides the second definition, and not the
first one. Which results in the :enable action to always be done for the
apache2 service, even when pacemaker is used.

https://bugzilla.suse.com/show_bug.cgi?id=1021106
(cherry picked from commit 1a1c30d4ee5965be654327f34bf656b9c1a71004)

Port of https://github.com/crowbar/crowbar-core/pull/1018