### PR TITLE
upgrade: Upgrade the nodes that are neither controllers nor compute

### DIFF
--- a/crowbar_framework/spec/fixtures/offline_chef/node_ceph.crowbar.com.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/node_ceph.crowbar.com.json
@@ -18,6 +18,7 @@
       }
     },
     "hostname": "ceph",
+    "run_list_map": {},
     "state": "crowbar_upgrade"
   },
   "name": "ceph.crowbar.com",

--- a/crowbar_framework/spec/fixtures/offline_chef/node_testing.crowbar.com.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/node_testing.crowbar.com.json
@@ -20,6 +20,7 @@
       }
     },
     "hostname": "testing",
+    "run_list_map": {},
     "state": "discovered",
     "nova": {
       "use_migration": true


### PR DESCRIPTION
Nodes that do not hold controller role but are not compute nodes
must be upgraded before compute nodes, so live migration
(executed during compute nodes upgrade) can rely on fully upgraded
services.

Currently conflicts with https://github.com/crowbar/crowbar-core/pull/1126 with `upgrade_one_node` method 
