### PR TITLE
[stable/3.0] Enable node upgrade status api 

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -18,7 +18,11 @@ class Api::UpgradeController < ApiController
   skip_before_filter :upgrade
 
   def show
-    render json: Api::Upgrade.status
+    if params[:nodes]
+      render json: Api::Upgrade.node_status
+    else
+      render json: Api::Upgrade.status
+    end
   end
 
   def prepare

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -23,6 +23,9 @@ module Api
         ::Crowbar::UpgradeStatus.new.progress
       end
 
+      #
+      # prechecks
+      #
       def checks
         upgrade_status = ::Crowbar::UpgradeStatus.new
         # the check for current_step means to allow running the step at any point in time

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -23,6 +23,13 @@ module Api
         ::Crowbar::UpgradeStatus.new.progress
       end
 
+      def node_status
+        {
+          upgraded: [],
+          not_upgraded: NodeObject.all.reject(&:admin?).map(&:name)
+        }
+      end
+
       #
       # prechecks
       #

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -142,6 +142,14 @@ module Crowbar
       step[:status] == :pending
     end
 
+    def failed?(step_name = nil)
+      progress[:steps][step_name || current_step][:status] == :failed
+    end
+
+    def passed?(step_name)
+      progress[:steps][step_name][:status] == :passed
+    end
+
     def finished?
       current_step == upgrade_steps_6_7.last
     end

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -44,6 +44,18 @@ describe Api::UpgradeController, type: :request do
       expect(response.body).to eq(upgrade_status)
     end
 
+    it "shows the node status" do
+      allow(NodeObject).to receive(:all).
+      and_return([NodeObject.find_node_by_name("testing.crowbar.com")])
+
+      get "/api/upgrade", { nodes: true }, headers
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq(
+        "not_upgraded" => ["testing.crowbar.com"],
+        "upgraded" => []
+      )
+    end
+
     it "prepares the crowbar upgrade" do
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :start_step

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -98,6 +98,40 @@ describe Crowbar::UpgradeStatus do
       expect(subject.running?(:prepare)).to be false
     end
 
+    it "determines whether current step has failed" do
+      allow(FileUtils).to receive(:touch).and_return(true)
+
+      expect(subject.current_step).to eql :prechecks
+      expect(subject.start_step(:prechecks)).to be true
+      expect(subject.failed?).to be false
+      subject.end_step
+      expect(subject.start_step(:prepare)).to be true
+      subject.end_step(false, "Some Error")
+      expect(subject.failed?).to be true
+    end
+
+    it "determines whether given step has failed" do
+      allow(FileUtils).to receive(:touch).and_return(true)
+
+      expect(subject.start_step(:prechecks)).to be true
+      expect(subject.failed?(:prechecks)).to be false
+      subject.end_step
+      expect(subject.start_step(:prepare)).to be true
+      subject.end_step(false, "Some Error")
+      expect(subject.failed?(:prepare)).to be true
+    end
+
+    it "determines whether given step has passed" do
+      allow(FileUtils).to receive(:touch).and_return(true)
+
+      expect(subject.start_step(:prechecks)).to be true
+      expect(subject.failed?(:prechecks)).to be false
+      subject.end_step
+      expect(subject.start_step(:prepare)).to be true
+      subject.end_step(false, "Some Error")
+      expect(subject.failed?(:prepare)).to be true
+    end
+
     it "moves to next step when requested" do
       expect(subject.current_step).to eql :prechecks
       expect(subject.current_step_state[:status]).to eql :pending

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -62,6 +62,16 @@ describe Api::Upgrade do
       expect(subject.class.status).to be_a(Hash)
       expect(subject.class.status.to_json).to eq(upgrade_status.to_json)
     end
+
+    it "checks the node upgrade status" do
+      allow(NodeObject).to receive(:all).
+      and_return([NodeObject.find_node_by_name("testing.crowbar.com")])
+
+      expect(subject.class.node_status).to eq(
+        not_upgraded: ["testing.crowbar.com"],
+        upgraded: []
+      )
+    end
   end
 
   context "with a successful check" do


### PR DESCRIPTION
Partial backport of https://github.com/crowbar/crowbar-core/pull/1062 - node status should be just always empty here