### PR TITLE
upgrade: Enable node upgrade status api

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -20,6 +20,7 @@ class Api::UpgradeController < ApiController
   api :GET, "/api/upgrade", "Show the Upgrade progress"
   header "Accept", "application/vnd.crowbar.v2.0+json", required: true
   api_version "2.0"
+  param :nodes, [true, false], desc: "Status of the nodes upgrade", required: false
   example '
   {
     "current_step": "admin",
@@ -75,7 +76,11 @@ class Api::UpgradeController < ApiController
   }
   '
   def show
-    render json: Api::Upgrade.status
+    if params[:nodes]
+      render json: Api::Upgrade.node_status
+    else
+      render json: Api::Upgrade.status
+    end
   end
 
   api :POST, "/api/upgrade/prepare", "Prepare Crowbar Upgrade"

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -23,6 +23,19 @@ module Api
         ::Crowbar::UpgradeStatus.new.progress
       end
 
+      def node_status
+        not_upgraded = if ::Crowbar::UpgradeStatus.new.pending?(:prepare) || \
+            ::Crowbar::UpgradeStatus.new.running?(:prepare)
+          ::Node.all.reject(&:admin?).map(&:name)
+        else
+          ::Node.find("state:crowbar_upgrade").map(&:name)
+        end
+        {
+          upgraded: ::Node.all.reject(&:admin?).select(&:ready_after_upgrade?).map(&:name),
+          not_upgraded: not_upgraded
+        }
+      end
+
       #
       # prechecks
       #

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -24,11 +24,10 @@ module Api
       end
 
       def node_status
-        not_upgraded = if ::Crowbar::UpgradeStatus.new.pending?(:prepare) || \
-            ::Crowbar::UpgradeStatus.new.running?(:prepare)
-          ::Node.all.reject(&:admin?).map(&:name)
-        else
+        not_upgraded = if ::Crowbar::UpgradeStatus.new.passed?(:prepare)
           ::Node.find("state:crowbar_upgrade").map(&:name)
+        else
+          ::Node.all.reject(&:admin?).map(&:name)
         end
         {
           upgraded: ::Node.all.reject(&:admin?).select(&:ready_after_upgrade?).map(&:name),

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -142,6 +142,14 @@ module Crowbar
       step[:status] == :pending
     end
 
+    def failed?(step_name = nil)
+      progress[:steps][step_name || current_step][:status] == :failed
+    end
+
+    def passed?(step_name)
+      progress[:steps][step_name][:status] == :passed
+    end
+
     def finished?
       current_step == upgrade_steps_6_7.last
     end

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -48,6 +48,24 @@ describe Api::UpgradeController, type: :request do
       expect(response.body).to eq(upgrade_status)
     end
 
+    it "shows the node status" do
+      allow(Node).to receive(:all).and_return([Node.find_by_name("testing.crowbar.com")])
+      allow_any_instance_of(Node).to receive(:ready_after_upgrade?).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:pending?).with(:prepare).and_return(
+        false
+      )
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:running?).with(:prepare).and_return(
+        false
+      )
+
+      get "/api/upgrade", { nodes: true }, headers
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq(
+        "upgraded" => ["testing.crowbar.com"],
+        "not_upgraded" => []
+      )
+    end
+
     it "prepares the crowbar upgrade" do
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :start_step

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -51,11 +51,8 @@ describe Api::UpgradeController, type: :request do
     it "shows the node status" do
       allow(Node).to receive(:all).and_return([Node.find_by_name("testing.crowbar.com")])
       allow_any_instance_of(Node).to receive(:ready_after_upgrade?).and_return(true)
-      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:pending?).with(:prepare).and_return(
-        false
-      )
-      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:running?).with(:prepare).and_return(
-        false
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:passed?).with(:prepare).and_return(
+        true
       )
 
       get "/api/upgrade", { nodes: true }, headers

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -98,6 +98,40 @@ describe Crowbar::UpgradeStatus do
       expect(subject.running?(:prepare)).to be false
     end
 
+    it "determines whether current step has failed" do
+      allow(FileUtils).to receive(:touch).and_return(true)
+
+      expect(subject.current_step).to eql :prechecks
+      expect(subject.start_step(:prechecks)).to be true
+      expect(subject.failed?).to be false
+      subject.end_step
+      expect(subject.start_step(:prepare)).to be true
+      subject.end_step(false, "Some Error")
+      expect(subject.failed?).to be true
+    end
+
+    it "determines whether given step has failed" do
+      allow(FileUtils).to receive(:touch).and_return(true)
+
+      expect(subject.start_step(:prechecks)).to be true
+      expect(subject.failed?(:prechecks)).to be false
+      subject.end_step
+      expect(subject.start_step(:prepare)).to be true
+      subject.end_step(false, "Some Error")
+      expect(subject.failed?(:prepare)).to be true
+    end
+
+    it "determines whether given step has passed" do
+      allow(FileUtils).to receive(:touch).and_return(true)
+
+      expect(subject.start_step(:prechecks)).to be true
+      expect(subject.failed?(:prechecks)).to be false
+      subject.end_step
+      expect(subject.start_step(:prepare)).to be true
+      subject.end_step(false, "Some Error")
+      expect(subject.failed?(:prepare)).to be true
+    end
+
     it "moves to next step when requested" do
       expect(subject.current_step).to eql :prechecks
       expect(subject.current_step_state[:status]).to eql :pending

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -96,6 +96,22 @@ describe Api::Upgrade do
       expect(subject.class.status).to be_a(Hash)
       expect(subject.class.status.to_json).to eq(upgrade_status.to_json)
     end
+
+    it "checks the node upgrade status" do
+      allow(Node).to receive(:all).and_return([Node.find_by_name("testing.crowbar.com")])
+      allow_any_instance_of(Node).to receive(:ready_after_upgrade?).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:pending?).with(:prepare).and_return(
+        false
+      )
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:running?).with(:prepare).and_return(
+        false
+      )
+
+      expect(subject.class.node_status).to eq(
+        upgraded: ["testing.crowbar.com"],
+        not_upgraded: []
+      )
+    end
   end
 
   context "with a successful maintenance updates check" do

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -100,11 +100,8 @@ describe Api::Upgrade do
     it "checks the node upgrade status" do
       allow(Node).to receive(:all).and_return([Node.find_by_name("testing.crowbar.com")])
       allow_any_instance_of(Node).to receive(:ready_after_upgrade?).and_return(true)
-      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:pending?).with(:prepare).and_return(
-        false
-      )
-      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:running?).with(:prepare).and_return(
-        false
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:passed?).with(:prepare).and_return(
+        true
       )
 
       expect(subject.class.node_status).to eq(


### PR DESCRIPTION
this lists all upgraded and all non upgraded nodes

## NOTE
~~`crowbarctl` PR will follow~~

here it is https://github.com/crowbar/crowbar-client/pull/147

## example response
```bash
{
  "upgraded": [
  ],
  "not_upgraded": [
    "d52-54-77-77-77-03.emil.suse.de",
    "d52-54-77-77-77-01.emil.suse.de",
    "d52-54-77-77-77-02.emil.suse.de",
    "d52-54-77-77-77-04.emil.suse.de"
  ]
}
```