### PR TITLE
upgrade: Do not allow creating remote related resources before upgrade

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1158,6 +1158,15 @@ module Api
           return
         end
 
+        compute_nodes.each do |n|
+          # Do not allow creating of remote related resources before remote nodes
+          # are upgraded. The value will be update on node's chef-client run.
+          if n["pacemaker"].key? "remote_setup"
+            n["pacemaker"]["remote_setup"] = false
+            n.save
+          end
+        end
+
         # This batch of actions can be executed in parallel for all compute nodes
         begin
           execute_scripts_and_wait_for_finish(


### PR DESCRIPTION
Before compute nodes are upgraded, do not create remote related resources by remote_delegator.

This is an alternative to https://github.com/crowbar/crowbar-openstack/pull/875

Main problem - it takes time before the remote resources are created (after chef-client executed in controller cluster), until then, freshly upgraded compute node does not have nova-compute service running..