### PR TITLE
network: Manually set datapath-ids on the ovs-bridges (bsc#1022074)

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -808,6 +808,22 @@ class ::Nic
       ::Kernel.system("ovs-vsctl add-port #{@nic} #{slave}")
     end
 
+    def datapath_id
+      res = ""
+      ::IO.popen("ovs-vsctl get Bridge #{@nic} datapath-id 2> /dev/null") do |f|
+        f.each do |line|
+          # There should only be one line of output, the double quoted
+          # datapath-id
+          res = line.strip.tr('"', '')
+        end
+      end
+      res
+    end
+
+    def datapath_id=(id)
+      ::Kernel.system("ovs-vsctl set Bridge #{@nic} other-config:datapath-id=#{id}")
+    end
+
     def self.create(nic, slaves = [])
       Chef::Log.info("Creating new OVS bridge #{nic}")
       if self.exists?(nic)


### PR DESCRIPTION
Openvswitch by default sets the datapath-id based on the MAC address of
the bridges. If the underlying interfaces share the same MAC address
(i.e.  when using eth0 for br-fixed and eth0.300 for br-public) we will
endup with duplicate datapath-ids, which break neutron-openvswitch-agent.

https://bugzilla.suse.com/show_bug.cgi?id=1022074