### PR TITLE
upgrade: Expose precheck failures to client

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -55,6 +55,15 @@ class Api::UpgradeController < ApiController
 
   def prechecks
     render json: Api::Upgrade.checks
+  rescue StandardError => e
+    render json: {
+      errors: {
+        prechecks: {
+          data: e.message,
+          help: I18n.t("api.upgrade.prechecks.help.default")
+        }
+      }
+    }, status: :unprocessable_entity
   end
 
   def cancel

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -794,6 +794,8 @@ en:
           default: 'Refer to the error message in the response'
     upgrade:
       prechecks:
+        help:
+          default: 'Running prechecks have failed. Check /var/log/crowbar/production.log for details.'
         network_checks:
           help:
             default: 'Examine the error messages'


### PR DESCRIPTION
**Why is this change necessary?**
When there was some exception during prechecks execution, the info was
stored in the status file but not returned to the client as a response.
Instead a generic 500 response was generated by the framework as a result
of exception propagation.

**How does it address the issue?**
Now the exceptions are caught in the controller and returned in proper
JSON response.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/39CCSguR/329-ui-failures-on-crowbar-crash