### PR TITLE
upgrade: Add a precheck for cinder-volume backends

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -220,15 +220,12 @@ module Api
         ret
       end
 
-      # Check for presence of HA setup, which is a requirement for non-disruptive upgrade
-      def ha_presence_check
-        unless addon_installed? "ha"
-          return { errors: [I18n.t("api.upgrade.prechecks.ha_configured.not_installed")] }
-        end
+      # Check for presence and state of HA setup, which is a requirement for non-disruptive upgrade
+      def ha_config_check
+        return { ha_not_installed: true } unless addon_installed? "ha"
         founders = NodeObject.find("pacemaker_founder:true AND pacemaker_config_environment:*")
-        founders.empty? ?
-          { errors: [I18n.t("api.upgrade.prechecks.ha_configured.not_configured")] }
-          : {}
+        return { ha_not_configured: true } if founders.empty?
+        {}
       end
 
       def maintenance_updates_check

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -225,6 +225,15 @@ module Api
         return { ha_not_installed: true } unless addon_installed? "ha"
         founders = NodeObject.find("pacemaker_founder:true AND pacemaker_config_environment:*")
         return { ha_not_configured: true } if founders.empty?
+
+        # Check if cinder is using correct backend enabling live-migration
+        prop = Proposal.where(barclamp: "cinder").first
+
+        backends = prop["attributes"]["cinder"]["volumes"].select do |volume|
+          backend_driver = volume["backend_driver"]
+          ["local", "raw"].include? backend_driver
+        end
+        return { cinder_wrong_backend: true } unless backends.empty?
         {}
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -99,11 +99,11 @@ module Api
             }
           end
 
-          ha_presence = Api::Crowbar.ha_presence_check
+          ha_config = Api::Crowbar.ha_config_check
           ret[:checks][:ha_configured] = {
             required: false,
-            passed: ha_presence.empty?,
-            errors: ha_presence.empty? ? {} : ha_presence_errors(ha_presence)
+            passed: ha_config.empty?,
+            errors: ha_config.empty? ? {} : ha_config_errors(ha_config)
           }
 
           if Api::Crowbar.addons.include?("ha")
@@ -352,13 +352,21 @@ module Api
         ret
       end
 
-      def ha_presence_errors(check)
-        {
-          ha_configured: {
-            data: check[:errors],
+      def ha_config_errors(check)
+        ret = {}
+        if check[:ha_not_installed]
+          ret[:ha_not_installed] = {
+            data: I18n.t("api.upgrade.prechecks.ha_configured.not_installed"),
             help: I18n.t("api.upgrade.prechecks.ha_configured.help.default")
           }
-        }
+        end
+        if check[:ha_not_configured]
+          ret[:ha_not_configured] = {
+            data: I18n.t("api.upgrade.prechecks.ha_configured.not_configured"),
+            help: I18n.t("api.upgrade.prechecks.ha_configured.help.default")
+          }
+        end
+        ret
       end
 
       def clusters_health_report_errors(check)

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -366,6 +366,12 @@ module Api
             help: I18n.t("api.upgrade.prechecks.ha_configured.help.default")
           }
         end
+        if check[:cinder_wrong_backend]
+          ret[:cinder_wrong_backend] = {
+            data: I18n.t("api.upgrade.prechecks.cinder_wrong_backend.error"),
+            help: I18n.t("api.upgrade.prechecks.cinder_wrong_backend.help")
+          }
+        end
         ret
       end
 

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -832,6 +832,9 @@ en:
           not_configured: 'No Pacemaker cluster is configured.'
           help:
             default: 'Without HA setup, non-disruptive upgrade is not possible.'
+        cinder_wrong_backend:
+          error: 'Unsupported cinder backend detected. The Raw Devices and Local File backend cannot be used with non-disruptive upgrade.'
+          help: 'For non-disruptive upgrade, cinder cannot use Raw Devices or Local File as a backend. Adapt your Cinder configuration before proceeding with the upgrade.'
         swift_replicas:
           error: 'The number of replicas is bigger than the number of disks assigned for Swift.'
           help: 'Such configuration is not supported in Swift delivered with SOC 7. Adapt your Swift configuration before proceeding with the upgrade.'

