### PR TITLE
dns: Add ability to configure additional search domains in resolv.conf

### DIFF
--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -60,6 +60,9 @@ unless node[:platform_family] == "windows"
     owner "root"
     group "root"
     mode 0644
-    variables(nameservers: dns_list_with_local, search: node[:dns][:domain])
+    variables(
+      nameservers: dns_list_with_local,
+      search_domains: dns_config["search_domains"] || []
+    )
   end
 end

--- a/chef/cookbooks/resolver/templates/default/resolv.conf.erb
+++ b/chef/cookbooks/resolver/templates/default/resolv.conf.erb
@@ -1,5 +1,5 @@
-<% unless @search.nil? -%>
-search <%= @search %>
+<% unless @search_domains.empty? -%>
+search <%= @search_domains.take(6).join(" ") %>
 <% end -%>
 <% @nameservers.each do |nameserver| -%>
 nameserver <%= nameserver %>

--- a/chef/data_bags/crowbar/migrate/dns/102_additional_search_domains.rb
+++ b/chef/data_bags/crowbar/migrate/dns/102_additional_search_domains.rb
@@ -1,0 +1,13 @@
+def upgrade(ta, td, a, d)
+  unless a.key?("additional_search_domains")
+    a["additional_search_domains"] = ta["additional_search_domains"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  unless ta.key?("additional_search_domains")
+    a.delete("additional_search_domains")
+  end
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-dns.json
+++ b/chef/data_bags/crowbar/template-dns.json
@@ -7,6 +7,7 @@
       "forwarders": [ ],
       "allow_transfer": [ ],
       "nameservers": [ ],
+      "additional_search_domains": [ ],
       "records": { },
       "auto_assign_server": true
     }
@@ -15,7 +16,7 @@
     "dns": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 102,
       "element_states": {
         "dns-server": [ "readying", "ready", "applying" ],
         "dns-client": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-dns.schema
+++ b/chef/data_bags/crowbar/template-dns.schema
@@ -23,6 +23,11 @@
               "required": false,
               "sequence": [ { "type": "str", "name": "IpAddress" } ]
             },
+            "additional_search_domains": {
+              "type": "seq",
+              "required": false,
+              "sequence": [ { "type": "str" } ]
+            },
             "allow_transfer": {
               "type": "seq",
               "required": false,

--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -175,7 +175,14 @@ class DnsService < ServiceObject
       addresses.concat(role.default_attributes["dns"]["nameservers"] || [])
       addresses = addresses.flatten.compact
 
-      config = { servers: addresses }
+      search_domains = role.default_attributes["dns"]["additional_search_domains"] || []
+      search_domains.unshift(role.default_attributes["dns"]["domain"])
+      search_domains.uniq!
+
+      config = {
+        servers: addresses,
+        search_domains: search_domains
+      }
     end
 
     instance = Crowbar::DataBagConfig.instance_from_role(old_role, role)

--- a/crowbar_framework/app/views/barclamp/dns/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/dns/_edit_attributes.html.haml
@@ -28,6 +28,10 @@
       %span.help-block
         = t('.ip_list_hint')
 
+      = array_string_field :additional_search_domains
+      %span.help-block
+        = t('.domain_list_hint')
+
     %fieldset
       %legend
         = t(".records")

--- a/crowbar_framework/config/locales/dns/en.yml
+++ b/crowbar_framework/config/locales/dns/en.yml
@@ -29,6 +29,8 @@ en:
 
         client_configuration: 'Client Configuration'
         nameservers: 'Additional Name Servers (for use in /etc/resolv.conf)'
+        additional_search_domains: 'Additional Search Domains (for use in /etc/resolv.conf)'
+        domain_list_hint: 'A comma-separated list of domains'
 
         records: 'Manual Records'
         record_name: 'Name'


### PR DESCRIPTION
This may be convenient as the domain for the cloud is generally not the
only domain used by the user of the cloud in his infrastructure.

Closes https://github.com/sap-oc/crowbar-core/issues/2
