### PR TITLE
upgrade: Remove all current repositories from the node to upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -25,10 +25,6 @@
 arch = node[:kernel][:machine]
 roles = node["run_list_map"].keys
 
-old_repos = Provisioner::Repositories.get_repos(
-  node[:platform], node[:platform_version], arch
-)
-
 target_platform, target_platform_version = node[:target_platform].split("-")
 new_repos = Provisioner::Repositories.get_repos(
   target_platform, target_platform_version, arch
@@ -59,9 +55,7 @@ template "/usr/sbin/crowbar-prepare-repositories.sh" do
   group "root"
   action :create
   variables(
-    old_repos: old_repos,
     new_repos: new_repos,
-    old_base_repo: old_install_url,
     new_base_repo: new_install_url,
     new_alias: new_alias
   )

--- a/chef/cookbooks/crowbar/templates/default/crowbar-prepare-repositories.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-prepare-repositories.sh.erb
@@ -27,10 +27,7 @@ fi
 
 
 log "Removing old repositories..."
-<% @old_repos.each do |name, _| %>
-zypper --non-interactive removerepo <%= name %>
-<% end %>
-zypper --non-interactive removerepo <%= @old_base_repo %>
+rm -f /etc/zypp/repos.d/*.repo
 
 log "Adding new repositories..."
 <% @new_repos.each do |name, attrs| %>


### PR DESCRIPTION
Since we now disable all repositories in crowbar before starting the
upgrade, we don't have a definitive list of repos to remove anymore.
So we just remove all configured repositories from the node. This
shouldn't do any harm as the nodes' repositories should be managed by
crowbar anyway.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

We needed to adapt this because of: https://github.com/crowbar/crowbar-core/pull/1094