### PR TITLE
Add missing return value

### DIFF
--- a/crowbar_framework/lib/crowbar/conduit_resolver.rb
+++ b/crowbar_framework/lib/crowbar/conduit_resolver.rb
@@ -41,9 +41,8 @@ module Crowbar
             break
           end
         end
-
-        result || []
       end
+      @bus_order || []
     end
 
     # Returns an array of interfaces like ["em1", "em2", "em3", "em4"],


### PR DESCRIPTION
The function `Crowbar::ConduitResolver.bus_order` does not return
anything in case the instance variable `@bus_order` is non nil.