### PR TITLE
[3.0] upgrade: Include best_method within the prechecks

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -52,10 +52,7 @@ class Api::UpgradeController < ApiController
   end
 
   def prechecks
-    render json: {
-      checks: Api::Upgrade.checks,
-      best_method: Api::Upgrade.best_method
-    }
+    render json: Api::Upgrade.checks
   end
 
   def cancel

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -29,22 +29,23 @@ module Api
         upgrade_status.start_step(:prechecks) if upgrade_status.current_step == :prechecks
 
         {}.tap do |ret|
+          ret[:checks] = {}
           network = ::Crowbar::Sanity.check
-          ret[:network_checks] = {
+          ret[:checks][:network_checks] = {
             required: true,
             passed: network.empty?,
             errors: network.empty? ? {} : sanity_check_errors(network)
           }
 
           health_check = Api::Crowbar.health_check
-          ret[:cloud_healthy] = {
+          ret[:checks][:cloud_healthy] = {
             required: true,
             passed: health_check.empty?,
             errors: health_check.empty? ? {} : health_check_errors(health_check)
           }
 
           maintenance_updates = ::Crowbar::Checks::Maintenance.updates_status
-          ret[:maintenance_updates_installed] = {
+          ret[:checks][:maintenance_updates_installed] = {
             required: true,
             passed: maintenance_updates.empty?,
             errors: maintenance_updates.empty? ? {} : maintenance_updates_check_errors(
@@ -53,7 +54,7 @@ module Api
           }
 
           compute = Api::Crowbar.compute_status
-          ret[:compute_status] = {
+          ret[:checks][:compute_status] = {
             required: false,
             passed: compute.empty?,
             errors: compute.empty? ? {} : compute_status_errors(compute)
@@ -61,7 +62,7 @@ module Api
 
           if Api::Crowbar.addons.include?("ceph")
             ceph_status = Api::Crowbar.ceph_status
-            ret[:ceph_healthy] = {
+            ret[:checks][:ceph_healthy] = {
               required: true,
               passed: ceph_status.empty?,
               errors: ceph_status.empty? ? {} : ceph_health_check_errors(ceph_status)
@@ -69,7 +70,7 @@ module Api
           end
 
           ha_presence = Api::Crowbar.ha_presence_check
-          ret[:ha_configured] = {
+          ret[:checks][:ha_configured] = {
             required: false,
             passed: ha_presence.empty?,
             errors: ha_presence.empty? ? {} : ha_presence_errors(ha_presence)
@@ -77,11 +78,21 @@ module Api
 
           if Api::Crowbar.addons.include?("ha")
             clusters_health = Api::Crowbar.clusters_health_report
-            ret[:clusters_healthy] = {
+            ret[:checks][:clusters_healthy] = {
               required: true,
               passed: clusters_health.empty?,
               errors: clusters_health.empty? ? {} : clusters_health_report_errors(clusters_health)
             }
+          end
+
+          ret[:best_method] = if ret[:checks].any? { |_id, c| c[:required] && !c[:passed] }
+            "none"
+          elsif !ret[:checks].any? { |_id, c| (c[:required] || !c[:required]) && !c[:passed] }
+            "non-disruptive"
+          elsif !ret[:checks].any? do |_id, c|
+            (c[:required] && !c[:passed]) && (!c[:required] && c[:passed])
+          end
+            "disruptive"
           end
 
           return ret unless upgrade_status.current_step == :prechecks
@@ -100,7 +111,7 @@ module Api
           #     another_error: { ... },
           #     maintenance_updates_installed: { data: "987", ... }
           # }
-          errors = ret.select { |_k, v| v[:required] && v[:errors].any? }.
+          errors = ret[:checks].select { |_k, v| v[:required] && v[:errors].any? }.
                    map { |_k, v| v[:errors] }.
                    reduce({}, :merge)
 
@@ -109,19 +120,6 @@ module Api
           else
             upgrade_status.end_step
           end
-        end
-      end
-
-      def best_method
-        checks_cached = checks
-        return "none" if checks_cached.any? do |_id, c|
-          c[:required] && !c[:passed]
-        end
-        return "non-disruptive" unless checks_cached.any? do |_id, c|
-          (c[:required] || !c[:required]) && !c[:passed]
-        end
-        return "disruptive" unless checks_cached.any? do |_id, c|
-          (c[:required] && !c[:passed]) && (!c[:required] && c[:passed])
         end
       end
 

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -77,7 +77,7 @@ describe Api::UpgradeController, type: :request do
         receive(:ha_presence_check).and_return({})
       )
       allow(Api::Upgrade).to receive(:checks).and_return(
-        JSON.parse(prechecks)["checks"].deep_symbolize_keys
+        JSON.parse(prechecks).deep_symbolize_keys
       )
 
       get "/api/upgrade/prechecks", {}, headers


### PR DESCRIPTION
this saves us from setting the upgrade status again by caching the checks
during invocation of best_method

(cherry picked from commit 0aa7a493aba4e3b39d87dcc365d35989cf03c6cc)

Backport of https://github.com/crowbar/crowbar-core/pull/1013