### PR TITLE
[stable/3.0] upgrade: Fix no_live_migration check without nova

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -159,7 +159,7 @@ module Api
           )
         end
         nova = NodeObject.find("roles:nova-controller").first
-        ret[:no_live_migration] = true unless nova["nova"]["use_migration"]
+        ret[:no_live_migration] = true if nova && !nova["nova"]["use_migration"]
         ret
       end
 


### PR DESCRIPTION
If nova-controller role is not applied correctly, prechecks were
failing with 500 response and status was left at running.

backport of #1033 