### PR TITLE
delayed_jobs: Enable traceback logging

### DIFF
--- a/crowbar_framework/config/initializers/delayed_job_config.rb
+++ b/crowbar_framework/config/initializers/delayed_job_config.rb
@@ -14,12 +14,24 @@
 # limitations under the License.
 #
 
+module Delayed
+  class Worker
+    def handle_failed_job_with_logging(job, error)
+      handle_failed_job_without_logging(job, error)
+      Rails.logger.error("Error processing job ID #{job.id}: #{error.message} "\
+        "#{error.backtrace.join("\n")}")
+    end
+    alias_method_chain :handle_failed_job, :logging
+  end
+end
+
 Delayed::Worker.destroy_failed_jobs = false
 Delayed::Worker.delay_jobs = !Rails.env.test?
 Delayed::Worker.raise_signal_exceptions = :term
 Delayed::Worker.max_attempts = 1
-if Rails.env.production?
-  Delayed::Worker.logger = Logger.new(File.join(ENV["CROWBAR_LOG_DIR"], "background_jobs.log"))
+log_file = if Rails.env.production?
+  File.join(ENV["CROWBAR_LOG_DIR"], "background_jobs.log")
 else
-  Delayed::Worker.logger = Logger.new(File.join(Rails.root, "log", "background_jobs.log"))
+  File.join(Rails.root, "log", "background_jobs.log")
 end
+Delayed::Worker.logger = Logger.new(log_file)

--- a/crowbar_framework/config/initializers/filter_sql_log.rb
+++ b/crowbar_framework/config/initializers/filter_sql_log.rb
@@ -24,6 +24,10 @@ module ActiveRecord
         Rails.logger.debug(
           "SQL: INSERT/UPDATE transaction: filtering query to not expose potentially sensitive data"
         )
+      elsif event.payload[:sql] =~ /^(INSERT INTO|DELETE FROM|UPDATE) "delayed_jobs".*/
+        Rails.logger.debug(
+          "SQL: delayed_jobs transaction: filtering query to not clutter the logs"
+        )
       else
         old_sql(event)
       end


### PR DESCRIPTION
We didnt have traceback logging enabled for
delayed jobs. This enables it and also filters
the SQL insert/update for them from the crowbar
log as to not pollute the log with uneeded and
unreadable lines