### PR TITLE
Register crowbar v2 api specific mime type (bsc#1023834)

### DIFF
--- a/crowbar_framework/config/initializers/register_json_mime_type.rb
+++ b/crowbar_framework/config/initializers/register_json_mime_type.rb
@@ -1,0 +1,20 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+api_mime_types = ["application/vnd.crowbar.v2.0+json", "text/x-json"]
+
+Mime::Type.unregister :json
+Mime::Type.register "application/json", :json, api_mime_types


### PR DESCRIPTION
This should make crowbar properly accept request with the v2 specific
Content-Type: application/vnd.crowbar.v2.0+json

As e.g. done by the crowbarctl upgrade subcommands. This is a followup
fix for:
https://github.com/crowbar/crowbar-client/commit/812c8ec0339cce9dda1a5fab3eaeff6cc1297454

As before that crowbarctl was actually sending all requests urlencoded.