### PR TITLE
Restore ovs bridge settings after reboot (bsc#1029180, bsc#1029179)

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -137,6 +137,9 @@ def kill_nic(nic)
     if ::File.exists?("/etc/sysconfig/network/ifroute-#{nic.name}")
       ::File.delete("/etc/sysconfig/network/ifroute-#{nic.name}")
     end
+    if ::File.exist?("/etc/wicked/scripts/#{nic.name}-pre-up")
+      ::File.delete("/etc/wicked/scripts/#{nic.name}-pre-up")
+    end
   end
 end
 
@@ -533,12 +536,38 @@ when "suse"
 
   Nic.nics.each do |nic|
     next unless ifs[nic.name]
+
+    pre_up_script = nil
+    if nic.is_a?(Nic::OvsBridge)
+      directory "/etc/wicked/scripts/" do
+        owner "root"
+        group "root"
+        mode "0755"
+        action :create
+      end
+
+      pre_up_script = "/etc/wicked/scripts/#{nic.name}-pre-up"
+      datapath_id = get_datapath_id_for_ovsbridge nic.name
+
+      template pre_up_script do
+        owner "root"
+        group "root"
+        mode "0755"
+        source "ovs-pre-up.sh.erb"
+        variables(
+          bridgename: nic.name,
+          datapath_id: datapath_id
+        )
+      end
+    end
+
     template "/etc/sysconfig/network/ifcfg-#{nic.name}" do
       source "suse-cfg.erb"
       variables({
         ethtool_options: ethtool_options,
         interfaces: ifs,
-        nic: nic
+        nic: nic,
+        pre_up_script: pre_up_script
       })
       notifies :create, "ruby_block[wicked-ifreload-required]", :immediately
     end

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -56,7 +56,7 @@ end
 require "fileutils"
 
 if node[:platform] == "ubuntu"
-  if ::File.exists?("/etc/init/network-interface.conf")
+  if ::File.exist?("/etc/init/network-interface.conf")
     # Make upstart stop trying to dynamically manage interfaces.
     ::File.unlink("/etc/init/network-interface.conf")
     ::Kernel.system("killall -HUP init")
@@ -64,8 +64,8 @@ if node[:platform] == "ubuntu"
 
   # Stop udev from jacking up our vlans and bridges as we create them.
   ["40-bridge-network-interface.rules","40-vlan-network-interface.rules"].each do |rule|
-    next if ::File.exists?("/etc/udev/rules.d/#{rule}")
-    next unless ::File.exists?("/lib/udev/rules.d/#{rule}")
+    next if ::File.exist?("/etc/udev/rules.d/#{rule}")
+    next unless ::File.exist?("/lib/udev/rules.d/#{rule}")
     ::Kernel.system("echo 'ACTION==\"add\", SUBSYSTEM==\"net\", RUN+=\"/bin/true\"' >/etc/udev/rules.d/#{rule}")
   end
 end
@@ -126,15 +126,15 @@ def kill_nic(nic)
   when "rhel"
     # Redhat and Centos have lots of small files definining interfaces.
     # Delete the ones we no longer care about here.
-    if ::File.exists?("/etc/sysconfig/network-scripts/ifcfg-#{nic.name}")
+    if ::File.exist?("/etc/sysconfig/network-scripts/ifcfg-#{nic.name}")
       ::File.delete("/etc/sysconfig/network-scripts/ifcfg-#{nic.name}")
     end
   when "suse"
     # SuSE also has lots of small files, but in slightly different locations.
-    if ::File.exists?("/etc/sysconfig/network/ifcfg-#{nic.name}")
+    if ::File.exist?("/etc/sysconfig/network/ifcfg-#{nic.name}")
       ::File.delete("/etc/sysconfig/network/ifcfg-#{nic.name}")
     end
-    if ::File.exists?("/etc/sysconfig/network/ifroute-#{nic.name}")
+    if ::File.exist?("/etc/sysconfig/network/ifroute-#{nic.name}")
       ::File.delete("/etc/sysconfig/network/ifroute-#{nic.name}")
     end
     if ::File.exist?("/etc/wicked/scripts/#{nic.name}-pre-up")

--- a/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
+++ b/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+ovs-vsctl br-exists <%= @bridgename %> || exit 0
+ovs-vsctl set Bridge <%= @bridgename %> other-config:datapath-id=<%= @datapath_id %>
+ovs-vsctl del-fail-mode <%= @bridgename %>

--- a/chef/cookbooks/network/templates/default/suse-cfg.erb
+++ b/chef/cookbooks/network/templates/default/suse-cfg.erb
@@ -76,3 +76,6 @@ IPADDR<%=(i == 0)?'':(i+1).to_s%>=<%=v4addrs[i].to_s%>
 <% if iface["mtu"] && iface["mtu"] != 1500 -%>
 MTU=<%=quote(iface["mtu"]) %>
 <% end -%>
+<% if @pre_up_script -%>
+PRE_UP_SCRIPT=<%= quote("wicked:#{@pre_up_script}") %>
+<% end -%>


### PR DESCRIPTION
During a clean shutdown wicked will delete any ovs bridges that it feels
responsible for. This means that any customer settings on tha brigde
will get lost and need to be restored. As we set a custom datapath_id
for our bridge to prevent bsc#1022074. We need to restore that setting
when the bridge is recreated during startup. Normally chef-client would
do that as part of crowbar_join, but we also need it to happen when the
admin server is down for some reason.

OTOH, when the node is shutdown uncleanly (e.g. during a fencing
operation) the ovs bridge will not get deleted, which for the bridges
that are touch by the neutron-openvswitch-agent means they will stay in
"secure" mode (without any flows defined) even after reboot. This means
that the node will be disconnected until neutron-openvswitch-agent is
started. To prevent this we now reset the bridge's fail-mode before the
interface is coming up.