### PR TITLE
[3.0] upgrade: better error output for wrong step order

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -115,8 +115,8 @@ module Crowbar
           raise Crowbar::Error::StartStepExistenceError.new(step_name)
         end
         if running?
-          @logger.warn("Some step is already running.")
-          raise Crowbar::Error::StartStepRunningError.new
+          @logger.warn("Step #{current_step} is already running.")
+          raise Crowbar::Error::StartStepRunningError.new(current_step)
         end
         unless step_allowed? step_name
           @logger.warn("The start of step #{step_name} is requested in the wrong order")


### PR DESCRIPTION
Provide the step that is currently running in the error output
for more clarity

(cherry picked from commit 192165d4a4bc2af4139d827a5613be627231fcb1)
