### PR TITLE
[3.0] upgrade: Implement a dummy cloud 7 api

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -156,6 +156,68 @@ class Api::UpgradeController < ApiController
     @backup.cleanup unless @backup.nil?
   end
 
+  # dummy routes to satisfy a client that calls an endpoint that only exists
+  # in a newer cloud version
+  def database_new
+    render json: {
+      errors: {
+        database: {
+          data: ::Crowbar::Error::StartStepOrderError.new(:database).message
+        }
+      }
+    }, status: :unprocessable_entity
+  end
+
+  def database_connect
+    render json: {
+      errors: {
+        database: {
+          data: ::Crowbar::Error::StartStepOrderError.new(:database).message
+        }
+      }
+    }, status: :unprocessable_entity
+  end
+
+  def noderepocheck
+    render json: {
+      errors: {
+        repocheck_nodes: {
+          data: ::Crowbar::Error::StartStepOrderError.new(:repocheck_nodes).message
+        }
+      }
+    }, status: :unprocessable_entity
+  end
+
+  def services
+    render json: {
+      errors: {
+        services: {
+          data: ::Crowbar::Error::StartStepOrderError.new(:services).message
+        }
+      }
+    }, status: :unprocessable_entity
+  end
+
+  def nodes
+    render json: {
+      errors: {
+        nodes: {
+          data: ::Crowbar::Error::StartStepOrderError.new(:nodes).message
+        }
+      }
+    }, status: :unprocessable_entity
+  end
+
+  def openstackbackup
+    render json: {
+      errors: {
+        backup_openstack: {
+          data: ::Crowbar::Error::StartStepOrderError.new(:backup_openstack).message
+        }
+      }
+    }, status: :unprocessable_entity
+  end
+
   protected
 
   def backup_params

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -208,11 +208,15 @@ Rails.application.routes.draw do
       only: [:show, :update] do
       post :prepare
       post :services
-      get :services
       get :prechecks
       post :cancel
       get :adminrepocheck
       post :adminbackup
+      post :database_new, path: "new"
+      post :database_connect, path: "connect"
+      post :nodes
+      get :noderepocheck
+      post :openstackbackup
     end
   end
 


### PR DESCRIPTION
when a client on cloud 6 requests an upgrade route that only exists
in cloud 7, a StartStepOrder exception should be thrown