### PR TITLE
provisioner: fix wrong parameter call

### DIFF
--- a/crowbar_framework/app/models/provisioner_service.rb
+++ b/crowbar_framework/app/models/provisioner_service.rb
@@ -203,7 +203,7 @@ class ProvisionerService < ServiceObject
     all_db.keys.each do |db_name|
       next unless db_name =~ /^repos-.*/
       begin
-        chef_data_bag_destroy(db_name)
+        Crowbar::Repository.chef_data_bag_destroy(db_name)
       rescue Net::HTTPServerException
         @logger.debug("Cannot disable repos for #{db_name}!")
       end


### PR DESCRIPTION
Commit ff6d7d14f9d3a802b463b4f07c6f87fd3cfd0a06 missed to
move one call to the proper Repository namespace