### PR TITLE
barclamp: Fix fetching config item when no instance is specified

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -417,7 +417,7 @@ module BarclampLibrary
           if instance.nil?
             # try the "default" instance, and fallback on any existing instance
             instance = "default"
-            unless @cache["groups"][group].fetch("default", {}).key?(barclamp)
+            unless @cache["groups"][group].fetch(instance, {}).key?(barclamp)
               # sort to guarantee a consistent order
               @cache["groups"][group].keys.sort.each do |key|
                 # ignore the id attribute from the data bag item, which is not

--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -420,6 +420,9 @@ module BarclampLibrary
             unless @cache["groups"][group].fetch("default", {}).key?(barclamp)
               # sort to guarantee a consistent order
               @cache["groups"][group].keys.sort.each do |key|
+                # ignore the id attribute from the data bag item, which is not
+                # an instance
+                next if key == "id"
                 if @cache["groups"][group][key].key?(barclamp)
                   instance = key
                   break


### PR DESCRIPTION
We were iterating over all instances based on keys, but the id of the
data bag item was included in the keys, leading to a crash:
```
NoMethodError
-------------
undefined method `key?' for "openstack":String
```