### PR TITLE
provisioner: Define nameservers in autoyast.xml (bsc#1026837)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -61,6 +61,9 @@ discovery_dir = "#{tftproot}/discovery"
 pxecfg_subdir = "bios/pxelinux.cfg"
 uefi_subdir = "efi"
 
+dns_config = Barclamp::Config.load("core", "dns")
+dns_list = dns_config["servers"] || []
+
 node_search_with_cache("*:*").each do |mnode|
   next if mnode[:state].nil?
 
@@ -366,7 +369,8 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
           default_fs: mnode[:crowbar_wall][:default_fs] || "ext4",
           needs_openvswitch: (mnode[:network] && mnode[:network][:needs_openvswitch]) || false,
           use_uefi: !mnode[:uefi].nil?,
-          domain_name: node.fetch(:dns, {})[:domain] || node[:domain]
+          domain_name: node.fetch(:dns, {})[:domain] || node[:domain],
+          nameservers: dns_list
         )
       end
 

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -100,6 +100,13 @@
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
       <domain><%= @domain_name %></domain>
       <hostname><%= @node_hostname %></hostname>
+<% unless @nameservers.empty? -%>
+      <nameservers config:type="list">
+  <% @nameservers.each do |nameserver| -%>
+        <nameserver><%= nameserver %></nameserver>
+  <% end -%>
+      </nameservers>
+<% end -%>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>
     </dns>


### PR DESCRIPTION
After the installation, but before chef is run, DNS resolution won't
work without this. This is critical in case the repositories are
configured with a DNS name, as this means the nodes won't be able to be
automatically configured (since packages won't be installable).

https://bugzilla.suse.com/show_bug.cgi?id=1026837

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
