### PR TITLE
upgrade: New API to set/get the current upgrade mode

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -227,6 +227,27 @@ class Api::UpgradeController < ApiController
     }, status: :unprocessable_entity
   end
 
+  def mode
+    if request.post?
+      Api::Upgrade.upgrade_mode = params[:mode]
+      render json: {}, status: :ok
+    else
+      render json: {
+        mode: Api::Upgrade.upgrade_mode
+      }
+    end
+  rescue ::Crowbar::Error::SaveUpgradeModeError,
+         ::Crowbar::Error::SaveUpgradeStatusError,
+         ::Crowbar::Error::UpgradeError => e
+    render json: {
+      errors: {
+        mode: {
+          data: e.message
+        }
+      }
+    }, status: :unprocessable_entity
+  end
+
   protected
 
   def backup_params

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -30,6 +30,19 @@ module Api
         }
       end
 
+      def upgrade_mode
+        ::Crowbar::UpgradeStatus.new.upgrade_mode
+      end
+
+      def upgrade_mode=(mode)
+        unless ["normal", "non_disruptive"].include? mode
+          raise ::Crowbar::Error::SaveUpgradeModeError, "Invalid upgrade mode #{mode}." \
+            "Valid upgrade modes are: 'normal' and 'non_disruptive'."
+        end
+        Rails.logger.debug("Setting upgrade mode #{mode}")
+        ::Crowbar::UpgradeStatus.new.save_selected_upgrade_mode(mode.to_sym)
+      end
+
       #
       # prechecks
       #

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -214,6 +214,8 @@ Rails.application.routes.draw do
       controller: :upgrade,
       only: [:show] do
       post :prepare
+      get :mode
+      post :mode
       post :services
       get :prechecks
       post :cancel

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -158,5 +158,26 @@ describe Api::UpgradeController, type: :request do
       post "/api/upgrade/adminbackup", { backup: { name: "crowbar_upgrade" } }, headers
       expect(response).to have_http_status(:ok)
     end
+
+    it "successfully sets the upgrade mode" do
+      allow(Api::Upgrade).to receive(:upgrade_mode=).and_return(true)
+      allow(Api::Upgrade).to receive(:upgrade_mode).and_return("normal")
+
+      post "/api/upgrade/mode", { mode: "normal" }, headers
+      expect(response).to have_http_status(:ok)
+
+      get "/api/upgrade/mode", {}, headers
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq('{"mode":"normal"}')
+    end
+
+    it "returns a error when setting the upgrade mode fails" do
+      allow(Api::Upgrade).to receive(:upgrade_mode=).and_raise(
+        Crowbar::Error::SaveUpgradeModeError.new("error")
+      )
+
+      post "/api/upgrade/mode", { mode: "normal" }, headers
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
   end
 end

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -419,6 +419,14 @@ describe Api::Upgrade do
     end
   end
 
+  context "setting the upgrade mode" do
+    it "returns an error when an invalid upgrade mode is set" do
+      expect { subject.class.upgrade_mode = "invalid" }.to raise_error(
+        Crowbar::Error::SaveUpgradeModeError
+      )
+    end
+  end
+
   context "with preparing the upgrade" do
     it "succeeds to spawn the prepare in the background" do
       allow_any_instance_of(CrowbarService).to receive(


### PR DESCRIPTION
Base on the recent status library changes it is now possible to request
a certain upgrade mode using POST/GET on /api/upgrade/mode.
