### PR TITLE
upgrade: Do not touch ceph nodes during services shutdown

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -541,7 +541,7 @@ module Api
         # initialize progress info about nodes upgrade
         if remaining.nil?
           remaining = ::Node.find(
-            "state:crowbar_upgrade AND NOT run_list_map:ceph_*"
+            "state:crowbar_upgrade AND NOT roles:ceph-*"
           ).size
           ::Crowbar::UpgradeStatus.new.save_nodes(0, remaining)
         end

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -376,7 +376,7 @@ module Api
 
         # Initiate the services shutdown for all nodes
         errors = []
-        upgrade_nodes = ::Node.find("state:crowbar_upgrade")
+        upgrade_nodes = ::Node.find("state:crowbar_upgrade AND NOT roles:ceph-*")
         cinder_node = nil
         upgrade_nodes.each do |node|
           if node.roles.include?("cinder-controller") &&
@@ -691,6 +691,7 @@ module Api
         ::Node.find_all_nodes.each do |node|
           finalize_node_upgrade node
         end
+        # FIXME: ceph nodes need to start chef-client/crowbar-join at some point!
       end
 
       #

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -373,7 +373,7 @@ describe Api::Upgrade do
       drbd_slave = Node.find_by_name("drbd.crowbar.com")
       allow(Node).to(
         receive(:find).
-        with("state:crowbar_upgrade AND NOT run_list_map:ceph_*").
+        with("state:crowbar_upgrade AND NOT roles:ceph-*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow(Node).to(
@@ -438,7 +438,7 @@ describe Api::Upgrade do
     it "successfully completes the upgrade when they are no compute nodes" do
       allow(Node).to(
         receive(:find).
-        with("state:crowbar_upgrade AND NOT run_list_map:ceph_*").
+        with("state:crowbar_upgrade AND NOT roles:ceph-*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow(Api::Upgrade).to receive(:upgrade_controller_clusters).and_return(true)
@@ -477,7 +477,7 @@ describe Api::Upgrade do
 
       allow(Node).to(
         receive(:find).
-        with("state:crowbar_upgrade AND NOT run_list_map:ceph_*").
+        with("state:crowbar_upgrade AND NOT roles:ceph-*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow(Api::Upgrade).to receive(:upgrade_controller_clusters).and_return(true)
@@ -515,7 +515,7 @@ describe Api::Upgrade do
       ).with(:nodes).and_return(true)
       allow(Node).to(
         receive(:find).
-        with("state:crowbar_upgrade AND NOT run_list_map:ceph_*").
+        with("state:crowbar_upgrade AND NOT roles:ceph-*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow(Node).to(
@@ -547,7 +547,7 @@ describe Api::Upgrade do
         :start_step
       ).with(:nodes).and_return(true)
       allow(Node).to(
-        receive(:find).with("state:crowbar_upgrade AND NOT run_list_map:ceph_*").
+        receive(:find).with("state:crowbar_upgrade AND NOT roles:ceph-*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow(Api::Upgrade).to receive(:upgrade_controller_clusters).and_return(true)
@@ -569,7 +569,7 @@ describe Api::Upgrade do
         :start_step
       ).with(:nodes).and_return(true)
       allow(Node).to(
-        receive(:find).with("state:crowbar_upgrade AND NOT run_list_map:ceph_*").
+        receive(:find).with("state:crowbar_upgrade AND NOT roles:ceph-*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow(Api::Upgrade).to receive(:upgrade_controller_clusters).and_return(true)
@@ -588,7 +588,7 @@ describe Api::Upgrade do
 
     it "successfully upgrades KVM compute nodes" do
       allow(Node).to(
-        receive(:find).with("state:crowbar_upgrade AND NOT run_list_map:ceph_*").
+        receive(:find).with("state:crowbar_upgrade AND NOT roles:ceph-*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow(Api::Upgrade).to receive(:upgrade_controller_clusters).and_return(true)

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -149,7 +149,7 @@ describe Api::Upgrade do
         :prepare_nodes_for_os_upgrade
       ).and_return(true)
       allow(Node).to(
-        receive(:find).with("state:crowbar_upgrade").
+        receive(:find).with("state:crowbar_upgrade AND NOT roles:ceph-*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow_any_instance_of(Node).to(


### PR DESCRIPTION
Ceph nodes should already be upgraded, there's no need to
mark an upgrade step there and it would be wrong to shut down
their services.

TODO: start chef-client & crowbar_join on ceph nodes, move them to ready state -missing, will be done in a followup