### PR TITLE
upgrade: use constants for scripts timeouts

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -1,0 +1,37 @@
+require "yaml"
+
+module Crowbar
+  class UpgradeTimeouts
+    def values
+      @timeouts_config = begin
+        YAML.load_file("/etc/crowbar/upgrade_timeouts.yml")
+      rescue
+        Rails.logger.info(
+          "No user provided upgraed timeouts, proceeding with the default ones."
+        )
+        {}
+      end
+
+      # clean up yaml config in case of there being strings
+      @timeouts_config.each do |k, v|
+        next if v.is_a? Integer
+        Rails.logger.error(
+          "Removing user configured upgrade timeout #{k} as the value provided is not an integer."
+        )
+        @timeouts_config.delete(k)
+      end
+
+      {
+        prepare_repositories: @timeouts_config[:prepare_repositories] || 120,
+        pre_upgrade: @timeouts_config[:pre_upgrade] || 300,
+        upgrade_os: @timeouts_config[:upgrade_os] || 900,
+        post_upgrade: @timeouts_config[:post_upgrade] || 600,
+        evacuate_host: @timeouts_config[:evacuate_host] || 300,
+        chef_upgraded: @timeouts_config[:chef_upgraded] || 900,
+        router_migration: @timeouts_config[:router_migration] || 600,
+        delete_pacemaker_resources: @timeouts_config[:delete_pacemaker_resources] || 300,
+        delete_cinder_services: @timeouts_config[:delete_cinder_services] || 300
+      }
+    end
+  end
+end

--- a/crowbar_framework/spec/lib/crowbar/upgrade_timeouts_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_timeouts_spec.rb
@@ -1,0 +1,105 @@
+#
+# Copyright 2017, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "yaml"
+
+describe Crowbar::UpgradeTimeouts do
+  def check_values(values, expected_values = nil)
+    # Generic checker for all values that should always exists
+    [
+      :prepare_repositories, :pre_upgrade, :upgrade_os, :post_upgrade,
+      :evacuate_host, :chef_upgraded, :router_migration,
+      :delete_pacemaker_resources, :delete_cinder_services
+    ].each do |k|
+      expect(values[k]).not_to be_nil
+      expect(values[k]).to be_a(Integer)
+      if !expected_values.nil? && expected_values.key?(k)
+        expect(values[k]).to be(expected_values[k])
+      end
+    end
+  end
+
+  context "no user provided timeout configuration" do
+    it "should always provide default values" do
+      timeouts = Crowbar::UpgradeTimeouts.new.values
+      check_values(timeouts)
+    end
+  end
+
+  context "with user provided timeout configuration" do
+    context "with a full correct configuration" do
+      before(:each) do
+        @full_config =
+          {
+            prepare_repositories: 1,
+            pre_upgrade: 1,
+            upgrade_os: 1,
+            post_upgrade: 1,
+            evacuate_host: 1,
+            chef_upgraded: 1,
+            router_migration: 1,
+            delete_pacemaker_resources: 1,
+            delete_cinder_services: 1
+          }
+        allow(YAML).to receive(:load_file).and_return(@full_config.clone)
+      end
+
+      it "should override all values with the user provided ones" do
+        timeouts = Crowbar::UpgradeTimeouts.new.values
+        check_values(timeouts, @full_config)
+      end
+    end
+
+    context "with partial correct configuration" do
+      before(:each) do
+        @partial_config =
+          {
+            prepare_repositories: 1,
+            pre_upgrade: 1,
+            upgrade_os: 1,
+            post_upgrade: 1
+          }
+        allow(YAML).to receive(:load_file).and_return(@partial_config.clone)
+      end
+
+      it "should override only the provided values" do
+        timeouts = Crowbar::UpgradeTimeouts.new.values
+        check_values(timeouts, @partial_config)
+      end
+    end
+
+    context "with a partial wrong configuration" do
+      before(:each) do
+        @wrong_config_file =
+          {
+            prepare_repositories: "Wubbalubbadubdub",
+            pre_upgrade: 1
+          }
+        allow(YAML).to receive(:load_file).and_return(@wrong_config_file.clone)
+      end
+
+      it "should ignore the wrong config" do
+        timeouts = Crowbar::UpgradeTimeouts.new.values
+        check_values(timeouts)
+        expect(timeouts[:prepare_repositories]).not_to be "Wubbalubbadubdub"
+        expect(timeouts[:prepare_repositories]).not_to be 1
+        expect(timeouts[:prepare_repositories]).to be 120
+        expect(timeouts[:pre_upgrade]).to be 1
+      end
+    end
+  end
+end

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -170,7 +170,8 @@ describe Api::Upgrade do
       ).and_return(true)
       allow_any_instance_of(Node).to(
         receive(:wait_for_script_to_finish).with(
-          "/usr/sbin/crowbar-delete-cinder-services-before-upgrade.sh", 300
+          "/usr/sbin/crowbar-delete-cinder-services-before-upgrade.sh",
+          ::Crowbar::UpgradeTimeouts.new.values[:delete_cinder_services]
         ).and_return(true)
       )
       allow(Api::Crowbar).to(
@@ -516,7 +517,9 @@ describe Api::Upgrade do
 
       # parallel_upgrade_compute_nodes:
       allow(Api::Upgrade).to receive(:execute_scripts_and_wait_for_finish).with(
-        [node1, node2], "/usr/sbin/crowbar-upgrade-os.sh", 900
+        [node1, node2],
+        "/usr/sbin/crowbar-upgrade-os.sh",
+        ::Crowbar::UpgradeTimeouts.new.values[:upgrade_os]
       ).and_return(true)
       allow_any_instance_of(Node).to receive(:upgraded?).and_return(false)
       allow_any_instance_of(Node).to receive(:ready_after_upgrade?).and_return(false)


### PR DESCRIPTION
Have all the timeouts for upgrade related timeouts on the
same location and makes it easier to track and change them at any time