--- a/crowbar_framework/spec/fixtures/data_bags/template-cinder.json
+++ b/crowbar_framework/spec/fixtures/data_bags/template-cinder.json
@@ -1,0 +1,188 @@
+{
+  "id": "template-cinder",
+  "description": "Installation for Cinder",
+  "attributes": {
+    "cinder": {
+      "debug": false,
+      "verbose": true,
+      "max_header_line": 16384,
+      "use_syslog": false,
+      "rabbitmq_instance": "none",
+      "keystone_instance": "none",
+      "glance_instance": "none",
+      "database_instance": "none",
+      "service_user": "cinder",
+      "service_password": "",
+      "max_pool_size": 30,
+      "max_overflow": 10,
+      "pool_timeout": 30,
+      "rpc_response_timeout": 60,
+      "use_multi_backend": true,
+      "use_multipath": false,
+      "volume_defaults": {
+        "raw": {
+          "volume_name": "cinder-volumes",
+          "cinder_raw_method": "first"
+        },
+        "local": {
+          "volume_name": "cinder-volumes",
+          "file_name": "/var/lib/cinder/volume.raw",
+          "file_size": 2000
+        },
+        "eqlx": {
+          "san_ip": "192.168.124.11",
+          "san_login": "grpadmin",
+          "san_password": "12345",
+          "san_thin_provision": false,
+          "eqlx_group_name": "group-0",
+          "eqlx_use_chap": false,
+          "eqlx_chap_login": "chapadmin",
+          "eqlx_chap_password": "12345",
+          "eqlx_cli_timeout": 30,
+          "eqlx_pool": "default"
+        },
+        "netapp": {
+          "storage_family": "ontap_7mode",
+          "storage_protocol": "iscsi",
+          "nfs_shares": "",
+          "vserver": "",
+          "netapp_server_hostname": "192.168.124.11",
+          "netapp_server_port": 443,
+          "netapp_login": "admin",
+          "netapp_password": "",
+          "netapp_vfiler": "",
+          "netapp_transport_type": "https",
+          "netapp_volume_list": ""
+        },
+        "emc": {
+          "ecom_server_ip": "192.168.124.11",
+          "ecom_server_port": 0,
+          "ecom_server_username": "admin",
+          "ecom_server_password": "",
+          "ecom_server_portgroups": [ "OS-PORTGROUP1-PG", "OS-PORTGROUP2-PG" ],
+          "ecom_server_array": "111111111111",
+          "ecom_server_pool": "FC_GOLD1",
+          "ecom_server_policy": "GOLD1"
+        },
+        "eternus": {
+          "protocol": "fc",
+          "ip": "",
+          "port": 5988,
+          "user": "",
+          "password": "",
+          "pool": "",
+          "iscsi_ip": ""
+        },
+        "nfs": {
+          "nfs_shares": "",
+          "nfs_mount_options": ""
+        },
+        "rbd": {
+          "use_crowbar": true,
+          "config_file": "/etc/ceph/ceph.conf",
+          "admin_keyring": "/etc/ceph/ceph.client.admin.keyring",
+          "pool": "volumes",
+          "user": "cinder",
+          "secret_uuid": ""
+        },
+        "vmware": {
+          "host": "",
+          "user": "",
+          "password": "",
+          "cluster_name": [],
+          "volume_folder": "cinder-volume",
+          "ca_file": "",
+          "insecure": false
+        },
+        "hitachi": {
+          "storage_protocol": "fc",
+          "hitachi_add_chap_user": false,
+          "hitachi_async_copy_check_interval": 10,
+          "hitachi_auth_method": "None",
+          "hitachi_auth_password": "HBSD-CHAP-password",
+          "hitachi_auth_user": "HBSD-CHAP-user",
+          "hitachi_copy_check_interval": 3,
+          "hitachi_copy_speed": 3,
+          "hitachi_default_copy_method": "FULL",
+          "hitachi_group_range": "None",
+          "hitachi_group_request": false,
+          "hitachi_horcm_add_conf": true,
+          "hitachi_horcm_numbers": "200,201",
+          "hitachi_horcm_password": "None",
+          "hitachi_horcm_resource_lock_timeout": 600,
+          "hitachi_horcm_user": "None",
+          "hitachi_ldev_range": "None",
+          "hitachi_pool_id": "None",
+          "hitachi_serial_number": "None",
+          "hitachi_target_ports": "None",
+          "hitachi_thin_pool_id": "None",
+          "hitachi_unit_name": "None",
+          "hitachi_zoning_request": false
+        },
+        "manual": {
+          "driver": "",
+          "config": ""
+        }
+      },
+      "volumes": [
+        {
+          "backend_driver": "raw",
+          "backend_name": "default",
+          "raw": {
+              "volume_name": "cinder-volumes",
+              "cinder_raw_method": "first"
+          }
+        }
+      ],
+      "api": {
+        "protocol": "http",
+        "bind_open_address": true,
+        "bind_port": 8776
+      },
+      "strict_ssh_host_key_policy": false,
+      "default_availability_zone": "",
+      "default_volume_type": "",
+      "ssl": {
+        "certfile": "/etc/cinder/ssl/certs/signing_cert.pem",
+        "keyfile": "/etc/cinder/ssl/private/signing_key.pem",
+        "generate_certs": false,
+        "insecure": false,
+        "cert_required": false,
+        "ca_certs": "/etc/cinder/ssl/certs/ca.pem"
+      },
+      "db": {
+        "password": "",
+        "user": "cinder",
+        "database": "cinder"
+      }
+    }
+  },
+  "deployment": {
+    "cinder": {
+      "crowbar-revision": 0,
+      "crowbar-applied": false,
+      "schema-revision": 50,
+      "element_states": {
+          "cinder-controller": [ "readying", "ready", "applying" ],
+          "cinder-volume": [ "readying", "ready", "applying" ]
+      },
+      "elements": {},
+      "element_order": [
+          [ "cinder-controller" ],
+          [ "cinder-volume" ]
+      ],
+      "element_run_list_order": {
+          "cinder-controller": 92,
+          "cinder-volume": 93
+      },
+      "config": {
+        "environment": "cinder-base-config",
+        "mode": "full",
+        "transitions": false,
+        "transition_list": [
+        ]
+      }
+    }
+  }
+}
+

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -316,7 +316,7 @@ describe Api::Crowbar do
         receive(:find).with("pacemaker_founder:true AND pacemaker_config_environment:*").
         and_return([node])
       )
