### PR TITLE
network: Allow custom MTU for all networks (bsc#1024277)

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -318,12 +318,8 @@ sorted_networks.each do |network|
     net_ifs << our_iface.name
   end
   if network.mtu
-    if ["admin", "storage", "os_sdn"].include? network.name
-      Chef::Log.info("Setting mtu #{network.mtu} for #{network.name} network on #{our_iface.name}")
-      ifs[our_iface.name]["mtu"] = network.mtu
-    else
-      Chef::Log.warn("Setting mtu for #{our_iface.name} network is not supported yet, skipping")
-    end
+    Chef::Log.info("Using mtu #{network.mtu} for #{network.name} network on #{our_iface.name}")
+    ifs[our_iface.name]["mtu"] = network.mtu
   end
   # Make sure our addresses are correct
   if_mapping[network.name] = net_ifs


### PR DESCRIPTION
Previously we allowed custom MTU values only for the "admin", "storage"
and "os_sdn" networks. This prevents users to create custom networks
with MTU!=1500 so allow custom MTUs for all networks.

For example, a network.json containing a network like:

"storageclient": {
  "add_bridge": false,
  "broadcast": "10.1.5.255",
  "conduit": "intf4",
  "mtu": 9000,
  "netmask": "255.255.255.0",
  "ranges": {
  "host": {
    "end": "10.1.5.239",
    "start": "10.1.5.10"
  }
}

works now.