### PR TITLE
upgrade: Mark successfull router migration on the target node

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-router-migration.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-router-migration.sh.erb
@@ -35,17 +35,23 @@ set +x
 source /root/.openrc
 set -x
 
+if ssh $hostname "test -e $UPGRADEDIR/crowbar-router-migrated" ; then
+    log "l3 agent was already evacuated from host $hostname"
+    touch $UPGRADEDIR/crowbar-router-migration-ok
+    exit 0
+fi
 
 zypper --non-interactive install openstack-neutron-ha-tool
 
 /usr/bin/neutron-ha-tool --l3-agent-evacuate $hostname --wait-for-router $delete_ns
 ret=$?
 if [ $ret != 0 ] ; then
-    echo "Failed to evacuate l3 agent on host: $hostname"
+    log "Failed to evacuate l3 agent on host: $hostname"
     echo $ret > $UPGRADEDIR/crowbar-router-migration-failed
     exit $ret
 fi
 
+ssh $hostname "mkdir -p $UPGRADEDIR && touch $UPGRADEDIR/crowbar-router-migrated"
 
 touch $UPGRADEDIR/crowbar-router-migration-ok
 log "$BASH_SOURCE is finished."


### PR DESCRIPTION
That way we should know that there's no need to run the script again.

This is trying to solve the problem where we restart the upgrade after the failure in the step where routers were already evacuated, neutron-server was stopped, but node upgrade did not reach the point where the new resource is configured.