### PR TITLE
upgrade: Treat 'nodes' step as a last one

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -117,11 +117,11 @@ module Crowbar
           status: success ? :passed : :failed,
           errors: errors
         }
-        next_step
-        save
         if finished? && success
           FileUtils.touch("/var/lib/crowbar/upgrade/6-to-7-upgraded-ok")
         end
+        next_step
+        save
         success
       end
     end
@@ -220,8 +220,7 @@ module Crowbar
         :repocheck_nodes,
         :services,
         :backup_openstack,
-        :nodes,
-        :finished
+        :nodes
       ]
     end
 

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -36,9 +36,6 @@
     },
     "nodes":{
       "status":"pending"
-    },
-    "finished":{
-      "status":"pending"
     }
   }
 }

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -187,10 +187,9 @@ describe Crowbar::UpgradeStatus do
       expect(subject.start_step(:backup_openstack)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :nodes
-      expect(subject.start_step(:nodes)).to be true
       allow(FileUtils).to receive(:touch).and_return(true)
+      expect(subject.start_step(:nodes)).to be true
       expect(subject.end_step).to be true
-      expect(subject.current_step).to eql :finished
       expect(subject.finished?).to be true
       expect { subject.end_step }.to raise_error(Crowbar::Error::EndStepRunningError)
     end


### PR DESCRIPTION
Remove strage 'finished' step, mark the upgrade end directly
after the nodes upgrade.