### PR TITLE
upgrade: Save more detailed information about current upgrade activity

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -894,6 +894,7 @@ module Api
 
       # Delete existing pacemaker resources, from other node in the cluster
       def delete_pacemaker_resources(node)
+        ::Crowbar::UpgradeStatus.new.save_current_node_action("deleting old pacemaker resources")
         node.wait_for_script_to_finish(
           "/usr/sbin/crowbar-delete-pacemaker-resources.sh", 300
         )
@@ -909,6 +910,7 @@ module Api
       # available network nodes. The evacuation procedure is started on the
       # specified controller node
       def evacuate_network_node(controller, network_node, delete_namespaces = false)
+        ::Crowbar::UpgradeStatus.new.save_current_node_action("evacuating routers")
         hostname = network_node["hostname"]
         migrated_file = "/var/lib/crowbar/upgrade/crowbar-router-migrated"
         if network_node.file_exist? migrated_file
@@ -1083,6 +1085,7 @@ module Api
       # Live migrate all instances of the specified
       # node to other available hosts.
       def live_evacuate_compute_node(controller, compute)
+        ::Crowbar::UpgradeStatus.new.save_current_node_action("live-evacuting nova instances")
         controller.wait_for_script_to_finish(
           "/usr/sbin/crowbar-evacuate-host.sh", 300, [compute]
         )

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -54,6 +54,7 @@ module Crowbar
         current_substep_status: nil,
         # current nodes value is relevant only for the nodes step
         current_nodes: nil,
+        current_node_action: nil,
         # number of nodes still to be upgraded
         remaining_nodes: nil,
         upgraded_nodes: nil,
@@ -243,6 +244,14 @@ module Crowbar
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
         load_while_locked
         progress[:current_nodes] = nodes
+        save
+      end
+    end
+
+    def save_current_node_action(action)
+      ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
+        load_while_locked
+        progress[:current_node_action] = action
         save
       end
     end

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -3,6 +3,7 @@
   "current_substep":null,
   "current_substep_status":null,
   "current_nodes":null,
+  "current_node_action": null,
   "remaining_nodes": null,
   "upgraded_nodes": null,
   "crowbar_backup": null,

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -29,6 +29,7 @@ describe Crowbar::UpgradeStatus do
     }
   end
 
+  let(:current_action) { "os-upgrade" }
   let(:crowbar_backup) { "/var/lib/crowbar.tgz" }
   let(:openstack_backup) { "/var/lib/openstack.tgz" }
 
@@ -297,6 +298,7 @@ describe Crowbar::UpgradeStatus do
     it "saves and checks current node data" do
       expect(subject.current_substep).to be_nil
       expect(subject.progress[:current_nodes]).to be nil
+      expect(subject.progress[:current_node_action]).to be nil
       expect(subject.progress[:remaining_nodes]).to be nil
       expect(subject.progress[:upgraded_nodes]).to be nil
 
@@ -316,6 +318,9 @@ describe Crowbar::UpgradeStatus do
       expect(subject.save_nodes(1, 2)).to be true
       expect(subject.progress[:remaining_nodes]).to be 2
       expect(subject.progress[:upgraded_nodes]).to be 1
+
+      expect(subject.save_current_node_action(current_action)).to be true
+      expect(subject.progress[:current_node_action]).to be current_action
     end
 
     it "saves and checks backup info" do


### PR DESCRIPTION
It seems useful to show more about what we are doing to nodes,
especially when it takes more time.
This extends the previous information saved as part of current_node,
which is marked only at the beginning and end of upgrade.