### PR TITLE
[3.0] Try to fix tempfile handling for UpgradeStatus lib

### DIFF
--- a/crowbar_framework/spec/spec_helper.rb
+++ b/crowbar_framework/spec/spec_helper.rb
@@ -115,11 +115,17 @@ RSpec.configure do |config|
   end
 
   config.before(:each) do
-    @upgrade_state_file = Tempfile.open("upgrade_status_spec.state.yml", &:path)
-    File.unlink @upgrade_state_file
+    @upgrade_state_file = File.join(
+      Dir::Tmpname.tmpdir,
+      Dir::Tmpname.make_tmpname("upgrade_status_spec.state.yaml", nil)
+    )
     allow(Crowbar::UpgradeStatus).to receive(:new).and_return(
       Crowbar::UpgradeStatus.new(Rails.logger, @upgrade_state_file)
     )
+  end
+
+  config.after(:each) do
+    File.unlink @upgrade_state_file
   end
 
   config.append_before(:each) do


### PR DESCRIPTION
The old way of creating the temporary filename for the status file
during the unit test caused a lot of test failures lately, because the
state file randomly disappeared during the test. This seemed to be
caused by our weird usage of Tempfile.open() and File.unlink().

This commit changes the code to generate a just temporary filename
(instead of actually creating and deleting the file again). File
deletion now happens explicitly in an "after"-hook.

(cherry picked from commit 8166dc1417b36061330cfbe3c0e619b723a69d3f)

Backport of https://github.com/crowbar/crowbar-core/pull/1137