### PR TITLE
upgrade: Fixes for ceph cluster health checks

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -103,12 +103,14 @@ module Api
         ret = {}
         ceph_nodes = ::Node.find("roles:ceph-* AND ceph_config_environment:*")
         return ret if ceph_nodes.empty?
-        ceph_node = ceph_nodes.first
+        mon_node = ::Node.find("run_list_map:ceph-mon AND ceph_config_environment:*").first
 
-        ssh_retval = ceph_node.run_ssh_cmd("LANG=C ceph health --connect-timeout 5 2>&1")
+        ssh_retval = mon_node.run_ssh_cmd("LANG=C ceph health --connect-timeout 5 2>&1")
+        # Some warnings do not need to be critical, but we have no way to find out.
+        # So we assume user knows how to tweak cluster settings to show the healthy state.
         unless ssh_retval[:stdout].include? "HEALTH_OK"
           ret[:health_errors] = ssh_retval[:stdout]
-          unless ssh_retval[:stderr].empty?
+          unless ssh_retval[:stderr].nil? || ssh_retval[:stderr].empty?
             ret[:health_errors] += "; " unless ssh_retval[:stdout].empty?
             ret[:health_errors] += ssh_retval[:stderr]
           end
@@ -119,7 +121,7 @@ module Api
         # ceph version 0.94.9-93-g239fe15 (239fe153ffde6a22e1efcaf734ff28d6a703a0ba)
         # SES4:
         # ceph version 10.2.4-211-g12b091b (12b091b4a40947aa43919e71a318ed0dcedc8734)
-        ssh_retval = ceph_node.run_ssh_cmd("LANG=C ceph --version | cut -d ' ' -f 3")
+        ssh_retval = mon_node.run_ssh_cmd("LANG=C ceph --version | cut -d ' ' -f 3")
         ret[:old_version] = true if ssh_retval[:stdout].to_f < 10.2
 
         not_prepared = ceph_nodes.select { |n| n.state != "crowbar_upgrade" }.map(&:name)
@@ -181,7 +183,7 @@ module Api
       def addon_deployed?(addon)
         case addon
         when "ceph"
-          ::Node.find("roles:ceph-mon AND ceph_config_environment:*").any?
+          ::Node.find("roles:ceph-* AND ceph_config_environment:*").any?
         when "ha"
           ::Node.find("pacemaker_founder:true AND pacemaker_config_environment:*").any?
         end

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1448,10 +1448,10 @@ module Api
 
       def ceph_health_check_errors(check)
         ret = {}
-        if check[:healh_errors]
-          ret[:ceph_not_healhy] = {
+        if check[:health_errors]
+          ret[:ceph_not_healthy] = {
             data: I18n.t("api.upgrade.prechecks.ceph_not_healthy.error",
-              error: check[:healh_errors]),
+              error: check[:health_errors]),
             help: I18n.t("api.upgrade.prechecks.ceph_not_healthy.help")
           }
         end

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -812,7 +812,12 @@ en:
           help:
             default: 'Without HA setup, non-disruptive upgrade is not possible.'
         ceph_not_healthy:
-          error: 'Ceph cluster health check has failed with %{error}. Make sure cluster is healthy before proceeding with the upgrade.'
+          error: |
+            Ceph cluster health check has failed with:
+            
+            %{error}
+                       
+            Make sure cluster is healthy before proceeding with the upgrade.
           help: 'Refer to the SUSE Enterprise Storage documentation for possible troubleshooting.'
         ceph_old_version:
           error: 'It appears you have an old version of SUSE Enterprise Storage installed. Upgrade to the latest version of SES before proceeding with the Cloud upgrade.'

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -155,6 +155,9 @@ describe Api::Crowbar do
         receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
         and_return([Node.find_by_name("ceph.crowbar.com")])
       )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
       allow_any_instance_of(Node).to(
         receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
         and_return(exit_code: 0, stdout: "HEALTH_OK\n", stderr: "")
@@ -172,6 +175,9 @@ describe Api::Crowbar do
         receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
         and_return([Node.find_by_name("testing"), Node.find_by_name("ceph")])
       )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
       allow_any_instance_of(Node).to(
         receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
         and_return(exit_code: 0, stdout: "HEALTH_OK\n", stderr: "")
@@ -189,6 +195,9 @@ describe Api::Crowbar do
         receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
         and_return([Node.find_by_name("ceph.crowbar.com")])
       )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
       allow_any_instance_of(Node).to(
         receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
         and_return(exit_code: 0, stdout: "HEALTH_OK\n", stderr: "")
@@ -208,6 +217,9 @@ describe Api::Crowbar do
         receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
       allow_any_instance_of(Node).to(
         receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
         and_return(exit_code: 1, stdout: "HEALTH_ERR\n", stderr: "")
@@ -220,6 +232,9 @@ describe Api::Crowbar do
         receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
       allow_any_instance_of(Node).to(
         receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
         and_return(exit_code: 0, stdout: "HEALTH_WARN", stderr: "")
@@ -232,6 +247,9 @@ describe Api::Crowbar do
         receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
       allow_any_instance_of(Node).to(
         receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
         and_return(


### PR DESCRIPTION
(cherry picked from commit 393830d098d33abbc089a9005d21e897a13deb9b)

Backport of https://github.com/crowbar/crowbar-core/pull/1108

We do not actually need ceph health checks on cloud7 side, but we need the check if Ceph (SES) addon is installed, so the repocheck for nodes can correctly activate also SES repositories.