### PR TITLE
dhcp: Don't send restart notifications to dhcp server if PXE is disabled

### DIFF
--- a/chef/cookbooks/dhcp/providers/host.rb
+++ b/chef/cookbooks/dhcp/providers/host.rb
@@ -29,12 +29,16 @@ action :add do
     owner "root"
     group "root"
     mode 0644
-    notifies :restart, resources(service: "dhcp3-server"), :delayed
+    if node[:provisioner][:enable_pxe]
+      notifies :restart, resources(service: "dhcp3-server"), :delayed
+    end
   end
   utils_line "include \"#{filename}\";" do
     action :add
     file "/etc/dhcp3/hosts.d/host_list.conf"
-    notifies :restart, resources(service: "dhcp3-server"), :delayed
+    if node[:provisioner][:enable_pxe]
+      notifies :restart, resources(service: "dhcp3-server"), :delayed
+    end
   end
 end
 
@@ -44,14 +48,18 @@ action :remove do
     Chef::Log.info "Removing #{new_resource.name} host from /etc/dhcp3/hosts.d/"
     file filename do
       action :delete
-      notifies :restart, resources(service: "dhcp3-server"), :delayed
+      if node[:provisioner][:enable_pxe]
+        notifies :restart, resources(service: "dhcp3-server"), :delayed
+      end
     end
     new_resource.updated_by_last_action(true)
   end
   utils_line "include \"#{filename}\";" do
     action :remove
     file "/etc/dhcp3/hosts.d/host_list.conf"
-    notifies :restart, resources(service: "dhcp3-server"), :delayed
+    if node[:provisioner][:enable_pxe]
+      notifies :restart, resources(service: "dhcp3-server"), :delayed
+    end
   end
 end
 

--- a/chef/cookbooks/dhcp/providers/subnet.rb
+++ b/chef/cookbooks/dhcp/providers/subnet.rb
@@ -27,12 +27,16 @@ action :add do
     owner "root"
     group "root"
     mode 0644
-    notifies :restart, resources(service: "dhcp3-server"), :delayed
+    if node[:provisioner][:enable_pxe]
+      notifies :restart, resources(service: "dhcp3-server"), :delayed
+    end
   end
   utils_line "include \"#{filename}\";" do
     action :add
     file "/etc/dhcp3/subnets.d/subnet_list.conf"
-    notifies :restart, resources(service: "dhcp3-server"), :delayed
+    if node[:provisioner][:enable_pxe]
+      notifies :restart, resources(service: "dhcp3-server"), :delayed
+    end
   end
 end
 
@@ -42,14 +46,18 @@ action :remove do
     Chef::Log.info "Removing #{new_resource.name} subnet from /etc/dhcp3/subnets.d/"
     file filename do
       action :delete
-      notifies :restart, resources(service: "dhcp3-server"), :delayed
+      if node[:provisioner][:enable_pxe]
+        notifies :restart, resources(service: "dhcp3-server"), :delayed
+      end
     end
     new_resource.updated_by_last_action(true)
   end
   utils_line "include \"#{filename}\";" do
     action :remove
     file "/etc/dhcp3/subnets.d/subnet_list.conf"
-    notifies :restart, resources(service: "dhcp3-server"), :delayed
+    if node[:provisioner][:enable_pxe]
+      notifies :restart, resources(service: "dhcp3-server"), :delayed
+    end
   end
 end
 

--- a/chef/cookbooks/dhcp/recipes/default.rb
+++ b/chef/cookbooks/dhcp/recipes/default.rb
@@ -75,7 +75,9 @@ when "debian"
       mode 0644
       source "dhcpd.conf.erb"
       variables(options: d_opts)
-      notifies :restart, "service[dhcp3-server]"
+      if node[:provisioner][:enable_pxe]
+        notifies :restart, "service[dhcp3-server]"
+      end
     end
     template "/etc/default/isc-dhcp-server" do
       owner "root"
@@ -83,7 +85,9 @@ when "debian"
       mode 0644
       source "dhcp3-server.erb"
       variables(interfaces: intfs)
-      notifies :restart, "service[dhcp3-server]"
+      if node[:provisioner][:enable_pxe]
+        notifies :restart, "service[dhcp3-server]"
+      end
     end
   else
     template "/etc/dhcp3/dhcpd.conf" do
@@ -92,7 +96,9 @@ when "debian"
       mode 0644
       source "dhcpd.conf.erb"
       variables(options: d_opts)
-      notifies :restart, "service[dhcp3-server]"
+      if node[:provisioner][:enable_pxe]
+        notifies :restart, "service[dhcp3-server]"
+      end
     end
     template "/etc/default/dhcp3-server" do
       owner "root"
@@ -100,7 +106,9 @@ when "debian"
       mode 0644
       source "dhcp3-server.erb"
       variables(interfaces: intfs)
-      notifies :restart, "service[dhcp3-server]"
+      if node[:provisioner][:enable_pxe]
+        notifies :restart, "service[dhcp3-server]"
+      end
     end
   end
 when "rhel"
@@ -118,7 +126,9 @@ when "rhel"
     mode 0644
     source "dhcpd.conf.erb"
     variables(options: d_opts)
-    notifies :restart, "service[dhcp3-server]"
+    if node[:provisioner][:enable_pxe]
+      notifies :restart, "service[dhcp3-server]"
+    end
   end
 
   template "/etc/sysconfig/dhcpd" do
@@ -127,7 +137,9 @@ when "rhel"
     mode 0644
     source "redhat-sysconfig-dhcpd.erb"
     variables(interfaces: intfs)
-    notifies :restart, "service[dhcp3-server]"
+    if node[:provisioner][:enable_pxe]
+      notifies :restart, "service[dhcp3-server]"
+    end
   end
 
 when "suse"
@@ -137,7 +149,9 @@ when "suse"
     mode 0644
     source "dhcpd.conf.erb"
     variables(options: d_opts)
-    notifies :restart, "service[dhcp3-server]"
+    if node[:provisioner][:enable_pxe]
+      notifies :restart, "service[dhcp3-server]"
+    end
   end
 
   template "/etc/sysconfig/dhcpd" do
@@ -146,7 +160,9 @@ when "suse"
     mode 0644
     source "suse-sysconfig-dhcpd.erb"
     variables(interfaces: intfs)
-    notifies :restart, "service[dhcp3-server]"
+    if node[:provisioner][:enable_pxe]
+      notifies :restart, "service[dhcp3-server]"
+    end
   end
 end
 


### PR DESCRIPTION
We don't want to start the dhcp server in that case, it should stay
stopped.