### PR TITLE
upgrade: Do not delete remote resources

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
@@ -35,7 +35,7 @@ log "Stopping pacemaker resources..."
 # Otherwise we could have services starting up in unwanted locations while deleting constraints.
 
 for type in clone group ms primitive; do
-    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /drbd|stonith|vip-/) {print \$2}"); do
+    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /drbd|stonith|remote-|vip-/) {print \$2}"); do
         log "Stopping resource $resource"
         crm --wait resource stop $resource
     done
@@ -53,7 +53,7 @@ log "Deleting pacemaker resources..."
 crm_cmd=""
 for type in location clone group ms primitive; do
     log "Looking at typ $type of resources..."
-    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /drbd|stonith|vip-/) {print \$2}"); do
+    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /drbd|stonith|remote-|vip-/) {print \$2}"); do
         printf -v crm_cmd "${crm_cmd}delete $resource\n"
     done
 done

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -24,7 +24,7 @@ set -x
 <% if @cluster_founder %>
 log "Stopping pacemaker resources..."
 
-exclude="postgresql|vip|rabbitmq|keystone|neutron|haproxy"
+exclude="postgresql|vip|rabbitmq|keystone|neutron|haproxy|remote"
 
 for type in clone ms primitive; do
     for resource in $(crm configure show | grep ^$type | grep -Ev $exclude | cut -d " " -f2);


### PR DESCRIPTION
It's not necessary to delete remote primitives during the upgrade,
the agents aren't systemd based.  (*EDIT for clarity:* we have to delete primitives for LSB resources to allow upgrading them to `systemd` resources.)