-      expect(subject.class.ha_presence_check).to eq({})
+      expect(subject.class.ha_config_check).to eq({})
     end
   end
 
@@ -330,7 +330,7 @@ describe Api::Crowbar do
         receive(:find).with("pacemaker_founder:true AND pacemaker_config_environment:*").
         and_return([])
       )
-      expect(subject.class.ha_presence_check).to have_key(:errors)
+      expect(subject.class.ha_config_check).to have_key(:ha_not_configured)
     end
   end
 
@@ -341,7 +341,7 @@ describe Api::Crowbar do
         receive(:addon_installed?).
         and_return(false)
       )
-      expect(subject.class.ha_presence_check).to have_key(:errors)
+      expect(subject.class.ha_config_check).to have_key(:ha_not_installed)
     end
   end
 

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -55,7 +55,7 @@ describe Api::Upgrade do
         )
       )
       allow(Api::Crowbar).to(
-        receive(:ha_presence_check).and_return({})
+        receive(:ha_config_check).and_return({})
       )
 
       expect(subject.class).to respond_to(:status)
@@ -90,7 +90,7 @@ describe Api::Upgrade do
         :addons
       ).and_return(["ceph", "ha"])
       allow(Api::Crowbar).to(
-        receive(:ha_presence_check).and_return({})
+        receive(:ha_config_check).and_return({})
       )
       allow(Api::Crowbar).to(
         receive(:clusters_health_report).and_return({})
@@ -355,7 +355,7 @@ describe Api::Upgrade do
         :addons
       ).and_return(["ceph", "ha"])
       allow(Api::Crowbar).to(
-        receive(:ha_presence_check).and_return({})
+        receive(:ha_config_check).and_return({})
       )
       allow(Api::Crowbar).to(
         receive(:clusters_health_report).and_return({})
@@ -384,7 +384,7 @@ describe Api::Upgrade do
         :updates_status
       ).and_return({})
       allow(Api::Crowbar).to receive(
-        :ha_presence_check
+        :ha_config_check
       ).and_return(error: "ERROR")
       allow(Api::Crowbar).to(
         receive(:clusters_health_report).and_return({})


### PR DESCRIPTION
cinder-volume needs to be configured with HA to enable non-disruptive upgrade