### PR TITLE
upgrade: better error output for wrong step order

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -115,8 +115,8 @@ module Crowbar
           raise Crowbar::Error::StartStepExistenceError.new(step_name)
         end
         if running?
-          @logger.warn("Some step is already running.")
-          raise Crowbar::Error::StartStepRunningError.new
+          @logger.warn("Step #{current_step} is already running.")
+          raise Crowbar::Error::StartStepRunningError.new(current_step)
         end
         unless step_allowed? step_name
           @logger.warn("The start of step #{step_name} is requested in the wrong order")


### PR DESCRIPTION
Provide the step that is currently running in the error output
for more clarity

**Why is this change necessary?**

Not necessary but provides a better error message

**How does it address the issue?**

Provide the step that is currently running in the error output
for more clarity

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**

Maybe complementary to https://trello.com/c/OolO2TT3/368-s57p14-bsc-1028950-confusing-message-when-running-crowbarctl-upgrade-repocheck-crowbar