### PR TITLE
Disruptive upgrade

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
@@ -47,7 +47,7 @@ fi
 
 # FIXME: here we need checks for potential errors during the evacuation
 
-while nova list --host "$host" --fields host 2>/dev/null | grep "$host"; do
+while nova list --all-tenants --host "$host" --fields host,status 2>/dev/null | grep -e ACTIVE -e MIGRATING | grep -q "$host"; do
     log "There is still some VM running at $host..."
     sleep 10
 done

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -381,7 +381,7 @@ module Api
         end
         cmd = "openstack server list --all-projects --long " \
           "--status active -f value -c Host"
-        out = controller.run_ssh_cmd("source /root/.openrc; #{cmd}")
+        out = controller.run_ssh_cmd("source /root/.openrc; #{cmd}", "60s")
         unless out[:exit_code].zero?
           raise_services_error(
             "Error happened when trying to list running instances.\n" \
@@ -1239,7 +1239,8 @@ module Api
         out = controller.run_ssh_cmd(
           "source /root/.openrc; " \
           "nova service-list --host #{hostname} --binary nova-compute " \
-          "| grep -q enabled"
+          "| grep -q enabled",
+          "60s"
         )
         unless out[:exit_code].zero?
           raise_node_upgrade_error(

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -814,8 +814,8 @@ class Node < ChefObject
   end
 
   # ssh to the node and wait until the command exits
-  def run_ssh_cmd(cmd)
-    args = ["sudo", "-i", "-u", "root", "--", "timeout", "-k", "5s", "15s",
+  def run_ssh_cmd(cmd, timeout = "15s", kill_after = "5s")
+    args = ["sudo", "-i", "-u", "root", "--", "timeout", "-k", kill_after, timeout,
             "ssh", "-o", "ConnectTimeout=10",
             "root@#{@node.name}",
             %("#{cmd.gsub('"', '\\"')}")

--- a/crowbar_framework/lib/crowbar/error.rb
+++ b/crowbar_framework/lib/crowbar/error.rb
@@ -37,6 +37,9 @@ module Crowbar
 
       autoload :NodeError,
         File.expand_path("../error/upgrade", __FILE__)
+
+      autoload :ServicesError,
+        File.expand_path("../error/upgrade", __FILE__)
     end
   end
 end

--- a/crowbar_framework/lib/crowbar/error/upgrade.rb
+++ b/crowbar_framework/lib/crowbar/error/upgrade.rb
@@ -58,6 +58,12 @@ module Crowbar
           super(message)
         end
       end
+
+      class ServicesError < UpgradeError
+        def initialize(message)
+          super(message)
+        end
+      end
     end
   end
 end

--- a/crowbar_framework/spec/fixtures/data_bags/template-cinder.json
+++ b/crowbar_framework/spec/fixtures/data_bags/template-cinder.json
@@ -1,0 +1,188 @@
+{
+  "id": "template-cinder",
+  "description": "Installation for Cinder",
+  "attributes": {
+    "cinder": {
+      "debug": false,
+      "verbose": true,
+      "max_header_line": 16384,
+      "use_syslog": false,
+      "rabbitmq_instance": "none",
+      "keystone_instance": "none",
+      "glance_instance": "none",
+      "database_instance": "none",
+      "service_user": "cinder",
+      "service_password": "",
+      "max_pool_size": 30,
+      "max_overflow": 10,
+      "pool_timeout": 30,
+      "rpc_response_timeout": 60,
+      "use_multi_backend": true,
+      "use_multipath": false,
+      "volume_defaults": {
+        "raw": {
+          "volume_name": "cinder-volumes",
+          "cinder_raw_method": "first"
+        },
+        "local": {
+          "volume_name": "cinder-volumes",
+          "file_name": "/var/lib/cinder/volume.raw",
+          "file_size": 2000
+        },
+        "eqlx": {
+          "san_ip": "192.168.124.11",
+          "san_login": "grpadmin",
+          "san_password": "12345",
+          "san_thin_provision": false,
+          "eqlx_group_name": "group-0",
+          "eqlx_use_chap": false,
+          "eqlx_chap_login": "chapadmin",
+          "eqlx_chap_password": "12345",
+          "eqlx_cli_timeout": 30,
+          "eqlx_pool": "default"
+        },
+        "netapp": {
+          "storage_family": "ontap_7mode",
+          "storage_protocol": "iscsi",
+          "nfs_shares": "",
+          "vserver": "",
+          "netapp_server_hostname": "192.168.124.11",
+          "netapp_server_port": 443,
+          "netapp_login": "admin",
+          "netapp_password": "",
+          "netapp_vfiler": "",
+          "netapp_transport_type": "https",
+          "netapp_volume_list": ""
+        },
+        "emc": {
+          "ecom_server_ip": "192.168.124.11",
+          "ecom_server_port": 0,
+          "ecom_server_username": "admin",
+          "ecom_server_password": "",
+          "ecom_server_portgroups": [ "OS-PORTGROUP1-PG", "OS-PORTGROUP2-PG" ],
+          "ecom_server_array": "111111111111",
+          "ecom_server_pool": "FC_GOLD1",
+          "ecom_server_policy": "GOLD1"
+        },
+        "eternus": {
+          "protocol": "fc",
+          "ip": "",
+          "port": 5988,
+          "user": "",
+          "password": "",
+          "pool": "",
+          "iscsi_ip": ""
+        },
+        "nfs": {
+          "nfs_shares": "",
+          "nfs_mount_options": ""
+        },
+        "rbd": {
+          "use_crowbar": true,
+          "config_file": "/etc/ceph/ceph.conf",
+          "admin_keyring": "/etc/ceph/ceph.client.admin.keyring",
+          "pool": "volumes",
+          "user": "cinder",
+          "secret_uuid": ""
+        },
+        "vmware": {
+          "host": "",
+          "user": "",
+          "password": "",
+          "cluster_name": [],
+          "volume_folder": "cinder-volume",
+          "ca_file": "",
+          "insecure": false
+        },
+        "hitachi": {
+          "storage_protocol": "fc",
+          "hitachi_add_chap_user": false,
+          "hitachi_async_copy_check_interval": 10,
+          "hitachi_auth_method": "None",
+          "hitachi_auth_password": "HBSD-CHAP-password",
+          "hitachi_auth_user": "HBSD-CHAP-user",
+          "hitachi_copy_check_interval": 3,
+          "hitachi_copy_speed": 3,
+          "hitachi_default_copy_method": "FULL",
+          "hitachi_group_range": "None",
+          "hitachi_group_request": false,
+          "hitachi_horcm_add_conf": true,
+          "hitachi_horcm_numbers": "200,201",
+          "hitachi_horcm_password": "None",
+          "hitachi_horcm_resource_lock_timeout": 600,
+          "hitachi_horcm_user": "None",
+          "hitachi_ldev_range": "None",
+          "hitachi_pool_id": "None",
+          "hitachi_serial_number": "None",
+          "hitachi_target_ports": "None",
+          "hitachi_thin_pool_id": "None",
+          "hitachi_unit_name": "None",
+          "hitachi_zoning_request": false
+        },
+        "manual": {
+          "driver": "",
+          "config": ""
+        }
+      },
+      "volumes": [
+        {
+          "backend_driver": "raw",
+          "backend_name": "default",
+          "raw": {
+              "volume_name": "cinder-volumes",
+              "cinder_raw_method": "first"
+          }
+        }
+      ],
+      "api": {
+        "protocol": "http",
+        "bind_open_address": true,
+        "bind_port": 8776
+      },
+      "strict_ssh_host_key_policy": false,
+      "default_availability_zone": "",
+      "default_volume_type": "",
+      "ssl": {
+        "certfile": "/etc/cinder/ssl/certs/signing_cert.pem",
+        "keyfile": "/etc/cinder/ssl/private/signing_key.pem",
+        "generate_certs": false,
+        "insecure": false,
+        "cert_required": false,
+        "ca_certs": "/etc/cinder/ssl/certs/ca.pem"
+      },
+      "db": {
+        "password": "",
+        "user": "cinder",
+        "database": "cinder"
+      }
+    }
+  },
+  "deployment": {
+    "cinder": {
+      "crowbar-revision": 0,
+      "crowbar-applied": false,
+      "schema-revision": 50,
+      "element_states": {
+          "cinder-controller": [ "readying", "ready", "applying" ],
+          "cinder-volume": [ "readying", "ready", "applying" ]
+      },
+      "elements": {},
+      "element_order": [
+          [ "cinder-controller" ],
+          [ "cinder-volume" ]
+      ],
+      "element_run_list_order": {
+          "cinder-controller": 92,
+          "cinder-volume": 93
+      },
+      "config": {
+        "environment": "cinder-base-config",
+        "mode": "full",
+        "transitions": false,
+        "transition_list": [
+        ]
+      }
+    }
+  }
+}
+

--- a/crowbar_framework/spec/fixtures/data_bags/template-database.json
+++ b/crowbar_framework/spec/fixtures/data_bags/template-database.json
@@ -1,0 +1,56 @@
+{
+  "id": "template-database",
+  "description": "Installation for Database",
+  "attributes": {
+    "database": {
+      "sql_engine": "postgresql",
+      "mysql": {
+        "datadir": "/var/lib/mysql"
+      },
+      "postgresql": {
+        "config": {
+          "max_connections": 1000,
+          "log_filename": "postgresql.log-%Y%m%d%H%M",
+          "log_truncate_on_rotation": false
+        }
+      },
+      "ha": {
+        "storage": {
+          "mode": "shared",
+          "drbd": {
+            "size": 50
+          },
+          "shared": {
+            "device": "",
+            "fstype": "",
+            "options": ""
+          }
+        }
+      }
+    }
+  },
+  "deployment": {
+    "database": {
+      "crowbar-revision": 0,
+      "crowbar-applied": false,
+      "schema-revision": 4,
+      "element_states": {
+        "database-server": [ "readying", "ready", "applying" ]
+      },
+      "elements": {
+        "database-server": []
+      },
+      "element_order": [
+        [ "database-server" ]
+      ],
+      "config": {
+        "environment": "database-base-config",
+        "mode": "full",
+        "transitions": false,
+        "transition_list": [
+        ]
+      }
+    }
+  }
+}
+

--- a/crowbar_framework/spec/fixtures/data_bags/template-nova.json
+++ b/crowbar_framework/spec/fixtures/data_bags/template-nova.json
@@ -1,0 +1,145 @@
+{
+  "id": "template-nova",
+  "description": "installs and configures the Openstack Nova component. It relies upon the network and glance barclamps for normal operation.",
+  "attributes": {
+    "nova": {
+      "database_instance": "none",
+      "rabbitmq_instance": "none",
+      "keystone_instance": "none",
+      "service_user": "nova",
+      "glance_instance": "none",
+      "cinder_instance": "none",
+      "neutron_instance": "none",
+      "itxt_instance": "none",
+      "trusted_flavors": false,
+      "libvirt_type": "kvm",
+      "use_novnc": true,
+      "debug": false,
+      "verbose": true,
+      "max_header_line": 16384,
+      "setup_shared_instance_storage": false,
+      "use_shared_instance_storage": false,
+      "use_migration": false,
+      "cross_az_attach": true,
+      "use_syslog": false,
+      "neutron_url_timeout": 30,
+      "force_config_drive": false,
+      "vnc_keymap": "en-us",
+      "scheduler": {
+        "ram_allocation_ratio": 1.0,
+        "cpu_allocation_ratio": 16.0,
+        "disk_allocation_ratio": 1.0
+      },
+      "db": {
+        "password": "",
+        "user": "nova",
+        "database": "nova"
+      },
+      "rbd": {
+        "user": "",
+        "secret_uuid": ""
+      },
+      "kvm": {
+        "ksm_enabled": false
+      },
+      "vcenter": {
+        "host": "",
+        "port": 443,
+        "user": "",
+        "password": "",
+        "clusters": [],
+        "datastore": "",
+        "interface": "vmnic0",
+        "ca_file": "",
+        "insecure": false
+      },
+      "zvm": {
+        "zvm_xcat_server": "",
+        "zvm_xcat_username": "",
+        "zvm_xcat_password": "",
+        "zvm_xcat_network": "admin",
+        "zvm_diskpool": "",
+        "zvm_diskpool_type": "",
+        "zvm_host": "",
+        "zvm_scsi_pool": "",
+        "zvm_user_profile": "",
+        "zvm_xcat_master": "",
+        "zvm_image_default_password": "rootpass",
+        "zvm_config_drive_inject_password": true,
+        "zvm_reachable_timeout": 600,
+        "zvm_user_default_password": "dfltpass",
+        "zvm_user_default_privilege": "g",
+        "zvm_xcat_ssh_key": ""
+      },
+      "ssl": {
+        "enabled": false,
+        "certfile": "/etc/nova/ssl/certs/signing_cert.pem",
+        "keyfile": "/etc/nova/ssl/private/signing_key.pem",
+        "generate_certs": false,
+        "insecure": false,
+        "cert_required": false,
+        "ca_certs": "/etc/nova/ssl/certs/ca.pem"
+      },
+      "novnc": {
+        "ssl": {
+          "enabled": false,
+          "certfile": "",
+          "keyfile": ""
+        }
+      },
+      "block_device": {
+        "allocate_retries": 60,
+        "allocate_retries_interval": 3
+      }
+    }
+  },
+  "deployment": {
+    "nova": {
+      "crowbar-revision": 0,
+      "crowbar-applied": false,
+      "schema-revision": 46,
+      "element_states": {
+        "nova-controller": [ "readying", "ready", "applying" ],
+        "nova-compute-docker": [ "readying", "ready", "applying" ],
+        "nova-compute-hyperv": [ "readying", "ready", "applying" ],
+        "nova-compute-kvm": [ "readying", "ready", "applying" ],
+        "nova-compute-qemu": [ "readying", "ready", "applying" ],
+        "nova-compute-vmware": [ "readying", "ready", "applying" ],
+        "nova-compute-xen": [ "readying", "ready", "applying" ],
+        "nova-compute-zvm": [ "readying", "ready", "applying" ],
+        "nova-ha-compute": [ "readying", "ready", "applying" ]
+      },
+      "elements": {},
+      "element_order": [
+        [ "nova-controller" ],
+        [
+          "nova-compute-docker",
+          "nova-compute-hyperv",
+          "nova-compute-kvm",
+          "nova-compute-qemu",
+          "nova-compute-vmware",
+          "nova-compute-xen",
+          "nova-compute-zvm"
+        ]
+      ],
+      "element_run_list_order": {
+        "nova-controller": 95,
+        "nova-compute-docker": 97,
+        "nova-compute-hyperv": 97,
+        "nova-compute-kvm": 97,
+        "nova-compute-qemu": 97,
+        "nova-compute-vmware": 97,
+        "nova-compute-xen": 97,
+        "nova-compute-zvm": 97,
+        "nova-ha-compute": 97
+      },
+      "config": {
+        "environment": "nova-config-base",
+        "mode": "full",
+        "transitions": false,
+        "transition_list": []
+      }
+    }
+  }
+}
+

--- a/crowbar_framework/spec/fixtures/offline_chef/node_drbd.crowbar.com.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/node_drbd.crowbar.com.json
@@ -25,7 +25,8 @@
       }
     },
     "hostname": "drbd",
-    "state": "discovered"
+    "state": "discovered",
+    "run_list_map": {}
   },
   "name": "drbd.crowbar.com",
   "_rev": "2-169913f4e0b095822a7d66b2543d4641",


### PR DESCRIPTION
**Why is this change necessary?**

Disruptive upgrade is needed for users without the setup that allows non-disruptive upgrade

**How does it address the issue?**

Implements the proposal described at https://etherpad.nue.suse.com/p/cloud-upgrade-disruptive


**For followup** 

- ~~Showing some nice status when doing paralel parts: https://github.com/crowbar/crowbar-core/pull/1133~~ **Merged**
- More paralelization (currently it is done only for OS upgrade of nodes)

