### PR TITLE
upgrade: Move "crowbar_upgrade_step" attribute to node role

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -24,7 +24,7 @@
 
 return unless node[:platform_family] == "suse"
 
-upgrade_step = node["crowbar_wall"]["crowbar_upgrade_step"] || "none"
+upgrade_step = node["crowbar_upgrade_step"] || "none"
 
 Chef::Log.info("Current upgrade step: #{upgrade_step}")
 

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -67,10 +67,10 @@ module Api
 
     def join_and_chef
       # Mark this upgrade step, so chef-client run can also start disabled services
-      unless @node["crowbar_wall"]["crowbar_upgrade_step"] == "done_os_upgrade"
+      unless @node.crowbar["crowbar_upgrade_step"] == "done_os_upgrade"
         # Make sure we save with the latest node data
         @node = ::Node.find_by_name(@node.name)
-        @node["crowbar_wall"]["crowbar_upgrade_step"] = "done_os_upgrade"
+        @node.crowbar["crowbar_upgrade_step"] = "done_os_upgrade"
         @node.save
       end
       begin

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -666,9 +666,9 @@ module Api
 
       # crowbar_upgrade_step will not be needed after node is upgraded
       def finalize_node_upgrade(node)
-        return unless node["crowbar_wall"].key? "crowbar_upgrade_step"
+        return unless node.crowbar.key? "crowbar_upgrade_step"
 
-        node["crowbar_wall"].delete "crowbar_upgrade_step"
+        node.crowbar.delete "crowbar_upgrade_step"
         node.crowbar.delete "node_upgrade_state"
         node.save
 

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -252,7 +252,7 @@ class CrowbarService < ServiceObject
         # for Hyper-V nodes, only change the state, but do not run chef-client
         node.set_state("crowbar_upgrade")
       else
-        node["crowbar_wall"]["crowbar_upgrade_step"] = "crowbar_upgrade"
+        node.crowbar["crowbar_upgrade_step"] = "crowbar_upgrade"
         node.save
         nodes_to_upgrade.push node.name
       end
@@ -310,7 +310,7 @@ class CrowbarService < ServiceObject
 
     upgrade_nodes.each do |node|
       node["target_platform"] = admin_node["provisioner"]["default_os"]
-      node["crowbar_wall"]["crowbar_upgrade_step"] = "prepare-os-upgrade"
+      node.crowbar["crowbar_upgrade_step"] = "prepare-os-upgrade"
       # skip initial keystone bootstrapping
       if node["run_list_map"].key? "keystone-server"
         node["keystone"]["bootstrap"] = true
@@ -383,8 +383,9 @@ class CrowbarService < ServiceObject
 
     Node.all.each do |node|
       next unless node.state == "crowbar_upgrade"
-      # revert nodes to previous state; mark the wall so apply does not change state again
-      node["crowbar_wall"]["crowbar_upgrade_step"] = "revert_to_ready"
+      # revert nodes to previous state; set "crowbar_upgrade_step" so apply does not
+      # change state again
+      node.crowbar["crowbar_upgrade_step"] = "revert_to_ready"
       node.save
       node.set_state("ready")
     end
@@ -401,10 +402,10 @@ class CrowbarService < ServiceObject
     @logger.debug("crowbar apply_role_pre_chef_call: entering #{all_nodes.inspect}")
     all_nodes.each do |n|
       node = Node.find_by_name(n)
-      # value of crowbar_wall["crowbar_upgrade"] indicates that the role should be executed
+      # value of node.crowbar["crowbar_upgrade_step"] indicates that the role should be executed
       # but node state should not be changed: this is needed when reverting node state to ready
       if node.role?("crowbar-upgrade") &&
-          node.crowbar_wall["crowbar_upgrade_step"] != "revert_to_ready"
+          node.crowbar["crowbar_upgrade_step"] != "revert_to_ready"
         node.set_state("crowbar_upgrade")
       end
     end


### PR DESCRIPTION
Similar to the previous "node_upgrade_state" change this is done to
prevent a race condition with a chef-client running on the node that
might overwrite "crowbar_wall".