### PR TITLE
upgrade: Save the state of more nodes being upgraded at once

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -25,7 +25,7 @@ class Api::UpgradeController < ApiController
   {
     "current_step": "admin",
     "current_substep": null,
-    "current_node": null,
+    "current_nodes": null,
     "remaining_nodes": null,
     "upgraded_nodes": null,
     "steps": {
@@ -170,7 +170,7 @@ class Api::UpgradeController < ApiController
         end
 
         if substep == :compute_nodes && status == :running
-          n = upgrade_status.progress[:current_node]
+          n = upgrade_status.progress[:current_nodes].first
           raise ::Crowbar::Error::UpgradeError.new(
             "Upgrade of node '#{n[:name]}' is already running. " \
             "Wait until it is finished before proceeding with next one."

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -148,12 +148,14 @@ module Api
 
     def save_node_state(role, state)
       status = ::Crowbar::UpgradeStatus.new
-      status.save_current_node(
-        name: @node.name,
-        alias: @node.alias,
-        ip: @node.public_ip,
-        state: state,
-        role: role
+      status.save_current_nodes(
+        [
+          name: @node.name,
+          alias: @node.alias,
+          ip: @node.public_ip,
+          state: state,
+          role: role
+        ]
       )
       if state == "upgraded"
         progress = status.progress

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1088,6 +1088,23 @@ module Api
         Rails.logger.info(message)
       end
 
+      # Save the state of multiple nodes, being upgraded in paralel
+      def save_nodes_state(nodes, role, state)
+        status = ::Crowbar::UpgradeStatus.new
+        current_nodes = nodes.map do |node|
+          node.crowbar["node_upgrade_state"] = state
+          node.save
+          {
+            name: node.name,
+            alias: node.alias,
+            ip: node.public_ip,
+            state: state,
+            role: role
+          }
+        end
+        status.save_current_nodes current_nodes
+      end
+
       # Take a list of nodes and execute given script at each node in the background
       # Wait until all scripts at all nodes correctly finish or until some error is detected
       def execute_scripts_and_wait_for_finish(nodes, script, seconds)

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -52,8 +52,8 @@ module Crowbar
         # substep is needed for more complex steps like upgrading the nodes
         current_substep: nil,
         current_substep_status: nil,
-        # current node is relevant only for the nodes step
-        current_node: nil,
+        # current nodes value is relevant only for the nodes step
+        current_nodes: nil,
         # number of nodes still to be upgraded
         remaining_nodes: nil,
         upgraded_nodes: nil,
@@ -239,10 +239,10 @@ module Crowbar
       end
     end
 
-    def save_current_node(node_data = {})
+    def save_current_nodes(nodes = [])
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
         load_while_locked
-        progress[:current_node] = node_data
+        progress[:current_nodes] = nodes
         save
       end
     end

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -2,7 +2,7 @@
   "current_step": "prechecks",
   "current_substep":null,
   "current_substep_status":null,
-  "current_node":null,
+  "current_nodes":null,
   "remaining_nodes": null,
   "upgraded_nodes": null,
   "crowbar_backup": null,

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -296,7 +296,7 @@ describe Crowbar::UpgradeStatus do
 
     it "saves and checks current node data" do
       expect(subject.current_substep).to be_nil
-      expect(subject.progress[:current_node]).to be nil
+      expect(subject.progress[:current_nodes]).to be nil
       expect(subject.progress[:remaining_nodes]).to be nil
       expect(subject.progress[:upgraded_nodes]).to be nil
 
@@ -304,9 +304,15 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_substep).to eql :controllers
       expect(subject.current_substep_status).to eql :running
       expect(subject.progress).to_not be_empty
-      expect(subject.save_current_node(current_node)).to be true
-      expect(subject.progress[:current_node][:name]).to be current_node[:name]
-      expect(subject.progress[:current_node][:alias]).to be current_node[:alias]
+      expect(subject.save_current_nodes([current_node])).to be true
+
+      expect(subject.progress[:current_nodes].size).to be 1
+      expect(subject.progress[:current_nodes][0][:name]).to be current_node[:name]
+      expect(subject.progress[:current_nodes][0][:alias]).to be current_node[:alias]
+
+      expect(subject.save_current_nodes([current_node, current_node])).to be true
+      expect(subject.progress[:current_nodes].size).to be 2
+
       expect(subject.save_nodes(1, 2)).to be true
       expect(subject.progress[:remaining_nodes]).to be 2
       expect(subject.progress[:upgraded_nodes]).to be 1


### PR DESCRIPTION
When an action is being done to set of nodes, we should
indicate the list of nodes being processed via the status library.

