### PR TITLE
crowbar: Log puma std{out,err}

### DIFF
--- a/crowbar_framework/config/puma.rb
+++ b/crowbar_framework/config/puma.rb
@@ -51,3 +51,9 @@ end
 ].each do |name|
   FileUtils.mkdir_p File.join(ROOT, name)
 end
+
+stdout_redirect(
+  "/var/log/crowbar/production.log",
+  "/var/log/crowbar/production.log",
+  true
+)


### PR DESCRIPTION
For debugging we should log puma's std{out,err}.