### PR TITLE
[stable/3.0] upgrade: Do not save the empty error hash to the progress file

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -124,7 +124,7 @@ module Crowbar
         load_while_locked
         progress[:current_step] = step_name
         progress[:steps][step_name][:status] = :running
-        progress[:steps][step_name][:errors] = {}
+        progress[:steps][step_name].delete :errors
         if step_name == :prepare
           FileUtils.touch running_file
         end
@@ -140,9 +140,9 @@ module Crowbar
         end
         load_while_locked
         progress[:steps][current_step] = {
-          status: success ? :passed : :failed,
-          errors: errors
+          status: success ? :passed : :failed
         }
+        progress[:steps][current_step][:errors] = errors unless errors.empty?
         if current_step == upgrade_steps_6_7.last && success
           # Mark the end of the upgrade process
           FileUtils.rm_f running_file


### PR DESCRIPTION
To make the progress file better trackable, let's try to remove
some unnecessary information like the empty error hash for each
step.

(cherry picked from commit bd00154d666ca1358ba22e1d27d826358f409731)

Backport of https://github.com/crowbar/crowbar-core/pull/1140
