### PR TITLE
upgrade: cleanup and catch unforeseen exceptions

### DIFF
--- a/crowbar_framework/app/controllers/api/crowbar_controller.rb
+++ b/crowbar_framework/app/controllers/api/crowbar_controller.rb
@@ -31,13 +31,6 @@ class Api::CrowbarController < ApiController
     render json: Api::Crowbar.status
   end
 
-  api :PATCH, "/api/crowbar", "Update Crowbar object"
-  header "Accept", "application/vnd.crowbar.v2.0+json", required: true
-  api_version "2.0"
-  def update
-    head :not_implemented
-  end
-
   api :GET, "/api/crowbar/upgrade", "Status of Crowbar Upgrade"
   header "Accept", "application/vnd.crowbar.v2.0+json", required: true
   example '

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -83,6 +83,8 @@ class Api::UpgradeController < ApiController
   api_version "2.0"
   error 422, "Failed to prepare nodes for Crowbar upgrade"
   def prepare
+    ::Crowbar::UpgradeStatus.new.start_step(:prepare)
+
     if Api::Upgrade.prepare(background: true)
       head :ok
     else
@@ -95,9 +97,9 @@ class Api::UpgradeController < ApiController
         }
       }, status: :unprocessable_entity
     end
-  rescue Crowbar::Error::StartStepRunningError,
-         Crowbar::Error::StartStepOrderError,
-         Crowbar::Error::SaveUpgradeStatusError => e
+  rescue ::Crowbar::Error::StartStepRunningError,
+         ::Crowbar::Error::StartStepOrderError,
+         ::Crowbar::Error::SaveUpgradeStatusError => e
     render json: {
       errors: {
         prepare: {
@@ -113,12 +115,12 @@ class Api::UpgradeController < ApiController
   api_version "2.0"
   error 422, "Failed to stop services on all nodes"
   def services
+    ::Crowbar::UpgradeStatus.new.start_step(:services)
     Api::Upgrade.services
     head :ok
-  rescue Crowbar::Error::StartStepRunningError,
-         Crowbar::Error::StartStepOrderError,
-         Crowbar::Error::EndStepRunningError,
-         Crowbar::Error::SaveUpgradeStatusError => e
+  rescue ::Crowbar::Error::StartStepRunningError,
+         ::Crowbar::Error::StartStepOrderError,
+         ::Crowbar::Error::SaveUpgradeStatusError => e
     render json: {
       errors: {
         services: {
@@ -135,12 +137,12 @@ class Api::UpgradeController < ApiController
   # This is gonna initiate the upgrade of all nodes.
   # The method runs asynchronously, so there's a need to poll for the status and possible errors
   def nodes
+    ::Crowbar::UpgradeStatus.new.start_step(:nodes)
     Api::Upgrade.nodes
     head :ok
-  rescue Crowbar::Error::StartStepRunningError,
-         Crowbar::Error::StartStepOrderError,
-         Crowbar::Error::EndStepRunningError,
-         Crowbar::Error::SaveUpgradeStatusError => e
+  rescue ::Crowbar::Error::StartStepRunningError,
+         ::Crowbar::Error::StartStepOrderError,
+         ::Crowbar::Error::SaveUpgradeStatusError => e
     render json: {
       errors: {
         nodes: {
@@ -291,10 +293,7 @@ class Api::UpgradeController < ApiController
   '
   def noderepocheck
     render json: Api::Upgrade.noderepocheck
-  rescue Crowbar::Error::StartStepRunningError,
-         Crowbar::Error::StartStepOrderError,
-         Crowbar::Error::EndStepRunningError,
-         Crowbar::Error::SaveUpgradeStatusError => e
+  rescue Crowbar::Error::UpgradeError => e
     render json: {
       errors: {
         repocheck_nodes: {
@@ -348,10 +347,7 @@ class Api::UpgradeController < ApiController
     else
       render json: check
     end
-  rescue Crowbar::Error::StartStepRunningError,
-         Crowbar::Error::StartStepOrderError,
-         Crowbar::Error::EndStepRunningError,
-         Crowbar::Error::SaveUpgradeStatusError => e
+  rescue Crowbar::Error::UpgradeError => e
     render json: {
       errors: {
         repocheck_crowbar: {
@@ -432,12 +428,12 @@ class Api::UpgradeController < ApiController
   api_version "2.0"
   error 422, "Failed to save backup, error details are provided in the response"
   def openstackbackup
+    ::Crowbar::UpgradeStatus.new.start_step(:backup_openstack)
     Api::Upgrade.openstackbackup
     head :ok
-  rescue Crowbar::Error::StartStepRunningError,
-         Crowbar::Error::StartStepOrderError,
-         Crowbar::Error::EndStepRunningError,
-         Crowbar::Error::SaveUpgradeStatusError => e
+  rescue ::Crowbar::Error::StartStepRunningError,
+         ::Crowbar::Error::StartStepOrderError,
+         ::Crowbar::Error::SaveUpgradeStatusError => e
     render json: {
       errors: {
         backup_openstack: {

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -78,13 +78,6 @@ class Api::UpgradeController < ApiController
     render json: Api::Upgrade.status
   end
 
-  api :PATCH, "/api/upgrade", "Update Upgrade status object"
-  header "Accept", "application/vnd.crowbar.v2.0+json", required: true
-  api_version "2.0"
-  def update
-    head :not_implemented
-  end
-
   api :POST, "/api/upgrade/prepare", "Prepare Crowbar Upgrade"
   header "Accept", "application/vnd.crowbar.v2.0+json", required: true
   api_version "2.0"

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -162,6 +162,11 @@ class Api::UpgradeController < ApiController
         "passed": true,
         "errors": {}
       },
+      "cloud_healthy": {
+        "required": true,
+        "passed": true,
+        "errors": {}
+      },
       "maintenance_updates_installed": {
         "required": true,
         "passed": false,
@@ -174,17 +179,22 @@ class Api::UpgradeController < ApiController
           }
         }
       },
-      "clusters_healthy": {
-        "required": true,
-        "passed": true,
-        "errors": {}
-      },
-      "compute_resources_available": {
+      "compute_status": {
         "required": false,
         "passed": true,
         "errors": {}
       },
       "ceph_healthy": {
+        "required": true,
+        "passed": true,
+        "errors": {}
+      },
+      "ha_configured": {
+        "required": false,
+        "passed": true,
+        "errors": {}
+      },
+      "clusters_healthy": {
         "required": true,
         "passed": true,
         "errors": {}

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -225,7 +225,7 @@ class Api::UpgradeController < ApiController
         }
       }, status: :unprocessable_entity
     end
-  rescue Crowbar::Error::UpgradeCancelError => e
+  rescue Crowbar::Error::Upgrade::CancelError => e
     render json: {
       errors: {
         cancel: {

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -415,6 +415,15 @@ class Api::UpgradeController < ApiController
         }
       }
     }, status: :unprocessable_entity
+  rescue StandardError => e
+    ::Crowbar::UpgradeStatus.new.end_step(
+      false,
+      backup_crowbar: {
+        data: e.message,
+        help: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+      }
+    )
+    raise e
   ensure
     @backup.cleanup unless @backup.nil?
   end

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -64,6 +64,15 @@ module Api
             message: msg
           }
         end
+      rescue StandardError => e
+        ::Crowbar::UpgradeStatus.new.end_step(
+          false,
+          admin: {
+            data: e.message,
+            help: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+          }
+        )
+        raise e
       end
 
       def version

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -124,14 +124,25 @@ module Api
             upgrade_status.end_step
           end
         end
+      rescue ::Crowbar::Error::StartStepRunningError,
+             ::Crowbar::Error::StartStepOrderError,
+             ::Crowbar::Error::SaveUpgradeStatusError => e
+        raise ::Crowbar::Error::UpgradeError.new(e.message)
+      rescue StandardError => e
+        ::Crowbar::UpgradeStatus.new.end_step(
+          false,
+          prechecks: {
+            data: e.message,
+            help: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+          }
+        )
+        raise e
       end
 
       #
       # prepare upgrade
       #
       def prepare(options = {})
-        ::Crowbar::UpgradeStatus.new.start_step(:prepare)
-
         background = options.fetch(:background, false)
 
         if background
@@ -244,6 +255,10 @@ module Api
             upgrade_status.end_step
           end
         end
+      rescue ::Crowbar::Error::StartStepRunningError,
+             ::Crowbar::Error::StartStepOrderError,
+             ::Crowbar::Error::SaveUpgradeStatusError => e
+        raise ::Crowbar::Error::UpgradeError.new(e.message)
       rescue StandardError => e
         ::Crowbar::UpgradeStatus.new.end_step(
           false,
@@ -280,6 +295,10 @@ module Api
           upgrade_status.end_step
         end
         response
+      rescue ::Crowbar::Error::StartStepRunningError,
+             ::Crowbar::Error::StartStepOrderError,
+             ::Crowbar::Error::SaveUpgradeStatusError => e
+        raise ::Crowbar::Error::UpgradeError.new(e.message)
       rescue StandardError => e
         ::Crowbar::UpgradeStatus.new.end_step(
           false,
@@ -308,7 +327,6 @@ module Api
       # service shutdown
       #
       def services
-        ::Crowbar::UpgradeStatus.new.start_step(:services)
         begin
           # prepare the scripts for various actions necessary for the upgrade
           service_object = CrowbarService.new(Rails.logger)
@@ -381,8 +399,6 @@ module Api
       handle_asynchronously :services
 
       def openstackbackup
-        ::Crowbar::UpgradeStatus.new.start_step(:backup_openstack)
-
         crowbar_lib_dir = "/var/lib/crowbar"
         dump_path = "#{crowbar_lib_dir}/upgrade/6-to-7-openstack_dump.sql"
         if File.exist?(dump_path)
@@ -511,7 +527,7 @@ module Api
           upgrade_all_compute_nodes
         end
         ::Crowbar::UpgradeStatus.new.end_step
-      rescue ::Crowbar::Error::UpgradeError => e
+      rescue ::Crowbar::Error::Upgrade::NodeError => e
         ::Crowbar::UpgradeStatus.new.end_step(
           false,
           nodes: {
@@ -531,6 +547,11 @@ module Api
         raise e
       end
       handle_asynchronously :nodes
+
+      def raise_node_upgrade_error(message = "")
+        Rails.logger.error(message)
+        raise ::Crowbar::Error::Upgrade::NodeError.new(message)
+      end
 
       protected
 
@@ -624,7 +645,7 @@ module Api
         # Explicitly mark the first node as cluster founder
         # and in case of DRBD setup, adapt DRBD config accordingly.
         unless Api::Pacemaker.set_node_as_founder node.name
-          raise_upgrade_error("Changing the cluster founder to #{node.name} has failed")
+          raise_node_upgrade_error("Changing the cluster founder to #{node.name} has failed")
           return false
         end
         # remove pre-upgrade attribute, so the services can start
@@ -714,7 +735,7 @@ module Api
         end
 
         if first.nil? || second.nil?
-          raise_upgrade_error("Unable to detect DRBD master and/or slave nodes")
+          raise_node_upgrade_error("Unable to detect DRBD master and/or slave nodes")
         end
 
         upgrade_first_cluster_node first, second
@@ -730,7 +751,7 @@ module Api
         )
         save_upgrade_state("Deleting pacemaker resources was successful.")
       rescue StandardError => e
-        raise_upgrade_error(
+        raise_node_upgrade_error(
           e.message +
             "Check /var/log/crowbar/node-upgrade.log for details."
         )
@@ -758,7 +779,7 @@ module Api
         # run the script again on this node (to evacuate other nodes)
         controller.delete_script_exit_files("/usr/sbin/crowbar-router-migration.sh")
       rescue StandardError => e
-        raise_upgrade_error(
+        raise_node_upgrade_error(
           e.message +
           " Check /var/log/crowbar/node-upgrade.log at #{controller.name} for details."
         )
@@ -792,8 +813,9 @@ module Api
         end
 
         controller = ::Node.find("roles:nova-controller").first
+
         if controller.nil?
-          raise_upgrade_error(
+          raise_node_upgrade_error(
             "No node with 'nova-controller' role node was found. " \
             "Cannot proceed with upgrade of compute nodes."
           )
@@ -819,7 +841,7 @@ module Api
           )
           save_upgrade_state("Services at compute nodes upgraded and prepared.")
         rescue StandardError => e
-          raise_upgrade_error(
+          raise_node_upgrade_error(
             "Error while preparing services at compute nodes. " + e.message
           )
         end
@@ -844,7 +866,7 @@ module Api
             "source /root/.openrc; nova service-enable #{hostname} nova-compute"
           )
           unless out[:exit_code].zero?
-            raise_upgrade_error(
+            raise_node_upgrade_error(
               "Enabling nova-compute service for #{hostname} has failed. " \
               "Check nova log files at #{controller.name} and #{n.name}."
             )
@@ -864,7 +886,7 @@ module Api
           "Migrating instances from node #{compute} was successful."
         )
       rescue StandardError => e
-        raise_upgrade_error(
+        raise_node_upgrade_error(
           e.message +
           "Check /var/log/crowbar/node-upgrade.log at #{controller.name} for details."
         )
@@ -875,18 +897,13 @@ module Api
         Rails.logger.info(message)
       end
 
-      def raise_upgrade_error(message = "")
-        Rails.logger.error(message)
-        raise ::Crowbar::Error::UpgradeError.new(message)
-      end
-
       # Take a list of nodes and execute given script at each node in the background
       # Wait until all scripts at all nodes correctly finish or until some error is detected
       def execute_scripts_and_wait_for_finish(nodes, script, seconds)
         nodes.each do |node|
           ssh_status = node.ssh_cmd(script).first
           if ssh_status != 200
-            raise_upgrade_error("Failed to connect to node #{node.name}!")
+            raise_node_upgrade_error("Failed to connect to node #{node.name}!")
             raise "Execution of script #{script} has failed on node #{node.name}."
           end
         end

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -139,6 +139,15 @@ module Api
         else
           prepare_nodes_for_crowbar_upgrade
         end
+      rescue StandardError => e
+        ::Crowbar::UpgradeStatus.new.end_step(
+          false,
+          prepare: {
+            data: e.message,
+            help: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+          }
+        )
+        raise e
       end
 
       #
@@ -235,6 +244,15 @@ module Api
             upgrade_status.end_step
           end
         end
+      rescue StandardError => e
+        ::Crowbar::UpgradeStatus.new.end_step(
+          false,
+          repocheck_crowbar: {
+            data: e.message,
+            help: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+          }
+        )
+        raise e
       end
 
       def noderepocheck
@@ -262,6 +280,15 @@ module Api
           upgrade_status.end_step
         end
         response
+      rescue StandardError => e
+        ::Crowbar::UpgradeStatus.new.end_step(
+          false,
+          repocheck_nodes: {
+            data: e.message,
+            help: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+          }
+        )
+        raise e
       end
 
       def target_platform(options = {})
@@ -341,6 +368,15 @@ module Api
         else
           ::Crowbar::UpgradeStatus.new.end_step
         end
+      rescue StandardError => e
+        ::Crowbar::UpgradeStatus.new.end_step(
+          false,
+          services: {
+            data: e.message,
+            help: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+          }
+        )
+        raise e
       end
       handle_asynchronously :services
 
@@ -415,6 +451,15 @@ module Api
             data: e.message
           }
         )
+      rescue StandardError => e
+        ::Crowbar::UpgradeStatus.new.end_step(
+          false,
+          backup_openstack: {
+            data: e.message,
+            help: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+          }
+        )
+        raise e
       end
       handle_asynchronously :openstackbackup
 
@@ -440,7 +485,6 @@ module Api
       #
       def nodes
         status = ::Crowbar::UpgradeStatus.new
-        status.start_step(:nodes)
 
         remaining = status.progress[:remaining_nodes]
         substep = status.current_substep

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -480,7 +480,8 @@ module Api
         ::Crowbar::UpgradeStatus.new.end_step(
           false,
           nodes: {
-            data: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+            data: e.message,
+            help: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
           }
         )
         raise e

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -479,8 +479,9 @@ module Api
         # end the step even for non-upgrade error, so we are not stuck with 'running'
         ::Crowbar::UpgradeStatus.new.end_step(
           false,
-          nodes: "Crowbar has failed. " \
-            "Check /var/log/crowbar/production.log for details."
+          nodes: {
+            data: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+          }
         )
         raise e
       end

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -223,7 +223,7 @@ Rails.application.routes.draw do
     constraints: ApiConstraint.new(2.0) do
     resource :crowbar,
       controller: :crowbar,
-      only: [:show, :update] do
+      only: [:show] do
       get :upgrade
       post :upgrade
       get :maintenance
@@ -247,7 +247,7 @@ Rails.application.routes.draw do
 
     resource :upgrade,
       controller: :upgrade,
-      only: [:show, :update] do
+      only: [:show] do
       post :prepare
       post :services
       post :nodes

--- a/crowbar_framework/lib/crowbar/error.rb
+++ b/crowbar_framework/lib/crowbar/error.rb
@@ -19,19 +19,24 @@ module Crowbar
     autoload :UpgradeError,
       File.expand_path("../error/upgrade", __FILE__)
 
-    autoload :UpgradeCancelError,
-      File.expand_path("../error/upgrade", __FILE__)
+    module Upgrade
+      autoload :CancelError,
+        File.expand_path("../error/upgrade", __FILE__)
 
-    autoload :UpgradeNotEnoughDiskSpaceError,
-      File.expand_path("../error/upgrade", __FILE__)
+      autoload :NotEnoughDiskSpaceError,
+        File.expand_path("../error/upgrade", __FILE__)
 
-    autoload :UpgradeFreeDiskSpaceError,
-      File.expand_path("../error/upgrade", __FILE__)
+      autoload :FreeDiskSpaceError,
+        File.expand_path("../error/upgrade", __FILE__)
 
-    autoload :UpgradeDatabaseDumpError,
-      File.expand_path("../error/upgrade", __FILE__)
+      autoload :DatabaseDumpError,
+        File.expand_path("../error/upgrade", __FILE__)
 
-    autoload :UpgradeDatabaseSizeError,
-      File.expand_path("../error/upgrade", __FILE__)
+      autoload :DatabaseSizeError,
+        File.expand_path("../error/upgrade", __FILE__)
+
+      autoload :NodeError,
+        File.expand_path("../error/upgrade", __FILE__)
+    end
   end
 end

--- a/crowbar_framework/lib/crowbar/error/upgrade.rb
+++ b/crowbar_framework/lib/crowbar/error/upgrade.rb
@@ -51,6 +51,13 @@ module Crowbar
           super("Cannot create dump of OpenStack databases. #{message}")
         end
       end
+
+      # node upgrade
+      class NodeError < UpgradeError
+        def initialize(message)
+          super(message)
+        end
+      end
     end
   end
 end

--- a/crowbar_framework/lib/crowbar/error/upgrade.rb
+++ b/crowbar_framework/lib/crowbar/error/upgrade.rb
@@ -19,35 +19,37 @@ module Crowbar
     class UpgradeError < StandardError
     end
 
-    # cancel upgrade
-    class UpgradeCancelError < StandardError
-      def initialize(step_name = "")
-        super("Not possible to cancel the upgrade at the step #{step_name}")
+    module Upgrade
+      # cancel upgrade
+      class CancelError < UpgradeError
+        def initialize(step_name = "")
+          super("Not possible to cancel the upgrade at the step #{step_name}")
+        end
       end
-    end
 
-    # openstack backup
-    class UpgradeNotEnoughDiskSpaceError < StandardError
-      def initialize(path)
-        super("Not enough space in #{path} to create an OpenStack database dump.")
+      # openstack backup
+      class NotEnoughDiskSpaceError < UpgradeError
+        def initialize(path)
+          super("Not enough space in #{path} to create an OpenStack database dump.")
+        end
       end
-    end
 
-    class UpgradeFreeDiskSpaceError < StandardError
-      def initialize(message = "")
-        super("Cannot determine free disk space. #{message}")
+      class FreeDiskSpaceError < UpgradeError
+        def initialize(message = "")
+          super("Cannot determine free disk space. #{message}")
+        end
       end
-    end
 
-    class UpgradeDatabaseSizeError < StandardError
-      def initialize(message = "")
-        super("Cannot determine size of OpenStack databases. #{message}")
+      class DatabaseSizeError < UpgradeError
+        def initialize(message = "")
+          super("Cannot determine size of OpenStack databases. #{message}")
+        end
       end
-    end
 
-    class UpgradeDatabaseDumpError < StandardError
-      def initialize(message = "")
-        super("Cannot create dump of OpenStack databases. #{message}")
+      class DatabaseDumpError < UpgradeError
+        def initialize(message = "")
+          super("Cannot create dump of OpenStack databases. #{message}")
+        end
       end
     end
   end

--- a/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/crowbar_controller_spec.rb
@@ -35,11 +35,6 @@ describe Api::CrowbarController, type: :request do
       expect(response.body).to eq(crowbar_object)
     end
 
-    it "updates the crowbar object" do
-      patch "/api/crowbar", {}, headers
-      expect(response).to have_http_status(:not_implemented)
-    end
-
     it "shows the status of the crowbar upgrade" do
       get "/api/crowbar/upgrade", {}, headers
       expect(response).to have_http_status(:ok)

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -48,11 +48,6 @@ describe Api::UpgradeController, type: :request do
       expect(response.body).to eq(upgrade_status)
     end
 
-    it "updates the upgrade status object" do
-      patch "/api/upgrade", {}, headers
-      expect(response).to have_http_status(:not_implemented)
-    end
-
     it "prepares the crowbar upgrade" do
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :start_step

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -446,13 +446,7 @@ describe Api::Upgrade do
       ).with(:nodes).and_return(true)
       allow(Node).to(receive(:find).and_raise("Some Error"))
       allow_any_instance_of(Crowbar::UpgradeStatus).to(
-        receive(:end_step).
-        with(
-          false, nodes: {
-            data: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
-          }
-        ).
-        and_return(false)
+        receive(:end_step).and_return(false)
       )
 
       expect { subject.class.nodes }.to raise_error(RuntimeError)

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -158,7 +158,7 @@ describe Api::Upgrade do
         receive(:compute_status).and_return({})
       )
 
-      expect(subject.class.services).to be_a(Delayed::Backend::ActiveRecord::Job)
+      expect(subject.class.services_without_delay).to be true
     end
   end
 
@@ -170,7 +170,7 @@ describe Api::Upgrade do
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
-      expect(subject.class.services).to be_a(Delayed::Backend::ActiveRecord::Job)
+      expect(subject.class.services_without_delay).to be nil
     end
   end
 
@@ -411,12 +411,13 @@ describe Api::Upgrade do
       allow_any_instance_of(Api::Node).to receive(:join_and_chef).and_return(true)
       allow_any_instance_of(Api::Node).to receive(:save_node_state).and_return(true)
       allow(Api::Upgrade).to receive(:upgrade_all_compute_nodes).and_return(true)
+      allow(Api::Upgrade).to receive(:evacuate_network_node).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :start_step
       ).with(:nodes).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
-      expect(subject.class.nodes).to be_a(Delayed::Backend::ActiveRecord::Job)
+      expect(subject.class.nodes_without_delay).to be true
     end
 
     it "successfully completes the upgrade when they are no compute nodes" do
@@ -437,7 +438,7 @@ describe Api::Upgrade do
       ).with(:nodes).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
-      expect(subject.class.nodes).to be_a(Delayed::Backend::ActiveRecord::Job)
+      expect(subject.class.nodes_without_delay).to be true
     end
 
     it "fails with some non-upgrade error" do
@@ -449,7 +450,7 @@ describe Api::Upgrade do
         receive(:end_step).and_return(false)
       )
 
-      expect { subject.class.nodes }.to raise_error(RuntimeError)
+      expect { subject.class.nodes_without_delay }.to raise_error(RuntimeError)
     end
 
     it "fails to upgrade compute nodes when there is no nova-controller" do
@@ -487,7 +488,7 @@ describe Api::Upgrade do
         and_return(false)
       )
 
-      expect(subject.class.nodes).to be_a(Delayed::Backend::ActiveRecord::Job)
+      expect(subject.class.nodes_without_delay).to be false
     end
 
     it "during the upgrade of controller nodes, detect that they are upgraded" do
@@ -518,7 +519,7 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to receive(:upgrade_all_compute_nodes).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
-      expect(subject.class.nodes).to be_a(Delayed::Backend::ActiveRecord::Job)
+      expect(subject.class.nodes_without_delay).to be true
     end
 
     it "during the upgrade of compute nodes, detect that they are upgraded" do
@@ -538,7 +539,7 @@ describe Api::Upgrade do
       allow(Node).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
-      expect(subject.class.nodes).to be_a(Delayed::Backend::ActiveRecord::Job)
+      expect(subject.class.nodes_without_delay).to be true
     end
 
     it "successfully upgrades KVM compute nodes" do
@@ -570,7 +571,7 @@ describe Api::Upgrade do
       ).with(:nodes).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
-      expect(subject.class.nodes).to be_a(Delayed::Backend::ActiveRecord::Job)
+      expect(subject.class.nodes_without_delay).to be true
     end
   end
 
@@ -763,7 +764,7 @@ describe Api::Upgrade do
         :end_step
       ).and_return(true)
 
-      expect(subject.class.openstackbackup).to be_a(Delayed::Backend::ActiveRecord::Job)
+      expect(subject.class.openstackbackup_without_delay).to be true
     end
 
     it "finds out that an OpenStack backup has already been created" do
@@ -777,7 +778,7 @@ describe Api::Upgrade do
         :end_step
       ).and_return(true)
 
-      expect(subject.class.openstackbackup).to be_a(Delayed::Backend::ActiveRecord::Job)
+      expect(subject.class.openstackbackup_without_delay).to be nil
     end
   end
 

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -448,8 +448,9 @@ describe Api::Upgrade do
       allow_any_instance_of(Crowbar::UpgradeStatus).to(
         receive(:end_step).
         with(
-          false, nodes:
-          "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+          false, nodes: {
+            data: "Crowbar has failed. Check /var/log/crowbar/production.log for details."
+          }
         ).
         and_return(false)
       )

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -595,7 +595,7 @@ describe Api::Upgrade do
       ).and_raise("Some Error")
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:current_step).and_return(:database)
 
-      expect { subject.class.cancel }.to raise_error(Crowbar::Error::UpgradeCancelError)
+      expect { subject.class.cancel }.to raise_error(Crowbar::Error::Upgrade::CancelError)
     end
 
     it "is allowed to cancel the upgrade" do
@@ -648,7 +648,7 @@ describe Api::Upgrade do
           :current_step
         ).and_return(allowed_step)
 
-        expect { subject.class.cancel }.to raise_error(Crowbar::Error::UpgradeCancelError)
+        expect { subject.class.cancel }.to raise_error(Crowbar::Error::Upgrade::CancelError)
       end
     end
 
@@ -663,7 +663,7 @@ describe Api::Upgrade do
         :running?
       ).and_return(true)
 
-      expect { subject.class.cancel }.to raise_error(Crowbar::Error::UpgradeCancelError)
+      expect { subject.class.cancel }.to raise_error(Crowbar::Error::Upgrade::CancelError)
     end
   end
 


### PR DESCRIPTION
What we need to test here:

- correct handling of progress lib errors (step out of order, step already running)
- correct handling of real upgrade errors (e.g. failure during some node action in nodes step)
- correct handling of non-upgrade errors (syntax errors, calling methods on nil objects etc.)