### PR TITLE
upgrade: Save 'node_upgrade_state' into the role, not node

### DIFF
--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -166,7 +166,7 @@ module Api
         end
       end
       @node = ::Node.find_by_name(@node.name)
-      @node["crowbar_wall"]["node_upgrade_state"] = state
+      @node.crowbar["node_upgrade_state"] = state
       @node.save
     end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -658,7 +658,7 @@ module Api
         return unless node["crowbar_wall"].key? "crowbar_upgrade_step"
 
         node["crowbar_wall"].delete "crowbar_upgrade_step"
-        node["crowbar_wall"].delete "node_upgrade_state"
+        node.crowbar.delete "node_upgrade_state"
         node.save
 
         scripts_to_delete = [

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -857,14 +857,14 @@ class Node < ChefObject
   end
 
   def upgraded?
-    upgrade_state = @node["crowbar_wall"]["node_upgrade_state"] || ""
+    upgrade_state = crowbar["node_upgrade_state"] || ""
     return false unless upgrade_state == "upgraded"
     Rails.logger.info("Node #{@node.name} was already upgraded.")
     true
   end
 
   def upgrading?
-    @node["crowbar_wall"]["node_upgrade_state"] == "upgrading"
+    crowbar["node_upgrade_state"] == "upgrading"
   end
 
   # Check the status of script that was previously executed on the node.


### PR DESCRIPTION
If node_upgrade_state is saved into the node object, it could get
rewritten from chef-client running at the node.