### PR TITLE
upgrade: Move "crowbar_upgrade_step" attribute to node role

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -24,7 +24,8 @@
 
 return unless node[:platform_family] == "suse"
 
-upgrade_step = node["crowbar_wall"]["crowbar_upgrade_step"] || "none"
+upgrade_step = node["crowbar_upgrade_step"] ||
+  node["crowbar_wall"]["crowbar_upgrade_step"] || "none"
 
 case upgrade_step
 

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -347,7 +347,7 @@ class CrowbarService < ServiceObject
         # for Hyper-V nodes, only change the state, but do not run chef-client
         node.set_state("crowbar_upgrade")
       else
-        node["crowbar_wall"]["crowbar_upgrade_step"] = "crowbar_upgrade"
+        node.crowbar["crowbar_upgrade_step"] = "crowbar_upgrade"
         node.save
         nodes_to_upgrade.push node.name
       end
@@ -452,7 +452,7 @@ class CrowbarService < ServiceObject
     NodeObject.all.each do |node|
       next unless node.state == "crowbar_upgrade"
       # revert nodes to previous state; mark the wall so apply does not change state again
-      node["crowbar_wall"]["crowbar_upgrade_step"] = "revert_to_ready"
+      node.crowbar["crowbar_upgrade_step"] = "revert_to_ready"
       node.save
       node.set_state("ready")
     end
@@ -469,10 +469,10 @@ class CrowbarService < ServiceObject
     @logger.debug("crowbar apply_role_pre_chef_call: entering #{all_nodes.inspect}")
     all_nodes.each do |n|
       node = NodeObject.find_node_by_name n
-      # value of crowbar_wall["crowbar_upgrade"] indicates that the role should be executed
+      # value of node.crowbar["crowbar_upgrade"] indicates that the role should be executed
       # but node state should not be changed: this is needed when reverting node state to ready
       if node.role?("crowbar-upgrade") &&
-          node.crowbar_wall["crowbar_upgrade_step"] != "revert_to_ready"
+          node.crowbar["crowbar_upgrade_step"] != "revert_to_ready"
         node.set_state("crowbar_upgrade")
       end
     end


### PR DESCRIPTION
This is a partial backport of
https://github.com/crowbar/crowbar-core/pull/1080 to stable/3.0

Note: This should not change any pieces related to the upgrade from
tex to stable/3.0 to avoid breaking that. That's why the there are still
a lot of reference to crowbar_wall["crowbar_upgrade_step"] left.