### PR TITLE
upgrade: Change the check for list of upgraded/not upgraded nodes

### DIFF
--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -50,8 +50,8 @@ describe Api::UpgradeController, type: :request do
 
     it "shows the node status" do
       allow(Node).to receive(:all).and_return([Node.find_by_name("testing.crowbar.com")])
-      allow_any_instance_of(Node).to receive(:ready_after_upgrade?).and_return(true)
-      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:passed?).with(:prepare).and_return(
+      allow_any_instance_of(Node).to receive(:upgraded?).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:passed?).with(:services).and_return(
         true
       )
 

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -99,8 +99,8 @@ describe Api::Upgrade do
 
     it "checks the node upgrade status" do
       allow(Node).to receive(:all).and_return([Node.find_by_name("testing.crowbar.com")])
-      allow_any_instance_of(Node).to receive(:ready_after_upgrade?).and_return(true)
-      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:passed?).with(:prepare).and_return(
+      allow_any_instance_of(Node).to receive(:upgraded?).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:passed?).with(:services).and_return(
         true
       )
 


### PR DESCRIPTION
Original ready_after_upgrade? is not 100% correct, there are still some
later node actions after this is set. So let's check node.upgraded?
However, this does only return correct results during the upgrade, so
additional check if full upgrade is finished is needed.

Requires https://github.com/crowbar/crowbar-core/pull/1071