### PR TITLE
provisioner: set blocksize option on tftp server to 1024

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/tftp.service.erb
+++ b/chef/cookbooks/provisioner/templates/default/tftp.service.erb
@@ -3,4 +3,4 @@ Description=Tftp Server
 
 [Service]
 Type=simple
-ExecStart=/usr/sbin/in.tftpd -u tftp -s <%= @tftproot %> -m /etc/tftpd.conf -L -a <%= @admin_ip %>
+ExecStart=/usr/sbin/in.tftpd -u tftp -s <%= @tftproot %> -m /etc/tftpd.conf -L -a <%= @admin_ip %> -B 1024 -v


### PR DESCRIPTION
It seems that a variety of tftp clients can be picky about
the options, so there is a mechanism to restrict what
options the server offers to the clients to increase compatibility
with a wide variety of clients.

The qemu uefi tftp client doesnt seem to work very well negotiating the
blocksize. Forcing it to be 1024 makes it work.