### PR TITLE
[3.0] upgrade: Extend running? method to check if any step is running (bsc#1028950)

### DIFF
--- a/crowbar_framework/lib/crowbar/error/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/error/upgrade_status.rb
@@ -24,7 +24,12 @@ module Crowbar
 
     class StartStepRunningError < StandardError
       def initialize(step_name = "")
-        super("The step '#{step_name}' has already been started.")
+        msg = if step_name.empty?
+          "Some step is already running."
+        else
+          "The step '#{step_name}' is already running."
+        end
+        super(msg)
       end
     end
 

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -286,9 +286,10 @@ describe Crowbar::UpgradeStatus do
       allow(FileUtils).to receive(:touch).and_return(true)
       expect(subject.start_step(:prepare)).to be true
       expect { subject.start_step(:prechecks) }.to raise_error(
-        Crowbar::Error::StartStepOrderError
+        Crowbar::Error::StartStepRunningError
       )
-      expect(subject.current_step).to eql :prepare
+      expect(subject.end_step).to be true
+      expect(subject.current_step).to eql :backup_crowbar
       expect { subject.start_step(:repocheck_crowbar) }.to raise_error(
         Crowbar::Error::StartStepOrderError
       )

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -285,7 +285,7 @@ describe Api::Upgrade do
       ).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :running?
-      ).with(:admin).and_return(false)
+      ).and_return(false)
       [
         :prechecks,
         :prepare,
@@ -320,7 +320,7 @@ describe Api::Upgrade do
         if allowed_step == :admin
           allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
             :running?
-          ).with(:admin).and_return(true)
+          ).and_return(true)
         end
         allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
           :current_step


### PR DESCRIPTION
upgrade: Extend running? method to check if any step is running (bsc#1028950)
    
(cherry picked from commit ad0d13e8f86c0842bf993c72a3d3adf49d7d7ec1)


Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

Backport.

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**

https://bugzilla.suse.com/show_bug.cgi?id=1028950
