### PR TITLE
[stable/3.0] sync the status library changes with master

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -51,6 +51,7 @@ module Crowbar
         current_step: upgrade_steps_6_7.first,
         # substep is needed for more complex steps like upgrading the nodes
         current_substep: nil,
+        current_substep_status: nil,
         # current node is relevant only for the nodes step
         current_node: nil,
         # number of nodes still to be upgraded
@@ -91,6 +92,10 @@ module Crowbar
 
     def current_substep
       progress[:current_substep]
+    end
+
+    def current_substep_status
+      progress[:current_substep_status]
     end
 
     def current_step
@@ -245,10 +250,11 @@ module Crowbar
       end
     end
 
-    def save_substep(substep)
+    def save_substep(substep, status)
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
         load_while_locked
         progress[:current_substep] = substep
+        progress[:current_substep_status] = status
         save
       end
     end

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -52,8 +52,8 @@ module Crowbar
         # substep is needed for more complex steps like upgrading the nodes
         current_substep: nil,
         current_substep_status: nil,
-        # current node is relevant only for the nodes step
-        current_node: nil,
+        # current nodes value is relevant only for the nodes step
+        current_nodes: nil,
         # number of nodes still to be upgraded
         remaining_nodes: nil,
         upgraded_nodes: nil,
@@ -233,10 +233,10 @@ module Crowbar
       end
     end
 
-    def save_current_node(node_data = {})
+    def save_current_nodes(nodes = [])
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
         load_while_locked
-        progress[:current_node] = node_data
+        progress[:current_nodes] = nodes
         save
       end
     end

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -1,6 +1,7 @@
 {
   "current_step": "prechecks",
   "current_substep":null,
+  "current_substep_status":null,
   "current_node":null,
   "remaining_nodes": null,
   "upgraded_nodes": null,

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -2,7 +2,7 @@
   "current_step": "prechecks",
   "current_substep":null,
   "current_substep_status":null,
-  "current_node":null,
+  "current_nodes":null,
   "remaining_nodes": null,
   "upgraded_nodes": null,
   "crowbar_backup": null,

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -295,7 +295,7 @@ describe Crowbar::UpgradeStatus do
 
     it "saves and checks current node data" do
       expect(subject.current_substep).to be_nil
-      expect(subject.progress[:current_node]).to be nil
+      expect(subject.progress[:current_nodes]).to be nil
       expect(subject.progress[:remaining_nodes]).to be nil
       expect(subject.progress[:upgraded_nodes]).to be nil
 
@@ -303,9 +303,15 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_substep).to eql :controllers
       expect(subject.current_substep_status).to eql "running"
       expect(subject.progress).to_not be_empty
-      expect(subject.save_current_node(current_node)).to be true
-      expect(subject.progress[:current_node][:name]).to be current_node[:name]
-      expect(subject.progress[:current_node][:alias]).to be current_node[:alias]
+      expect(subject.save_current_nodes([current_node])).to be true
+
+      expect(subject.progress[:current_nodes].size).to be 1
+      expect(subject.progress[:current_nodes][0][:name]).to be current_node[:name]
+      expect(subject.progress[:current_nodes][0][:alias]).to be current_node[:alias]
+
+      expect(subject.save_current_nodes([current_node, current_node])).to be true
+      expect(subject.progress[:current_nodes].size).to be 2
+
       expect(subject.save_nodes(1, 2)).to be true
       expect(subject.progress[:remaining_nodes]).to be 2
       expect(subject.progress[:upgraded_nodes]).to be 1

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -299,8 +299,9 @@ describe Crowbar::UpgradeStatus do
       expect(subject.progress[:remaining_nodes]).to be nil
       expect(subject.progress[:upgraded_nodes]).to be nil
 
-      expect(subject.save_substep(:controllers)).to be true
+      expect(subject.save_substep(:controllers, "running")).to be true
       expect(subject.current_substep).to eql :controllers
+      expect(subject.current_substep_status).to eql "running"
       expect(subject.progress).to_not be_empty
       expect(subject.save_current_node(current_node)).to be true
       expect(subject.progress[:current_node][:name]).to be current_node[:name]


### PR DESCRIPTION

Partial backport of https://github.com/crowbar/crowbar-core/pull/1060 (commit related to status library)

Partial backport of https://github.com/crowbar/crowbar-core/pull/1133 (only parts related to status library)