### PR TITLE
Don't do platform checks against clusters in JS validation

### DIFF
--- a/crowbar_framework/vendor/assets/javascripts/jquery/nodeList.js
+++ b/crowbar_framework/vendor/assets/javascripts/jquery/nodeList.js
@@ -370,37 +370,43 @@
         }
       }
 
-      if (constraints.platform !== undefined && constraints.platform) {
-        var platforms = $.map(constraints.platform, function(c_version, c_platform) {
-          return (platform === c_platform) && self.equalOrMatchVersion(platform_version, c_version);
-        });
-        var is_any_true = platforms.some(function (element, index, array) {
-          return element;
-        });
-        if (!is_any_true) {
-          return self.errorMessage(
-            'barclamp.node_selector.platform'.localize().format(
-              alias,
-              role
-            )
-          );
-        }
-      }
+      if (!cluster && !remotes) {
+        // Don't do platform checks for clusters; clusters don't include platform information
+        // so, for example, if a constraint specifies a specific platform requirement, the
+        // check will always fail because there's no platform set for the cluster.
 
-      if (constraints.exclude_platform !== undefined && constraints.exclude_platform) {
-        var platforms = $.map(constraints.exclude_platform, function(c_version, c_platform) {
-          return (platform === c_platform) && self.equalOrMatchVersion(platform_version, c_version);
-        });
-        var is_any_true = platforms.some(function (element, index, array) {
-          return element;
-        });
-        if (is_any_true) {
-          return self.errorMessage(
-            'barclamp.node_selector.exclude_platform'.localize().format(
-              alias,
-              role
-            )
-          );
+        if (constraints.platform !== undefined && constraints.platform) {
+          var platforms = $.map(constraints.platform, function(c_version, c_platform) {
+            return (platform === c_platform) && self.equalOrMatchVersion(platform_version, c_version);
+          });
+          var is_any_true = platforms.some(function (element, index, array) {
+            return element;
+          });
+          if (!is_any_true) {
+            return self.errorMessage(
+              'barclamp.node_selector.platform'.localize().format(
+                alias,
+                role
+              )
+            );
+          }
+        }
+
+        if (constraints.exclude_platform !== undefined && constraints.exclude_platform) {
+          var platforms = $.map(constraints.exclude_platform, function(c_version, c_platform) {
+            return (platform === c_platform) && self.equalOrMatchVersion(platform_version, c_version);
+          });
+          var is_any_true = platforms.some(function (element, index, array) {
+            return element;
+          });
+          if (is_any_true) {
+            return self.errorMessage(
+              'barclamp.node_selector.exclude_platform'.localize().format(
+                alias,
+                role
+              )
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
Found while investigating https://bugzilla.suse.com/show_bug.cgi?id=956582
If a role specifies a platform constraint, the JavaScript validation will
try to enforce this when assigning a cluster to that role.  But, clusters
don't actually have platform information attached, so the check will always
fail (this isn't a problem for platform *exclusion* tests, which effectively
work by accident).  This commit skips all platform checks for clusters,
which seems to be the approach taken by the backend code in service_object.rb
(violates_platform_constraint? and violates_exclude_platform_constraint?)

Signed-off-by: Tim Serong <tserong@suse.com>