### PR TITLE
upgrade: Allow access to docs during upgrade

### DIFF
--- a/crowbar_framework/app/controllers/docs_controller.rb
+++ b/crowbar_framework/app/controllers/docs_controller.rb
@@ -16,6 +16,8 @@
 #
 
 class DocsController < ApplicationController
+  skip_before_filter :upgrade
+
   api :GET, "/docs", "List documentation resources"
   header "Accept", "application/json", required: true
   example '


### PR DESCRIPTION
Documentation served from crowbar should be available during upgrade.