### PR TITLE
upgrade: Check if Swift configuration is compatible with the upgrade

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -171,6 +171,21 @@ module Api
         ret
       end
 
+      def openstack_check
+        ret = {}
+        # swift replicas check vs. number of disks
+        prop = Proposal.where(barclamp: "swift").first
+        return ret if prop.nil?
+        replicas = prop["attributes"]["swift"]["replicas"] || 0
+
+        disks = 0
+        NodeObject.find("roles:swift-storage").each do |n|
+          disks += n["swift"]["devs"].size
+        end
+        ret[:too_many_replicas] = replicas if replicas > disks
+        ret
+      end
+
       def compute_status
         ret = {}
         ["kvm", "xen"].each do |virt|

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -70,6 +70,13 @@ module Api
             errors: compute.empty? ? {} : compute_status_errors(compute)
           }
 
+          openstack = Api::Crowbar.openstack_check
+          ret[:checks][:openstack_check] = {
+            required: true,
+            passed: openstack.empty?,
+            errors: openstack.empty? ? {} : openstack_check_errors(openstack)
+          }
+
           if Api::Crowbar.addons.include?("ceph")
             ceph_status = Api::Crowbar.ceph_status
             ret[:checks][:ceph_healthy] = {
@@ -359,6 +366,18 @@ module Api
             nodes: failed_actions.keys.join(",")
           )
         } if failed_actions
+        ret
+      end
+
+      def openstack_check_errors(check)
+        ret = {}
+        if check[:too_many_replicas]
+          ret[:too_many_replicas] = {
+            data: I18n.t("api.upgrade.prechecks.swift_replicas.error",
+              replicas: check[:too_many_replicas]),
+            help: I18n.t("api.upgrade.prechecks.swift_replicas.help")
+          }
+        end
         ret
       end
 

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -816,6 +816,9 @@ en:
           not_configured: 'No Pacemaker cluster is configured.'
           help:
             default: 'Without HA setup, non-disruptive upgrade is not possible.'
+        swift_replicas:
+          error: 'The number of replicas is bigger than the number of disks assigned for Swift.'
+          help: 'Such configuration is not supported in Swift delivered with SOC 7. Adapt your Swift configuration before proceeding with the upgrade.'
         ceph_not_healthy:
           error: 'Ceph cluster health check has failed with %{error}. Make sure cluster is healthy before proceeding with the upgrade.'
           help: 'Refer to the SUSE Enterprise Storage documentation for possible troubleshooting.'


### PR DESCRIPTION
**Why is this change necessary?**

Newton's Swift does not allow number of replicas bigger than number
of disks.