### PR TITLE
upgrade: Save the upgrade mode into the progress library

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -122,6 +122,8 @@ module Api
             "disruptive"
           end
 
+          ::Crowbar::UpgradeStatus.new.save_upgrade_mode(ret[:best_method])
+
           return ret unless upgrade_status.current_step == :prechecks
 
           # transform from this:
@@ -143,9 +145,9 @@ module Api
                    reduce({}, :merge)
 
           if errors.any?
-            upgrade_status.end_step(false, errors)
+            ::Crowbar::UpgradeStatus.new.end_step(false, errors)
           else
-            upgrade_status.end_step
+            ::Crowbar::UpgradeStatus.new.end_step
           end
         end
       rescue ::Crowbar::Error::StartStepRunningError,

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -59,7 +59,9 @@ module Crowbar
         upgraded_nodes: nil,
         # locations of the backups taken during the upgrade
         crowbar_backup: nil,
-        openstack_backup: nil
+        openstack_backup: nil,
+        # disruptive vs. nondisruptive
+        upgrade_mode: nil
       }
       # in 'steps', we save the information about each step that was executed
       @progress[:steps] = upgrade_steps_6_7.map do |step|
@@ -73,6 +75,10 @@ module Crowbar
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: true, logger: @logger, path: lock_path) do
         @progress = YAML.load(progress_file_path.read)
       end
+    end
+
+    def upgrade_mode
+      progress[:upgrade_mode]
     end
 
     def current_substep
@@ -186,6 +192,13 @@ module Crowbar
     def save_openstack_backup(backup_location)
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
         progress[:openstack_backup] = backup_location
+        save
+      end
+    end
+
+    def save_upgrade_mode(mode)
+      ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
+        progress[:upgrade_mode] = mode
         save
       end
     end

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -7,6 +7,7 @@
   "upgraded_nodes": null,
   "crowbar_backup": null,
   "openstack_backup": null,
+  "upgrade_mode": null,
   "steps":{
     "prechecks":{
       "status":"pending"

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -324,6 +324,14 @@ describe Crowbar::UpgradeStatus do
       expect(subject.progress[:openstack_backup]).to be openstack_backup
     end
 
+    it "saves and checks upgrade mode" do
+      expect(subject.current_substep).to be_nil
+      expect(subject.upgrade_mode).to be nil
+
+      expect(subject.save_upgrade_mode(:disruptive)).to be true
+      expect(subject.upgrade_mode).to be :disruptive
+    end
+
     it "fails while saving the status initially" do
       allow_any_instance_of(Pathname).to(
         receive(:open).and_raise("Failed to write File")


### PR DESCRIPTION
Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

We need to track the upgrade mode that is decided at the start of upgrade, so we can later do different upgrade actions for disruptive and non-disruptive upgrade.

**How does it address the issue?**

Saves the info into the file that we are already using for similar purposes

