### PR TITLE
[3.0] provisioner: Ensure /srv/tftpboot/validation.pem is correct

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -347,12 +347,10 @@ else
   end
 end
 
-bash "copy validation pem" do
-  code <<-EOH
-  cp /etc/chef/validation.pem #{tftproot}
-  chmod 0444 #{tftproot}/validation.pem
-EOH
-  not_if "test -f #{tftproot}/validation.pem"
+file "#{tftproot}/validation.pem" do
+  content IO.read("/etc/chef/validation.pem")
+  mode "0644"
+  action :create
 end
 
 # By default, install the same OS that the admin node is running


### PR DESCRIPTION
If for some reason /srv/tftpboot/validation.pem gets overwritten, then
it's impossible to allocate new nodes. We should make sure that
we converge properly here.

Also, using a File resource is much more chef-y than the bash code.

(cherry picked from commit 686b95a2ad2316dee010320aecec285c7faf94fd)

Backport of https://github.com/crowbar/crowbar-core/pull/750