### PR TITLE
Disable all current repos before starting the upgrade

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -523,8 +523,11 @@ module Api
           raise ::Crowbar::Error::Upgrade::CancelError.new(upgrade_status.current_step)
         end
 
-        service_object = CrowbarService.new(Rails.logger)
-        service_object.revert_nodes_from_crowbar_upgrade
+        provisioner_service = ProvisionerService.new(Rails.logger)
+        provisioner_service.enable_all_repositories
+
+        crowbar_service = CrowbarService.new(Rails.logger)
+        crowbar_service.revert_nodes_from_crowbar_upgrade
         upgrade_status.initialize_state
       end
 
@@ -1218,8 +1221,11 @@ module Api
       end
 
       def prepare_nodes_for_crowbar_upgrade
-        service_object = CrowbarService.new(Rails.logger)
-        service_object.prepare_nodes_for_crowbar_upgrade
+        crowbar_service = CrowbarService.new(Rails.logger)
+        crowbar_service.prepare_nodes_for_crowbar_upgrade
+
+        provisioner_service = ProvisionerService.new(Rails.logger)
+        provisioner_service.disable_all_repositories
 
         ::Crowbar::UpgradeStatus.new.end_step
         true

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -147,6 +147,9 @@ describe Api::UpgradeController, type: :request do
       allow_any_instance_of(CrowbarService).to receive(
         :revert_nodes_from_crowbar_upgrade
       ).and_return(true)
+      allow_any_instance_of(ProvisionerService).to receive(
+        :enable_all_repositories
+      ).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :initialize_state
       ).and_return(true)
@@ -159,6 +162,9 @@ describe Api::UpgradeController, type: :request do
     end
 
     it "fails to cancel the upgrade" do
+      allow_any_instance_of(ProvisionerService).to receive(
+        :enable_all_repositories
+      ).and_return(true)
       allow_any_instance_of(CrowbarService).to receive(
         :revert_nodes_from_crowbar_upgrade
       ).and_raise("an Error")

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -623,6 +623,9 @@ describe Api::Upgrade do
 
   context "canceling the upgrade" do
     it "successfully cancels the upgrade" do
+      allow_any_instance_of(ProvisionerService).to receive(
+        :enable_all_repositories
+      ).and_return(true)
       allow_any_instance_of(CrowbarService).to receive(
         :revert_nodes_from_crowbar_upgrade
       ).and_return(true)
@@ -646,6 +649,9 @@ describe Api::Upgrade do
     end
 
     it "is allowed to cancel the upgrade" do
+      allow_any_instance_of(ProvisionerService).to receive(
+        :enable_all_repositories
+      ).and_return(true)
       allow_any_instance_of(CrowbarService).to receive(
         :revert_nodes_from_crowbar_upgrade
       ).and_return(true)


### PR DESCRIPTION
As part of the node upgrade we're replacing all the product repositories
with the ones from the new product version. To be able to cleanup
correctly we need disable the old product repositories in crowbar (i.e.
remove the associated data bags) before the repository configuration
files (/etc/crowbar/repos.yml and ./crowbar_framework/config/repos-*.yml)
are replaced.

If the upgrade is canceled, we re-enable them.