### PR TITLE
update: Error out on first failed router-migration (bsc#1020914)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-router-migration.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-router-migration.sh.erb
@@ -38,7 +38,9 @@ set -x
 
 zypper --non-interactive install openstack-neutron-ha-tool
 
-/usr/bin/neutron-ha-tool --l3-agent-evacuate $hostname --wait-for-router $delete_ns
+/usr/bin/neutron-ha-tool --l3-agent-evacuate $hostname \
+                         --wait-for-router $delete_ns \
+                         --exit-on-first-failure
 ret=$?
 if [ $ret != 0 ] ; then
     echo "Failed to evacuate l3 agent on host: $hostname"


### PR DESCRIPTION
This uses the newly introduced "--exit-on-first-failure" argument for
neutron-ha-tool to immediately exit when a single router migration
fails.

We want the user to give a chance to debug/fix failing router
migrations to prevent all routers going offline at once in case
something is wrong on the target nodes (e.g. non-running l2-agents).

https://bugzilla.suse.com/show_bug.cgi?id=1020914