### PR TITLE
upgrade: Cleanup the current progress at the end of upgrade

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -144,8 +144,12 @@ module Crowbar
           errors: errors
         }
         if current_step == upgrade_steps_6_7.last && success
-          # Mark the end of the upgrade process
+          # Mark the end of the upgrade process and cleanup the progress
           FileUtils.rm_f running_file
+          progress[:current_substep] = :end_of_upgrade
+          progress[:current_substep_status] = :finished
+          progress[:current_nodes] = {}
+          progress[:current_node_action] = "finished"
         end
         next_step
         save


### PR DESCRIPTION
Once the upgrade is finished, there's no point in showing the 'current' information that was used during the upgrade.