### PR TITLE
provisioner: Use correct attributes for autoyast profile (bsc#1021596)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -370,7 +370,9 @@ if not nodes.nil? and not nodes.empty?
                       crowbar_join: "#{os_url}/crowbar_join.sh",
                       default_fs: mnode[:crowbar_wall][:default_fs] || "ext4",
                       needs_openvswitch:
-                        (mnode[:network] && mnode[:network][:needs_openvswitch]) || false
+                        (mnode[:network] && mnode[:network][:needs_openvswitch]) || false,
+                      use_uefi: !mnode[:uefi].nil?,
+                      domain_name: node.fetch(:dns, {})[:domain] || node[:domain]
             )
           end
 

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -98,7 +98,7 @@
     <keep_install_network config:type="boolean">true</keep_install_network>
     <dns>
       <dhcp_hostname config:type="boolean">true</dhcp_hostname>
-      <domain><%= node[:domain] %></domain>
+      <domain><%= @domain_name %></domain>
       <hostname><%= @node_hostname %></hostname>
       <resolv_conf_policy>auto</resolv_conf_policy>
       <write_hostname config:type="boolean">false</write_hostname>
@@ -118,7 +118,7 @@
         <type config:type="symbol">CT_DISK</type>
         <disklabel>gpt</disklabel>
         <partitions config:type="list">
-          <% if node["uefi"] %>
+          <% if @use_uefi %>
           <partition>
             <create config:type="boolean">true</create>
             <format config:type="boolean">true</format>
@@ -156,7 +156,7 @@
           <type config:type="symbol">CT_DISK</type>
           <initialize config:type="boolean">true</initialize>
           <partitions config:type="list">
-            <% if node["uefi"] %>
+            <% if @use_uefi %>
             <partition>
               <create config:type="boolean">true</create>
               <format config:type="boolean">true</format>


### PR DESCRIPTION
Using the UEFI attribute from the admin server doesn't help figure out
if the node is using UEFI.

Similarly, be a bit safer for the domain.

https://bugzilla.suse.com/show_bug.cgi?id=1021596
(cherry picked from commit ca7c715823d69453d001b43d2aa146a75527543a)

Backport of https://github.com/crowbar/crowbar-core/pull/1040