### PR TITLE
network: Really run wicked ifreload when ifcfg files change (refix bsc#1011889)

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -545,7 +545,7 @@ when "suse"
   end
 
   bash "wicked-ifreload-all" do
-    action :nothing
+    action :run
     code <<-EOF
       wicked ifcheck --changed --quiet all
       rc=$?


### PR DESCRIPTION
Commit 46998819996 introduced a regression which cause the wicked
ifrelaod to be never actually called. Which reintroduced the original
bug that caused new deployments to loose their network connectivity
after the very first reboot.
