### PR TITLE
upgrade: Extend the deployment prechecks

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -227,6 +227,40 @@ module Api
         return { ha_not_installed: true } unless addon_installed? "ha"
         founders = NodeObject.find("pacemaker_founder:true AND pacemaker_config_environment:*")
         return { ha_not_configured: true } if founders.empty?
+
+        # Check if roles important for non-disruptive upgrade are deployed in the cluster
+        clustered_roles = [
+          "database-server",
+          "rabbitmq-server",
+          "keystone-server",
+          "glance-server",
+          "cinder-controller",
+          "neutron-server",
+          "neutron-network",
+          "nova-controller"
+        ]
+        barclamps = [
+          "database",
+          "rabbitmq",
+          "keystone",
+          "glance",
+          "cinder",
+          "neutron",
+          "nova"
+        ]
+        roles_not_ha = []
+        barclamps.each do |barclamp|
+          proposal = Proposal.where(barclamp: barclamp).first
+          next if proposal.nil?
+          proposal["deployment"][barclamp]["elements"].each do |role, elements|
+            next unless clustered_roles.include? role
+            elements.each do |element|
+              next if ServiceObject.is_cluster?(element)
+              roles_not_ha |= [role]
+            end
+          end
+        end
+        return { roles_not_ha: roles_not_ha } if roles_not_ha.any?
         {}
       end
 

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -261,7 +261,34 @@ module Api
           end
         end
         return { roles_not_ha: roles_not_ha } if roles_not_ha.any?
-        {}
+
+        # Make sure nova compute role is not mixed with a controller roles
+        conflicting_roles = [
+          "cinder-controller",
+          "glance-server",
+          "keystone-server",
+          "neutron-server",
+          "neutron-network",
+          "nova-controller",
+          "swift-proxy",
+          "swift-ring-compute",
+          "ceilometer-server",
+          "heat-server",
+          "horizon-server",
+          "manila-server",
+          "trove-server"
+        ]
+        ret = {}
+        ["kvm", "xen"].each do |virt|
+          NodeObject.find("roles:nova-compute-#{virt}").each do |node|
+            conflict = node.roles & conflicting_roles
+            unless conflict.empty?
+              ret[:role_conflicts] ||= {}
+              ret[:role_conflicts][node.name] = conflict
+            end
+          end
+        end
+        ret
       end
 
       def maintenance_updates_check

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -373,6 +373,16 @@ module Api
             help: I18n.t("api.upgrade.prechecks.roles_not_ha.help")
           }
         end
+        if check[:role_conflicts]
+          nodes = check[:role_conflicts].map do |node, roles|
+            "#{node}: " + roles.join(", ")
+          end
+          ret[:role_conflicts] = {
+            data: I18n.t("api.upgrade.prechecks.role_conflicts.error",
+              nodes: nodes.join("\n")),
+            help: I18n.t("api.upgrade.prechecks.role_conflicts.help")
+          }
+        end
         ret
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -366,6 +366,13 @@ module Api
             help: I18n.t("api.upgrade.prechecks.ha_configured.help.default")
           }
         end
+        if check[:roles_not_ha]
+          ret[:roles_not_ha] = {
+            data: I18n.t("api.upgrade.prechecks.roles_not_ha.error",
+              roles: check[:roles_not_ha].join(", ")),
+            help: I18n.t("api.upgrade.prechecks.roles_not_ha.help")
+          }
+        end
         ret
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -67,6 +67,13 @@ module Api
             errors: health_check.empty? ? {} : health_check_errors(health_check)
           }
 
+          deployment = Api::Crowbar.deployment_check
+          ret[:checks][:cloud_deployment] = {
+            required: true,
+            passed: deployment.empty?,
+            errors: deployment.empty? ? {} : deployment_errors(deployment)
+          }
+
           maintenance_updates = Api::Crowbar.maintenance_updates_check
           ret[:checks][:maintenance_updates_installed] = {
             required: true,
@@ -271,6 +278,17 @@ module Api
           network_checks: {
             data: check,
             help: I18n.t("api.upgrade.prechecks.network_checks.help.default")
+          }
+        }
+      end
+
+      def deployment_errors(check)
+        {
+          controller_roles: {
+            data: I18n.t("api.upgrade.prechecks.controller_roles.error",
+              node: check[:controller_roles][:node],
+              roles: check[:controller_roles][:roles]),
+            help: I18n.t("api.upgrade.prechecks.controller_roles.help")
           }
         }
       end

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -838,6 +838,9 @@ en:
         role_conflicts:
           error: 'These compute nodes have some roles that belong to controllers: %{nodes}.'
           help: 'For non-disruptive upgrade, compute nodes cannot hold controller roles.'
+        controller_roles:
+          error: 'Found compute node %{node} with controller roles: %{roles}.'
+          help: 'It is not possible to upgrade with such setup. These roles cannot be placed on compute node.'
         swift_replicas:
           error: 'The number of replicas is bigger than the number of disks assigned for Swift.'
           help: 'Such configuration is not supported in Swift delivered with SOC 7. Adapt your Swift configuration before proceeding with the upgrade.'

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -832,6 +832,9 @@ en:
           not_configured: 'No Pacemaker cluster is configured.'
           help:
             default: 'Without HA setup, non-disruptive upgrade is not possible.'
+        roles_not_ha:
+          error: 'These roles are not deployed in a cluster: %{roles}.'
+          help: 'For non-disruptive upgrade, controller roles must be deployed in HA cluser.'
         swift_replicas:
           error: 'The number of replicas is bigger than the number of disks assigned for Swift.'
           help: 'Such configuration is not supported in Swift delivered with SOC 7. Adapt your Swift configuration before proceeding with the upgrade.'

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -835,6 +835,9 @@ en:
         roles_not_ha:
           error: 'These roles are not deployed in a cluster: %{roles}.'
           help: 'For non-disruptive upgrade, controller roles must be deployed in HA cluser.'
+        role_conflicts:
+          error: 'These compute nodes have some roles that belong to controllers: %{nodes}.'
+          help: 'For non-disruptive upgrade, compute nodes cannot hold controller roles.'
         swift_replicas:
           error: 'The number of replicas is bigger than the number of disks assigned for Swift.'
           help: 'Such configuration is not supported in Swift delivered with SOC 7. Adapt your Swift configuration before proceeding with the upgrade.'

--- a/crowbar_framework/spec/fixtures/offline_chef/role_cinder-controller.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/role_cinder-controller.json
@@ -1,0 +1,18 @@
+{
+  "name": "cinder-controller",
+  "description": "Cinder API and Scheduler Role",
+  "json_class": "Chef::Role",
+  "default_attributes": {
+  },
+  "override_attributes": {
+  },
+  "chef_type": "role",
+  "run_list": [
+    "recipe[cinder::api]",
+    "recipe[cinder::scheduler]",
+    "recipe[cinder::controller_ha]",
+    "recipe[cinder::monitor]"
+  ],
+  "env_run_lists": {
+  }
+}


### PR DESCRIPTION
1. Make really sure controller nodes are HA
2. Make sure compute nodes do not have controller roles.

1+2 are the checks that when failing, still allow "normal" upgrade

3. Make sure nova-compute cannot go before nova-controller

3 is a special case of 2, (as described in https://github.com/crowbar/crowbar-core/pull/1109#issuecomment-285008466), but does not allow any kind of upgrade. So it belongs to extra method with `required = true`