### PR TITLE
upgrade: Precheck for lbaas version

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -175,15 +175,14 @@ module Api
         ret = {}
         # swift replicas check vs. number of disks
         prop = Proposal.where(barclamp: "swift").first
-        return ret if prop.nil?
-        replicas = prop["attributes"]["swift"]["replicas"] || 0
-
-        disks = 0
-        NodeObject.find("roles:swift-storage").each do |n|
-          disks += n["swift"]["devs"].size
+        unless prop.nil?
+          replicas = prop["attributes"]["swift"]["replicas"] || 0
+          disks = 0
+          NodeObject.find("roles:swift-storage").each do |n|
+            disks += n["swift"]["devs"].size
+          end
+          ret[:too_many_replicas] = replicas if replicas > disks
         end
-        ret[:too_many_replicas] = replicas if replicas > disks
-
         # keystone hybrid backend check
         prop = Proposal.where(barclamp: "keystone").first
         return ret if prop.nil?

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -384,6 +384,12 @@ module Api
             help: I18n.t("api.upgrade.prechecks.keystone_hybrid_backend.help")
           }
         end
+        if check[:lbaas_v1]
+          ret[:lbaas_v1] = {
+            data: I18n.t("api.upgrade.prechecks.lbaas_v1.error"),
+            help: I18n.t("api.upgrade.prechecks.lbaas_v1.help")
+          }
+        end
         ret
       end
 

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -838,6 +838,12 @@ en:
         keystone_hybrid_backend:
           error: 'Keystone is configured with hybrid backend.'
           help: 'It is not possible to upgrade keystone with hybrid backend. Adapt your Keystone configuration before proceeding with the upgrade.'
+        lbaas_v1:
+          error: 'Old version of LBaaS is configured and active.'
+          help: |
+            Such a configuration is not supported for the upgrade. Please switch to LBaaS v2 before you continue.
+            Currently, no migration path exists between v1 and v2 load balancers.
+            When you switch from v1 to v2, you must recreate all load balancers, pools, and health monitors.
         ceph_not_healthy:
           error: 'Ceph cluster health check has failed with %{error}. Make sure cluster is healthy before proceeding with the upgrade.'
           help: 'Refer to the SUSE Enterprise Storage documentation for possible troubleshooting.'


### PR DESCRIPTION
We only allow lbaas v2 during the upgrade.

UPDATE: Added check if lbaas config is active. If I read https://docs.openstack.org/admin-guide/networking-adv-features.html#basic-load-balancer-as-a-service-operations correctly, pool is needed for all other kind of objects, so I'm only listing pools in the check ... correct me if I'm wrong