### PR TITLE
backup: Fix upload params

### DIFF
--- a/crowbar_framework/app/controllers/backups_controller.rb
+++ b/crowbar_framework/app/controllers/backups_controller.rb
@@ -182,6 +182,6 @@ class BackupsController < ApplicationController
   end
 
   def backup_upload_params
-    params.require(:backup).require(:payload).permit(:file)
+    params.require(:backup).permit(:file)
   end
 end


### PR DESCRIPTION
After crowbar-client >= 3.2.2 the backup params are sent differenty.
We need to account for that and make the params be able to deal with both
ways of sending the params.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

To fix the Jenkis CI job https://ci.suse.de/view/Cloud/view/Cloud6/job/cloud-mkcloud6-job-backup-restore-x86_64/

Also to prevent any customers to update crowbar-client on a cloud 6 and fail to be able to do a backup.

**How does it address the issue?**

It allows for both types of arguments to be send to the backup endpoint. One for crowbar-client >= 3.2.2 and for older versions.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
