### PR TITLE
provisioner: fix wrong parameter call

### DIFF
--- a/crowbar_framework/app/models/provisioner_service.rb
+++ b/crowbar_framework/app/models/provisioner_service.rb
@@ -203,7 +203,7 @@ class ProvisionerService < ServiceObject
     all_db.keys.each do |db_name|
       next unless db_name =~ /^repos-.*/
       begin
-        chef_data_bag_destroy(db_name)
+        Crowbar::Repository.chef_data_bag_destroy(db_name)
       rescue Net::HTTPServerException
         @logger.debug("Cannot disable repos for #{db_name}!")
       end


### PR DESCRIPTION
This call was left without the full namespace, causing the upgrade prepare step to fail.


**Why is this change necessary?**

This seems to block the current CI upgrade jobs from doing the `prepare` step thus making all upgrade jobs unable to continue.
