### PR TITLE
[stable/3.0] Extra page for preparing ceph nodes for the upgrade

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -79,6 +79,9 @@ nav:
     logs:
       order: 20
       route: 'utils_path'
+    ceph_pre_upgrade:
+      order: 30
+      route: 'ceph_pre_upgrade_path'
   help:
     order: 80
     route: 'docs_path'

--- a/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
@@ -18,6 +18,13 @@ class CephPreUpgradeController < ApplicationController
     ceph_nodes = get_ceph_nodes
     @prepared = nodes_prepared(ceph_nodes)
     @no_ceph_nodes = ceph_nodes.empty?
+
+    respond_to do |format|
+      format.json do
+        render json: { prepared: @prepared, no_ceph_nodes: @no_ceph_nodes }
+      end
+      format.html
+    end
   end
 
   def prepare
@@ -41,12 +48,19 @@ class CephPreUpgradeController < ApplicationController
       status = :unprocessable_entity
     end
 
-    if status == :ok
-      flash[:notice] = success_msg
-    else
-      flash[:alert] = error_msg
+    respond_to do |format|
+      format.json do
+        render json: status
+      end
+      format.html do
+        if status == :ok
+          flash[:notice] = success_msg
+        else
+          flash[:alert] = error_msg
+        end
+        redirect_to ceph_pre_upgrade_url
+      end
     end
-    redirect_to ceph_pre_upgrade_url
   end
 
   private

--- a/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
@@ -15,8 +15,9 @@
 #
 class CephPreUpgradeController < ApplicationController
   def index
-    # FIXME: Check if Ceph is actually deployed!
-    @prepared = nodes_prepared
+    ceph_nodes = get_ceph_nodes
+    @prepared = nodes_prepared(ceph_nodes)
+    @no_ceph_nodes = ceph_nodes.empty?
   end
 
   def prepare
@@ -50,9 +51,13 @@ class CephPreUpgradeController < ApplicationController
 
   private
 
-  def nodes_prepared
+  def get_ceph_nodes
+    NodeObject.find("roles:ceph-* AND ceph_config_environment:*")
+  end
+
+  def nodes_prepared(nodes)
     ret = true
-    NodeObject.find("roles:ceph-* AND ceph_config_environment:*").each do |node|
+    nodes.each do |node|
       ret &&= node.state == "crowbar_upgrade"
     end
     ret

--- a/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
@@ -1,0 +1,60 @@
+#
+# Copyright 2017, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class CephPreUpgradeController < ApplicationController
+  def index
+    # FIXME: Check if Ceph is actually deployed!
+    @prepared = nodes_prepared
+  end
+
+  def prepare
+    status = :ok
+    error_msg = ""
+
+    begin
+      service_object = CrowbarService.new(Rails.logger)
+      if params["nodes_action"] == "revert"
+        Rails.logger.info("Reverting state of ceph nodes to ready....")
+        service_object.revert_nodes_from_crowbar_upgrade(true)
+        success_msg = I18n.t("ceph_pre_upgrade.success_revert")
+      else
+        Rails.logger.info("Preparing ceph nodes for upgrade....")
+        service_object.prepare_nodes_for_crowbar_upgrade(true)
+        success_msg = I18n.t("ceph_pre_upgrade.success_prepare")
+      end
+    rescue => e
+      error_msg = e.message
+      Rails.logger.error error_msg
+      status = :unprocessable_entity
+    end
+
+    if status == :ok
+      flash[:notice] = success_msg
+    else
+      flash[:alert] = error_msg
+    end
+    redirect_to ceph_pre_upgrade_url
+  end
+
+  private
+
+  def nodes_prepared
+    ret = true
+    NodeObject.find("roles:ceph-* AND ceph_config_environment:*").each do |node|
+      ret &&= node.state == "crowbar_upgrade"
+    end
+    ret
+  end
+end

--- a/crowbar_framework/app/views/ceph_pre_upgrade/index.html.haml
+++ b/crowbar_framework/app/views/ceph_pre_upgrade/index.html.haml
@@ -1,0 +1,19 @@
+.row
+  .col-xs-12
+    %h1.page-header
+      = t(".title")
+    .alert.alert-info
+      = t(".hint_html")
+
+    = form_for :ceph_pre_upgrade, url: prepare_ceph_pre_upgrade_path, html: { role: "form" }, data: { blockui: t(".blockui_message") } do |f|
+
+      .panel-body.text-left
+        - if @prepared
+          = t(".nodes_prepared")
+        - else
+          = t(".nodes_not_prepared")
+
+      .panel-body.text-left
+        .btn-group
+          %input{ type: "hidden", name: "nodes_action", value: @prepared ? "revert" : "prepare" }
+          %input.btn.btn-default{ type: "submit", name: "submit", value: @prepared ? t(".revert") : t(".prepare") }

--- a/crowbar_framework/app/views/ceph_pre_upgrade/index.html.haml
+++ b/crowbar_framework/app/views/ceph_pre_upgrade/index.html.haml
@@ -5,15 +5,21 @@
     .alert.alert-info
       = t(".hint_html")
 
-    = form_for :ceph_pre_upgrade, url: prepare_ceph_pre_upgrade_path, html: { role: "form" }, data: { blockui: t(".blockui_message") } do |f|
+    - if @no_ceph_nodes
 
-      .panel-body.text-left
-        - if @prepared
-          = t(".nodes_prepared")
-        - else
-          = t(".nodes_not_prepared")
+      = t(".no_ceph_nodes")
 
