### PR TITLE
upgrade: Fix showing missing repositories in prechecks

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -191,7 +191,7 @@ module Api
 
         # Now look for missing repositories
         if initial_repocheck.any? { |_k, v| !v[:available] }
-          missing_repos = ret.collect do |k, v|
+          missing_repos = initial_repocheck.collect do |k, v|
             next if v[:errors].empty?
             missing_repo_arch = v[:errors].keys.first.to_sym
             v[:errors][missing_repo_arch][:missing]

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -152,7 +152,7 @@ module Api
       def adminrepocheck
         upgrade_status = ::Crowbar::UpgradeStatus.new
         upgrade_status.start_step(:repocheck_crowbar)
-        ret = Api::Crowbar.check_repositories("7")
+        ret = Api::Crowbar.check_repositories("7", true)
 
         # zypper errors have already ended the step
         return ret if ret.key? :error
@@ -280,6 +280,14 @@ module Api
             data: I18n.t("api.upgrade.prechecks.repos_missing.error",
               missing: check[:repositories_missing]),
             help: I18n.t("api.upgrade.prechecks.repos_missing.help")
+          }
+        end
+
+        if check[:repositories_too_soon]
+          ret[:repositories_too_soon] = {
+            data: I18n.t("api.upgrade.prechecks.repos_too_soon.error",
+              too_soon: check[:repositories_too_soon]),
+            help: I18n.t("api.upgrade.prechecks.repos_too_soon.help")
           }
         end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -278,7 +278,7 @@ module Api
         if check[:repositories_missing]
           ret[:repositories_missing] = {
             data: I18n.t("api.upgrade.prechecks.repos_missing.error",
-              missing: check[:repositories_missing].join(", ")),
+              missing: check[:repositories_missing]),
             help: I18n.t("api.upgrade.prechecks.repos_missing.help")
           }
         end

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -790,7 +790,7 @@ en:
           help:
             default: 'Make sure maintenance updates are installed.'
         repos_missing:
-          error: 'These repositories are missing: %{misssing}.'
+          error: 'These repositories are missing: %{missing}.'
           help: 'Fix your SOC6 repository setup so the latest maintenance updates can be installed.'
         ceph_health_check:
           help:

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -792,6 +792,9 @@ en:
         repos_missing:
           error: 'These repositories are missing: %{missing}.'
           help: 'Fix your SOC6 repository setup so the latest maintenance updates can be installed.'
+        repos_too_soon:
+          error: 'These repositories are enabled when they should not: %{too_soon}.'
+          help: 'SOC7 repositories cannot be enabled at this stage. First the maintenance updates for SOC6 must be installed.'
         ceph_health_check:
           help:
             default: 'Make sure Ceph is healthy'

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -84,6 +84,9 @@ describe Api::Upgrade do
         :check_repositories
       ).with("6").and_return(os: { available: true })
       allow(Api::Crowbar).to receive(
+        :check_repositories
+      ).with("7").and_return(os: { available: false })
+      allow(Api::Crowbar).to receive(
         :addons
       ).and_return(["ceph", "ha"])
       allow(Api::Crowbar).to(
@@ -358,6 +361,9 @@ describe Api::Upgrade do
       allow(Api::Crowbar).to receive(
         :check_repositories
       ).with("6").and_return(os: { available: true })
+      allow(Api::Crowbar).to receive(
+        :check_repositories
+      ).with("7").and_return(os: { available: false })
       allow(Api::Upgrade).to receive(
         :maintenance_updates_status
       ).and_return(errors: ["Some Error"])


### PR DESCRIPTION
1st commit is about the fix of https://github.com/crowbar/crowbar-core/pull/1088
Surprisingly, this was not properly checked when merging .

@skazi0 with 2nd commit, we actually can make the check somewhat usable even with the products - if user did not clean Cloud7/SP2 repos after cancel, this should show an error in next precheck.