### PR TITLE
upgrade: Add a check for unsupported mixed-roles setup

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -207,6 +207,37 @@ module Api
         ret
       end
 
+      def mixed_roles_check
+        conflicting_roles = [
+          "cinder-controller",
+          "glance-server",
+          "keystone-server",
+          "neutron-server",
+          "neutron-network",
+          "nova-controller",
+          "swift-proxy",
+          "swift-ring-compute",
+          "ceilometer-server",
+          "heat-server",
+          "horizon-server",
+          "manila-server",
+          "trove-server",
+          # FIXME: use this as better check to make sure compute node is not part of cluster?
+          "pacemaker-cluster-member"
+        ]
+        ret = {}
+        ["kvm", "xen"].each do |virt|
+          NodeObject.find("roles:nova-compute-#{virt}").each do |node|
+            conflict = node.roles & conflicting_roles
+            unless conflict.empty?
+              ret[:role_conflicts] ||= {}
+              ret[:role_conflicts][node.name] = conflict
+            end
+          end
+        end
+        ret
+      end
+
       def compute_status
         ret = {}
         ["kvm", "xen"].each do |virt|


### PR DESCRIPTION
**Why is this change necessary?**

If compute node has some controller related role, we should not allow non-disruptive upgrade. It's because with non-disruptive upgrade we want to upgrade control plane first, and only then continue with the compute nodes.

**How does it address the issue?**

Check for additional OpenStack roles that are assigned to compute nodes.

The list of roles that are really conflicting (from the upgrade process POV) is open to debate.