### PR TITLE
[stable/3.0] Restore ovs bridge settings after reboot (bsc#1029179)

### DIFF
--- a/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
+++ b/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+ovs-vsctl br-exists <%= @bridgename %> || exit 0
+ovs-vsctl del-fail-mode <%= @bridgename %>

--- a/chef/cookbooks/network/templates/default/suse-cfg.erb
+++ b/chef/cookbooks/network/templates/default/suse-cfg.erb
@@ -76,3 +76,6 @@ IPADDR<%=(i == 0)?'':(i+1).to_s%>=<%=v4addrs[i].to_s%>
 <% if iface["mtu"] && iface["mtu"] != 1500 -%>
 MTU=<%=quote(iface["mtu"]) %>
 <% end -%>
+<% if @pre_up_script -%>
+PRE_UP_SCRIPT=<%= quote("wicked:#{@pre_up_script}") %>
+<% end -%>


### PR DESCRIPTION
During a clean shutdown wicked will delete any ovs bridges that it feels
responsible for. OTOH, when the node is shutdown uncleanly (e.g. during
a fencing operation) the ovs bridge will not get deleted, which for the
bridges that are touched by the neutron-openvswitch-agent means they
will stay in "secure" mode (without any flows defined) even after
reboot.  This means that the node will be disconnected until
neutron-openvswitch-agent is started. To prevent this we now reset the
bridge's fail-mode before the interface is coming up.