### PR TITLE
upgrade: Disable cron during the node upgrade

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
@@ -28,5 +28,8 @@ fi
 # Move node to ready state and execute chef-client for the first time
 crowbar_join --start
 
+systemctl start cron
+systemctl enable cron
+
 touch $UPGRADEDIR/crowbar-chef-upgraded-ok
 log "$BASH_SOURCE is finished."

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -61,4 +61,8 @@ do
 done
 
 <% end %>
+
+systemctl stop cron
+systemctl disable cron
+
 log "$BASH_SOURCE is finished."


### PR DESCRIPTION
Some existing cron jobs might try to start services that were
not fully configured yet.