### PR TITLE
upgrade:Allow overriding the detected upgrade mode

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -111,7 +111,7 @@ module Api
           else
             # otherwise choose the disruptive upgrade path (i.e. the required
             # checks succeeded and some of the non-required ones failed)
-            "disruptive"
+            "normal"
           end
 
           ::Crowbar::UpgradeStatus.new.save_suggested_upgrade_mode(ret[:best_method])

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -104,14 +104,14 @@ module Api
 
           ret[:best_method] = if ret[:checks].any? { |_id, c| c[:required] && !c[:passed] }
             # no upgrade if any of the required prechecks failed
-            "none"
+            :none
           elsif !ret[:checks].any? { |_id, c| !c[:required] && !c[:passed] }
             # allow non-disruptive when all prechecks succeeded
-            "non-disruptive"
+            :non_disruptive
           else
             # otherwise choose the disruptive upgrade path (i.e. the required
             # checks succeeded and some of the non-required ones failed)
-            "normal"
+            :normal
           end
 
           ::Crowbar::UpgradeStatus.new.save_suggested_upgrade_mode(ret[:best_method])

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -114,7 +114,7 @@ module Api
             "disruptive"
           end
 
-          ::Crowbar::UpgradeStatus.new.save_upgrade_mode(ret[:best_method])
+          ::Crowbar::UpgradeStatus.new.save_suggested_upgrade_mode(ret[:best_method])
 
           return ret unless upgrade_status.current_step == :prechecks
 

--- a/crowbar_framework/lib/crowbar/error/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/error/upgrade_status.rb
@@ -47,5 +47,11 @@ module Crowbar
         super("Exception during saving the status file: #{msg}")
       end
     end
+
+    class SaveUpgradeModeError < StandardError
+      def initialize(msg)
+        super("Error setting the upgrade mode: #{msg}")
+      end
+    end
   end
 end

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -60,7 +60,7 @@ module Crowbar
         crowbar_backup: nil,
         openstack_backup: nil,
         # disruptive vs. nondisruptive
-        upgrade_mode: nil
+        suggested_upgrade_mode: nil
       }
       # in 'steps', we save the information about each step that was executed
       @progress[:steps] = upgrade_steps_6_7.map do |step|
@@ -70,8 +70,8 @@ module Crowbar
       save
     end
 
-    def upgrade_mode
-      progress[:upgrade_mode]
+    def suggested_upgrade_mode
+      progress[:suggested_upgrade_mode]
     end
 
     def current_substep
@@ -183,10 +183,10 @@ module Crowbar
       end
     end
 
-    def save_upgrade_mode(mode)
+    def save_suggested_upgrade_mode(mode)
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
         load_while_locked
-        progress[:upgrade_mode] = mode
+        progress[:suggested_upgrade_mode] = mode
         save
       end
     end

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -59,7 +59,7 @@ module Crowbar
         # locations of the backups taken during the upgrade
         crowbar_backup: nil,
         openstack_backup: nil,
-        # disruptive vs. nondisruptive
+        # normal vs. nondisruptive
         suggested_upgrade_mode: nil
       }
       # in 'steps', we save the information about each step that was executed

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -212,6 +212,11 @@ module Crowbar
     def save_selected_upgrade_mode(mode)
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
         load_while_locked
+        # It's ok to change the upgrade mode until starting the services step
+        unless pending? :services
+          raise ::Crowbar::Error::SaveUpgradeModeError,
+            "Changing the upgrade mode after starting the 'services' step is not possible."
+        end
         if suggested_upgrade_mode == :normal && mode != :normal
           raise ::Crowbar::Error::SaveUpgradeModeError,
             "Upgrade mode '#{mode}' is not possible. " \

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -59,7 +59,7 @@ module Crowbar
         # locations of the backups taken during the upgrade
         crowbar_backup: nil,
         openstack_backup: nil,
-        # normal vs. nondisruptive
+        # :normal vs. :non_disruptive
         suggested_upgrade_mode: nil
       }
       # in 'steps', we save the information about each step that was executed

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -6,7 +6,7 @@
   "upgraded_nodes": null,
   "crowbar_backup": null,
   "openstack_backup": null,
