### PR TITLE
upgrade: avoid sudo/ssh calls during unit tests

### DIFF
--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -75,6 +75,11 @@ describe Api::UpgradeController, type: :request do
       allow_any_instance_of(CrowbarService).to receive(
         :prepare_nodes_for_os_upgrade
       ).and_return(true)
+      allow_any_instance_of(Node).to receive(:ssh_cmd).and_return(
+        stdout: "",
+        tderr: "",
+        exit_code: 0
+      )
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 


### PR DESCRIPTION
The services step call shutdown_services_before_upgrade which tries to
call "sudo ssh ...". Avoid that by mocking the ssh_cmd method.

This should fix local rspec runs. 
(Apart from a log message it doesn't seem to be an issue in  travis. See e.g.: https://travis-ci.org/crowbar/crowbar-core/builds/206615051#L890)