### PR TITLE
upgrade: Adapt the swift configuration on compute nodes

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -149,6 +149,8 @@ if neutron[:neutron][:use_dvr]
   metadata_agent = "openstack-neutron-metadata-agent"
 end
 
+swift_storage = roles.include? "swift-storage"
+
 # Following script executes all actions that are needed directly on the node
 # directly before the OS upgrade is initiated.
 template "/usr/sbin/crowbar-pre-upgrade.sh" do
@@ -160,6 +162,7 @@ template "/usr/sbin/crowbar-pre-upgrade.sh" do
   variables(
     use_ha: use_ha,
     compute_node: compute_node,
+    swift_storage: swift_storage,
     bridges_to_reset: bridges_to_reset,
     cinder_volume: cinder_volume,
     neutron_agent: neutron_agent,

--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -113,6 +113,16 @@ zypper --non-interactive up openstack-cinder-volume
 systemctl restart openstack-cinder-volume.service
 <% end %>
 
+<% if @swift_storage %>
+log "Upgrading swift-storage configuration"
+crudini --set /etc/swift/object-server.conf DEFAULT bind_port 6200
+crudini --set /etc/swift/container-server.conf DEFAULT bind_port 6201
+crudini --set /etc/swift/account-server.conf DEFAULT bind_port 6202
+systemctl restart openstack-swift-account
+systemctl restart openstack-swift-object
+systemctl restart openstack-swift-container
+<% end %>
+
 # Remove temporary config options
 rm -f /etc/nova/nova.conf.d/200-crowbar-upgrade.conf
 rm -f /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf


### PR DESCRIPTION
Before is the compute node fully upgraded, we upgrade only selected
services that are needed for instances live-migration.

The configuration needs to be adapted as well, to be able to talk
to upgraded services at controller nodes.