### PR TITLE
upgrade: Precheck for keystone hybrid backend.

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -183,6 +183,12 @@ module Api
           disks += n["swift"]["devs"].size
         end
         ret[:too_many_replicas] = replicas if replicas > disks
+
+        # keystone hybrid backend check
+        prop = Proposal.where(barclamp: "keystone").first
+        return ret if prop.nil?
+        driver = prop["attributes"]["identity"]["driver"] || "sql"
+        ret[:keystone_hybrid_backend] if driver == "hybrid"
         ret
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -378,6 +378,12 @@ module Api
             help: I18n.t("api.upgrade.prechecks.swift_replicas.help")
           }
         end
+        if check[:keystone_hybrid_backend]
+          ret[:keystone_hybrid_backend] = {
+            data: I18n.t("api.upgrade.prechecks.keystone_hybrid_backend.error"),
+            help: I18n.t("api.upgrade.prechecks.keystone_hybrid_backend.help")
+          }
+        end
         ret
       end
 

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -835,6 +835,9 @@ en:
         swift_replicas:
           error: 'The number of replicas is bigger than the number of disks assigned for Swift.'
           help: 'Such configuration is not supported in Swift delivered with SOC 7. Adapt your Swift configuration before proceeding with the upgrade.'
+        keystone_hybrid_backend:
+          error: 'Keystone is configured with hybrid backend.'
+          help: 'It is not possible to upgrade keystone with hybrid backend. Adapt your Keystone configuration before proceeding with the upgrade.'
         ceph_not_healthy:
           error: 'Ceph cluster health check has failed with %{error}. Make sure cluster is healthy before proceeding with the upgrade.'
           help: 'Refer to the SUSE Enterprise Storage documentation for possible troubleshooting.'


### PR DESCRIPTION
Hybrid backend is not upgradable (or is it not supported with Cloud7 at all?), so we are adding precheck at the start of the upgrade.