### PR TITLE
[stable/3.0] network: Really run wicked ifreload when needed (refix bsc#1011889)

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -527,7 +527,7 @@ when "suse"
   end
 
   bash "wicked-ifreload-all" do
-    action :nothing
+    action :run
     code <<-EOF
       wicked ifcheck --changed --quiet all
       rc=$?


### PR DESCRIPTION
Commit 46998819996 introduced a regression which cause the wicked
ifreload to be never actually called. Which reintroduced the original
bug that caused new deployments to loose their network connectivity
after the very first reboot.