-  "upgrade_mode": null,
+  "suggested_upgrade_mode": null,
   "steps":{
     "prechecks":{
       "status":"pending"

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -7,6 +7,7 @@
   "crowbar_backup": null,
   "openstack_backup": null,
   "suggested_upgrade_mode": null,
+  "selected_upgrade_mode": null,
   "steps":{
     "prechecks":{
       "status":"pending"

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -326,8 +326,32 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_substep).to be_nil
       expect(subject.suggested_upgrade_mode).to be nil
 
+      expect(subject.save_suggested_upgrade_mode(:non_disruptive)).to be true
+      expect(subject.suggested_upgrade_mode).to be :non_disruptive
+      expect(subject.save_selected_upgrade_mode(:normal)).to be true
+      expect(subject.selected_upgrade_mode).to be :normal
+      expect(subject.upgrade_mode).to be :normal
+    end
+
+    it "fails to set upgrade mode to 'non-disruptive' when only 'normal' is possible" do
+      expect(subject.current_substep).to be_nil
+      expect(subject.suggested_upgrade_mode).to be nil
       expect(subject.save_suggested_upgrade_mode(:normal)).to be true
       expect(subject.suggested_upgrade_mode).to be :normal
+      expect { subject.save_selected_upgrade_mode(:non_disruptive) }.to raise_error(
+        Crowbar::Error::SaveUpgradeModeError
+      )
+    end
+
+    it "reset selected_upgrade_mode if suggest_upgrade_mode is downgraded to 'normal' or 'none'" do
+      expect(subject.current_substep).to be_nil
+      expect(subject.suggested_upgrade_mode).to be nil
+      expect(subject.save_selected_upgrade_mode(:non_disruptive)).to be true
+      expect(subject.selected_upgrade_mode).to be :non_disruptive
+      expect(subject.save_suggested_upgrade_mode(:normal)).to be true
+      expect(subject.suggested_upgrade_mode).to be :normal
+      expect(subject.selected_upgrade_mode).to be nil
+      expect(subject.upgrade_mode).to be :normal
     end
 
     it "fails while saving the status initially" do

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -324,10 +324,10 @@ describe Crowbar::UpgradeStatus do
 
     it "saves and checks upgrade mode" do
       expect(subject.current_substep).to be_nil
-      expect(subject.upgrade_mode).to be nil
+      expect(subject.suggested_upgrade_mode).to be nil
 
-      expect(subject.save_upgrade_mode(:disruptive)).to be true
-      expect(subject.upgrade_mode).to be :disruptive
+      expect(subject.save_suggested_upgrade_mode(:disruptive)).to be true
+      expect(subject.suggested_upgrade_mode).to be :disruptive
     end
 
     it "fails while saving the status initially" do

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -326,8 +326,8 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_substep).to be_nil
       expect(subject.suggested_upgrade_mode).to be nil
 
-      expect(subject.save_suggested_upgrade_mode(:disruptive)).to be true
-      expect(subject.suggested_upgrade_mode).to be :disruptive
+      expect(subject.save_suggested_upgrade_mode(:normal)).to be true
+      expect(subject.suggested_upgrade_mode).to be :normal
     end
 
     it "fails while saving the status initially" do

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -354,6 +354,29 @@ describe Crowbar::UpgradeStatus do
       expect(subject.upgrade_mode).to be :normal
     end
 
+    it "fails to change upgrade mode after starting the services step" do
+      allow(FileUtils).to receive(:touch).and_return(true)
+      expect(subject.start_step(:prechecks)).to be true
+      expect(subject.end_step).to be true
+      expect(subject.start_step(:prepare)).to be true
+      expect(subject.end_step).to be true
+      expect(subject.start_step(:backup_crowbar)).to be true
+      expect(subject.end_step).to be true
+      expect(subject.start_step(:repocheck_crowbar)).to be true
+      expect(subject.end_step).to be true
+      expect(subject.start_step(:admin)).to be true
+      expect(subject.end_step).to be true
+      expect(subject.start_step(:database)).to be true
+      expect(subject.end_step).to be true
+      expect(subject.start_step(:repocheck_nodes)).to be true
+      expect(subject.end_step).to be true
+      expect(subject.start_step(:services)).to be true
+
+      expect { subject.save_selected_upgrade_mode(:normal) }.to raise_error(
+        Crowbar::Error::SaveUpgradeModeError
+      )
+    end
+
     it "fails while saving the status initially" do
       allow_any_instance_of(Pathname).to(
         receive(:open).and_raise("Failed to write File")

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -354,13 +354,13 @@ describe Api::Upgrade do
       expect(subject.class.checks.deep_symbolize_keys[:best_method]).to eq("non-disruptive")
     end
 
-    it "chooses disruptive upgrade when a non-required prechecks fails" do
+    it "chooses 'normal' upgrade when a non-required prechecks fails" do
       upgrade_prechecks = prechecks
       upgrade_prechecks["checks"]["compute_status"]["passed"] = false
-      upgrade_prechecks["best_method"] = "disruptive"
+      upgrade_prechecks["best_method"] = "normal"
       allow(subject.class).to receive(:checks).and_return(upgrade_prechecks)
 
-      expect(subject.class.checks.deep_symbolize_keys[:best_method]).to eq("disruptive")
+      expect(subject.class.checks.deep_symbolize_keys[:best_method]).to eq("normal")
     end
 
     it "chooses none when a required precheck fails" do

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -347,20 +347,58 @@ describe Api::Upgrade do
 
   context "determining the best upgrade method" do
     it "chooses non-disruptive upgrade when all prechecks succeed" do
-      allow(subject.class).to receive(:checks).and_return(
-        prechecks.deep_symbolize_keys
+      allow(Crowbar::Sanity).to receive(:check).and_return([])
+      allow(Api::Crowbar).to receive(
+        :maintenance_updates_check
+      ).and_return({})
+      allow(Api::Crowbar).to receive(
+        :addons
+      ).and_return(["ceph", "ha"])
+      allow(Api::Crowbar).to(
+        receive(:ha_presence_check).and_return({})
       )
+      allow(Api::Crowbar).to(
+        receive(:clusters_health_report).and_return({})
+      )
+      allow(Api::Crowbar).to(
+        receive(:health_check).and_return({})
+      )
+      allow(Api::Crowbar).to(
+        receive(:compute_status).and_return({})
+      )
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
-      expect(subject.class.checks.deep_symbolize_keys[:best_method]).to eq("non-disruptive")
+      expect(subject.class.checks.deep_symbolize_keys[:best_method]).to be :non_disruptive
     end
 
     it "chooses 'normal' upgrade when a non-required prechecks fails" do
-      upgrade_prechecks = prechecks
-      upgrade_prechecks["checks"]["compute_status"]["passed"] = false
-      upgrade_prechecks["best_method"] = "normal"
-      allow(subject.class).to receive(:checks).and_return(upgrade_prechecks)
+      allow(Crowbar::Sanity).to receive(:check).and_return([])
+      allow(Api::Crowbar).to receive(
+        :maintenance_updates_check
+      ).and_return({})
+      allow(Api::Crowbar).to receive(
+        :addons
+      ).and_return(["ceph", "ha"])
+      allow(Crowbar::Checks::Maintenance).to receive(
+        :updates_status
+      ).and_return({})
+      allow(Api::Crowbar).to receive(
+        :ha_presence_check
+      ).and_return(error: "ERROR")
+      allow(Api::Crowbar).to(
+        receive(:clusters_health_report).and_return({})
+      )
+      allow(Api::Crowbar).to(
+        receive(:health_check).and_return({})
+      )
+      allow(Api::Crowbar).to(
+        receive(:compute_status).and_return({})
+      )
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
-      expect(subject.class.checks.deep_symbolize_keys[:best_method]).to eq("normal")
+      expect(subject.class.checks.deep_symbolize_keys[:best_method]).to be :normal
     end
 
     it "chooses none when a required precheck fails" do
@@ -374,8 +412,10 @@ describe Api::Upgrade do
         :maintenance_updates_status
       ).and_return(errors: ["Some Error"])
       allow(Api::Crowbar).to receive(:compute_status).and_return({})
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
+      allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
-      expect(subject.class.checks[:best_method]).to eq("none")
+      expect(subject.class.checks[:best_method]).to be :none
     end
   end
 


### PR DESCRIPTION
This is needed as we want to provide a way to force a "normal" upgrade on system that would support a "non-disruptive" upgrade.

This PR also include quite a bit of cleanup and fixes for the related unit tests.

As this got a bit more complex than initially expected as decided to split this into two pull requests. This one just changes the status library. The follow up PR will add the new Rest API .