### PR TITLE
upgrade: Allow access to the repositories page during the Upgrade

### DIFF
--- a/crowbar_framework/app/controllers/repositories_controller.rb
+++ b/crowbar_framework/app/controllers/repositories_controller.rb
@@ -15,7 +15,9 @@
 #
 
 class RepositoriesController < ApplicationController
+  skip_before_filter :upgrade
   before_filter :reload_registry
+
   api :GET, "/utils/repositories", "List all node repositories"
   header "Accept", "application/json", required: true
   example '


### PR DESCRIPTION
This might make it easier to debug/fix problems with the new
repositories when upgarding.