-      .panel-body.text-left
-        .btn-group
-          %input{ type: "hidden", name: "nodes_action", value: @prepared ? "revert" : "prepare" }
-          %input.btn.btn-default{ type: "submit", name: "submit", value: @prepared ? t(".revert") : t(".prepare") }
+    - else
+
+      = form_for :ceph_pre_upgrade, url: prepare_ceph_pre_upgrade_path, html: { role: "form" }, data: { blockui: t(".blockui_message") } do |f|
+
+        .panel-body.text-left
+          - if @prepared
+            = t(".nodes_prepared")
+          - else
+            = t(".nodes_not_prepared")
+
+        .panel-body.text-left
+          .btn-group
+            %input{ type: "hidden", name: "nodes_action", value: @prepared ? "revert" : "prepare" }
+            %input.btn.btn-default{ type: "submit", name: "submit", value: @prepared ? t(".revert") : t(".prepare") }

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -571,6 +571,9 @@ en:
       nodes_prepared: 'Ceph nodes are already prepared for the upgrade.'
       nodes_not_prepared: 'Ceph nodes are currently not prepared for the upgrade.'
       blockui_message: 'Processing, please wait...'
+      no_ceph_nodes: 'No Ceph nodes were found. Upgrade preparation is not needed.'
+    success_prepare: 'Ceph nodes were successfully prepared for SES upgrade.'
+    success_revert: 'Ceph nodes were successfully reverted to normal state.'
 
   installer:
     title: 'Installer'

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -84,6 +84,7 @@ en:
       logs: 'Exported Items'
       repositories: 'Repositories'
       backup: 'Backup & Restore'
+      ceph_pre_upgrade: 'Prepare Ceph Upgrade'
       upgrade: 'Upgrade'
     help: 'Help'
 
@@ -558,6 +559,18 @@ en:
       check_failed_fingerprint: 'Unexpected fingerprint'
       active: 'Active'
       active_repo_tooltip: 'Managed nodes will be automatically configured to use repositories only if they are marked as active'
+
+  ceph_pre_upgrade:
+    index:
+      title: 'Preparation of Ceph Nodes'
+      hint_html: |
+        The upgrade from SUSE Enterprise Storage 2.1 to 4 must be performed as outlined in the <a href="https://www.suse.com/documentation/ses-4/book_storage_admin/data/ceph_upgrade_to4.html">SUSE Enterprise Storage 4 documentation</a>.<br>
+        For this to work, the Ceph nodes must first be put into a prepared state, so that Crowbar will stop configuring them for the duration of the upgrade of both SUSE Enterprise Storage and SUSE OpenStack Cloud products.
+      prepare: 'Prepare for the Upgrade'
+      revert: 'Revert to normal state'
+      nodes_prepared: 'Ceph nodes are already prepared for the upgrade.'
+      nodes_not_prepared: 'Ceph nodes are currently not prepared for the upgrade.'
+      blockui_message: 'Processing, please wait...'
 
   installer:
     title: 'Installer'

--- a/crowbar_framework/config/navigation.rb
+++ b/crowbar_framework/config/navigation.rb
@@ -38,9 +38,9 @@ SimpleNavigation::Configuration.run do |navigation|
       level2.item :queue, t("nav.utils.queue"), deployment_queue_path
       level2.item :repositories, t("nav.utils.repositories"), repositories_path
       level2.item :backup, t("nav.utils.backup"), backups_path
+      level2.item :ceph_pre_upgrade, t("nav.utils.ceph_pre_upgrade"), ceph_pre_upgrade_path
       level2.item :backup, t("nav.utils.upgrade"), "/upgrade"
       level2.item :logs, t("nav.utils.logs"), utils_path
-      level2.item :ceph_pre_upgrade, t("nav.utils.ceph_pre_upgrade"), ceph_pre_upgrade_path
     end
   end
 end

--- a/crowbar_framework/config/navigation.rb
+++ b/crowbar_framework/config/navigation.rb
@@ -40,6 +40,7 @@ SimpleNavigation::Configuration.run do |navigation|
       level2.item :backup, t("nav.utils.backup"), backups_path
       level2.item :backup, t("nav.utils.upgrade"), "/upgrade"
       level2.item :logs, t("nav.utils.logs"), utils_path
+      level2.item :ceph_pre_upgrade, t("nav.utils.ceph_pre_upgrade"), ceph_pre_upgrade_path
     end
   end
 end

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -76,6 +76,13 @@ Rails.application.routes.draw do
   post "utils/repositories/activate_all(.:format)", controller: "repositories", action: "activate_all", as: "activate_all_repositories"
   post "utils/repositories/deactivate_all(.:format)", controller: "repositories", action: "deactivate_all", as: "deactivate_all_repositories"
 
+  get "utils/ceph_pre_upgrade(.:format)",
+    controller: "ceph_pre_upgrade", action: "index", as: "ceph_pre_upgrade"
+  post "utils/ceph_pre_upgrade/prepare(.:format)",
+    controller: "ceph_pre_upgrade",
+    action: "prepare",
+    as: "prepare_ceph_pre_upgrade"
+
   scope :utils do
     resources :backups, only: [:index, :create, :destroy] do
       collection do


### PR DESCRIPTION
Before the Cloud upgrade, ceph nodes must be manually upgraded to
the latest version of SES. Before that, we need to move them to
crowbar_upgrade state.
There is no UI for SES upgrade, but we can provide simple UI for
the preparation that is needed for both SES and following SOC upgrades.

Requires https://github.com/crowbar/crowbar-core/pull/1077


![ceph_pre_upgrade](https://cloud.githubusercontent.com/assets/910000/23022630/313df8d2-f452-11e6-84ba-40457e1f2b34.png)
