### PR TITLE
upgrade: simplify conditions for determining best upgrade method

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -96,12 +96,14 @@ module Api
           end
 
           ret[:best_method] = if ret[:checks].any? { |_id, c| c[:required] && !c[:passed] }
+            # no upgrade if any of the required prechecks failed
             "none"
-          elsif !ret[:checks].any? { |_id, c| (c[:required] || !c[:required]) && !c[:passed] }
+          elsif !ret[:checks].any? { |_id, c| !c[:required] && !c[:passed] }
+            # allow non-disruptive when all prechecks succeeded
             "non-disruptive"
-          elsif !ret[:checks].any? do |_id, c|
-            (c[:required] && !c[:passed]) && (!c[:required] && c[:passed])
-          end
+          else
+            # otherwise choose the disruptive upgrade path (i.e. the required
+            # checks succeeded and some of the non-required ones failed)
             "disruptive"
           end
 

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -346,7 +346,7 @@ describe Api::Upgrade do
   end
 
   context "determining the best upgrade method" do
-    it "chooses non-disruptive upgrade" do
+    it "chooses non-disruptive upgrade when all prechecks succeed" do
       allow(subject.class).to receive(:checks).and_return(
         prechecks.deep_symbolize_keys
       )
@@ -354,7 +354,7 @@ describe Api::Upgrade do
       expect(subject.class.checks.deep_symbolize_keys[:best_method]).to eq("non-disruptive")
     end
 
-    it "chooses disruptive upgrade" do
+    it "chooses disruptive upgrade when a non-required prechecks fails" do
       upgrade_prechecks = prechecks
       upgrade_prechecks["checks"]["compute_status"]["passed"] = false
       upgrade_prechecks["best_method"] = "disruptive"
@@ -363,7 +363,7 @@ describe Api::Upgrade do
       expect(subject.class.checks.deep_symbolize_keys[:best_method]).to eq("disruptive")
     end
 
-    it "chooses none" do
+    it "chooses none when a required precheck fails" do
       allow(Api::Crowbar).to receive(
         :check_repositories
       ).with("6").and_return(os: { available: true })


### PR DESCRIPTION
This removes some redundancy from the condtions by which we try to
figure out the best upgrade method (disruptive vs. non-distruptive).

It also adds a more specific wording to the description of the unit
tests.

(cherry picked from commit 1fc781d04e449bb128947c63a5637d8308648362)

Backport of: https://github.com/crowbar/crowbar-core/pull/1097