### PR TITLE
[3.0] upgrade: provide better help for pacemaker issues

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -375,17 +375,11 @@ module Api
         failed_actions = check["failed_actions"]
         ret[:clusters_health_crm_failures] = {
           data: crm_failures.values,
-          help: I18n.t(
-            "api.upgrade.prechecks.clusters_health.crm_failures",
-            nodes: crm_failures.keys.join(",")
-          )
+          help: I18n.t("api.upgrade.prechecks.clusters_health.crm_failures")
         } if crm_failures
         ret[:clusters_health_failed_actions] = {
           data: failed_actions.values,
-          help: I18n.t(
-            "api.upgrade.prechecks.clusters_health.failed_actions",
-            nodes: failed_actions.keys.join(",")
-          )
+          help: I18n.t("api.upgrade.prechecks.clusters_health.failed_actions")
         } if failed_actions
         ret
       end

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -816,8 +816,8 @@ en:
           help:
             default: 'Make sure Ceph is healthy'
         clusters_health:
-          crm_failures: '"crm status" failed at nodes %{nodes}.'
-          failed_actions: '"crm status" is showing some failed actions at nodes %{nodes}.'
+          crm_failures: 'Please check that all cluster resources are online or refer to the SUSE High Availability documentation for possible troubleshooting.'
+          failed_actions: 'Please clean the resource history and re−check the current state with "crm_resource -C" or refer to the SUSE High Availability documentation for possible troubleshooting.'
           help:
             default: 'Make sure clusters are healthy'
         no_resources:


### PR DESCRIPTION
Tries to provide a small help or refer to the HA docs in case of failures
on the cluster resources. Also moves the references of the node names
to the data field and pairs the node name with the error found at it.

(cherry picked from commit ba5f4bad3f53c556f788411471810fb37dc5f2c2)
