### PR TITLE
provisioner: Stop calling crowbar_join with --debug (bsc#1023972)

### DIFF
--- a/chef/cookbooks/crowbar/files/default/crowbar
+++ b/chef/cookbooks/crowbar/files/default/crowbar
@@ -25,7 +25,7 @@ if [[ -f /etc/crowbar.install.key ]]; then
 fi
 
 post_state() {
-  local curlargs=(-o "/var/log/crowbar/$1-$2.json" --connect-timeout 60 -s \
+  local curlargs=(-o /dev/null --connect-timeout 60 -s \
       -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
       -H "Accept: application/json" -H "Content-Type: application/json" \
       --max-time 240)

--- a/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
@@ -70,7 +70,7 @@
           fi
           post_state() {
               mkdir -p /var/log/crowbar
-              local curlargs=(-o "/mnt/var/log/crowbar/$1-$2.json" --connect-timeout 60 -s \
+              local curlargs=(-o /dev/null --connect-timeout 60 -s \
                 -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
                 -H "Accept: application/json" -H "Content-Type: application/json" \
                 --max-time 240)

--- a/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
@@ -128,7 +128,7 @@
       <script>
         <source>
 <![CDATA[
-/usr/sbin/crowbar_join --setup --debug --verbose
+/usr/sbin/crowbar_join --setup --verbose
 ]]>
         </source>
       </script>

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -273,7 +273,7 @@ fi
 
 post_state() {
 mkdir -p /var/log/crowbar
-local curlargs=(-o "/mnt/var/log/crowbar/$1-$2.json" --connect-timeout 60 -s \
+local curlargs=(-o /dev/null --connect-timeout 60 -s \
   -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
   -H "Accept: application/json" -H "Content-Type: application/json" \
   --max-time 240)

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -320,7 +320,7 @@ sync
       <script>
         <source>
 <![CDATA[
-/usr/sbin/crowbar_join --setup --debug --verbose
+/usr/sbin/crowbar_join --setup --verbose
 ]]>
         </source>
       </script>

--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.redhat.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.redhat.sh.erb
@@ -63,7 +63,7 @@ log_to() {
 }
 
 post_state() {
-  local curlargs=(-o "/var/log/$1-$2.json" --connect-timeout 60 -s \
+  local curlargs=(-o /dev/null --connect-timeout 60 -s \
       -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
       -H "Accept: application/json" -H "Content-Type: application/json" \
       --max-time 240)

--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -64,7 +64,7 @@ log_to() {
 }
 
 post_state() {
-  local curlargs=(-o "/var/log/crowbar/$1-$2.json" --connect-timeout 60 -s \
+  local curlargs=(-o /dev/null --connect-timeout 60 -s \
       -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
       -H "Accept: application/json" -H "Content-Type: application/json" \
       --max-time 240)

--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.ubuntu.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.ubuntu.sh.erb
@@ -64,7 +64,7 @@ log_to() {
 }
 
 post_state() {
-  local curlargs=(-o "/var/log/$1-$2.json" --connect-timeout 60 -s \
+  local curlargs=(-o /dev/null --connect-timeout 60 -s \
       -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
       -H "Accept: application/json" -H "Content-Type: application/json" \
       --max-time 240)

--- a/chef/cookbooks/provisioner/templates/default/net-post-install.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/net-post-install.sh.erb
@@ -77,7 +77,7 @@ elif [[ -f /etc/crowbar.install.key ]]; then
 fi
 
 post_state() {
-  local curlargs=(-o "/var/log/crowbar/$1-$2.json" --connect-timeout 60 -s \
+  local curlargs=(-o /dev/null --connect-timeout 60 -s \
       -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
       -H "Accept: application/json" -H "Content-Type: application/json" \
       --max-time 240)

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -127,7 +127,7 @@ post_allocate() {
 
 post_state() {
   local curlargs=($(get_common_curl_args) \
-                  -o "/var/log/crowbar/$1-$2.json"
+                  -o /dev/null
                   -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
                   -H "Accept: application/json" -H "Content-Type: application/json")
 

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -465,4 +465,4 @@ if test $? -eq 0; then
 fi
 rm -f "$DHCP_VARS"
 
-/usr/sbin/crowbar_join --setup --debug --verbose
+/usr/sbin/crowbar_join --setup --verbose


### PR DESCRIPTION
This is not really helpful (it's way too detailed), and this exposes
potentially sensitive data.

https://bugzilla.suse.com/show_bug.cgi?id=1023972