### PR TITLE
upgrade: Do not save the empty error hash to the progress file

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -124,7 +124,7 @@ module Crowbar
         load_while_locked
         progress[:current_step] = step_name
         progress[:steps][step_name][:status] = :running
-        progress[:steps][step_name][:errors] = {}
+        progress[:steps][step_name].delete :errors
         if step_name == :prepare
           FileUtils.touch running_file
         end
@@ -140,9 +140,9 @@ module Crowbar
         end
         load_while_locked
         progress[:steps][current_step] = {
-          status: success ? :passed : :failed,
-          errors: errors
+          status: success ? :passed : :failed
         }
+        progress[:steps][current_step][:errors] = errors unless errors.empty?
         if current_step == upgrade_steps_6_7.last && success
           # Mark the end of the upgrade process
           FileUtils.rm_f running_file


### PR DESCRIPTION
To make the progress file better readable (e.g. in one page in terminal window), let's try to remove
some unnecessary information like the empty error hash for each
step.

This is how the progress file looks now (without the errors hashes removed):
```
---
:current_step: :nodes
:current_substep: :controller_nodes
:current_node:
:remaining_nodes: 3
:upgraded_nodes: 2 
:crowbar_backup: "/var/lib/crowbar/backup/crowbar_upgrade_1489054667.tar.gz"
:openstack_backup: "/var/lib/crowbar/backup/6-to-7-openstack_dump.sql.gz"
:suggested_upgrade_mode: :normal
:selected_upgrade_mode:
:steps:
  :prechecks:
    :status: :passed
    :errors: {}
  :prepare:
    :status: :passed
    :errors: {}
  :backup_crowbar:
    :status: :passed
    :errors: {}
  :repocheck_crowbar:
    :status: :passed
    :errors: {}
  :admin:
    :status: :passed
    :errors: {}
  :database:
    :status: :passed
    :errors: {}
  :repocheck_nodes:
    :status: :passed
    :errors: {}
  :services:
    :status: :passed
    :errors: {}
  :backup_openstack:
    :status: :passed
    :errors: {}
  :nodes:
    :status: :running
    :errors: {}
:current_substep_status: :running
:current_nodes:
- :name: d52-54-77-77-77-05.vi7.cloud.suse.de
  :alias: compute3
  :ip: 192.168.241.84
  :state: upgrading
  :role: swift
:current_node_action: rebooting

```

Note that this change is not yet tested, and I'm not sure if it does not affect the UI...