### PR TITLE
upgrade: Indicate running upgrade process

### DIFF
--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -34,8 +34,7 @@ class ApplicationController < ActionController::Base
     Rails.env.test?
   }
   before_filter :upgrade, if: proc {
-    File.exist?("/var/lib/crowbar/upgrade/6-to-7-progress.yml") && \
-      !File.exist?("/var/lib/crowbar/upgrade/6-to-7-upgraded-ok")
+    File.exist?("/var/lib/crowbar/upgrade/6-to-7-upgrade-running")
   }
   before_filter :sanity_checks, unless: proc {
     Rails.env.test? || \

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -64,6 +64,7 @@ module Crowbar
       @progress[:steps] = upgrade_steps_6_7.map do |step|
         [step, { status: :pending }]
       end.to_h
+      FileUtils.rm_f("/var/lib/crowbar/upgrade/6-to-7-upgrade-running")
       save
     end
 
@@ -103,6 +104,9 @@ module Crowbar
         progress[:current_step] = step_name
         progress[:steps][step_name][:status] = :running
         progress[:steps][step_name][:errors] = {}
+        if step_name == :prepare
+          FileUtils.touch("/var/lib/crowbar/upgrade/6-to-7-upgrade-running")
+        end
         save
       end
     end
@@ -120,7 +124,7 @@ module Crowbar
         next_step
         save
         if finished? && success
-          FileUtils.touch("/var/lib/crowbar/upgrade/6-to-7-upgraded-ok")
+          FileUtils.rm_f("/var/lib/crowbar/upgrade/6-to-7-upgrade-running")
         end
         success
       end

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -163,6 +163,7 @@ describe Crowbar::UpgradeStatus do
       expect(subject.start_step(:prechecks)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :prepare
+      allow(FileUtils).to receive(:touch).and_return(true)
       expect(subject.start_step(:prepare)).to be true
       expect(subject.end_step).to be true
       expect(subject.current_step).to eql :backup_crowbar
@@ -206,6 +207,7 @@ describe Crowbar::UpgradeStatus do
       )
       expect(subject.running?(:prechecks)).to be true
       expect(subject.end_step).to be true
+      allow(FileUtils).to receive(:touch).and_return(true)
       expect(subject.start_step(:prepare)).to be true
       expect(subject.end_step).to be true
       expect(subject.start_step(:backup_crowbar)).to be true
@@ -247,6 +249,7 @@ describe Crowbar::UpgradeStatus do
     it "prevents repeating steps when it's too late or too early" do
       expect(subject.start_step(:prechecks)).to be true
       expect(subject.end_step).to be true
+      allow(FileUtils).to receive(:touch).and_return(true)
       expect(subject.start_step(:prepare)).to be true
       expect { subject.start_step(:prechecks) }.to raise_error(
         Crowbar::Error::StartStepOrderError


### PR DESCRIPTION
The file can be used by crowbar so the non-upgrade related
requests are blocked during the upgrade.

Fixes bsc#1016923

(cherry picked from commit a86a4bb5677137cead375e4a94d80d1afdc92ad3)
