### PR TITLE
upgrade: Correctly restart services managed by pacemaker at remote nodes

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -129,6 +129,7 @@ end
 
 compute_node = roles.include? "nova-compute-kvm"
 cinder_volume = roles.include? "cinder-volume"
+remote_node = roles.include? "pacemaker-remote"
 neutron = search(:node, "run_list_map:neutron-server").first
 
 if !neutron.nil? && neutron[:neutron][:networking_plugin] == "ml2"
@@ -158,6 +159,7 @@ template "/usr/sbin/crowbar-pre-upgrade.sh" do
   variables(
     use_ha: use_ha,
     compute_node: compute_node,
+    remote_node: remote_node,
     swift_storage: swift_storage,
     bridges_to_reset: bridges_to_reset,
     cinder_volume: cinder_volume,

--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -92,20 +92,31 @@ zypper --non-interactive up <%= @neutron_agent %>
 crudini --set /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf ovs ovsdb_interface vsctl
 crudini --set /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf ovs of_interface ovs-ofctl
 <% end %>
+<% unless @remote_node %>
 systemctl restart <%= @neutron_agent %>
+<% end %>
 
 <% if @l3_agent %>
 zypper --non-interactive up <%= @l3_agent %>
+<% unless @remote_node %>
 systemctl restart <%= @l3_agent %>
+<% end %>
 <% end %>
 
 <% if @metadata_agent %>
 zypper --non-interactive up <%= @metadata_agent %>
+<% unless @remote_node %>
 systemctl restart <%= @metadata_agent %>
 <% end %>
+<% end %>
 
+<% if @remote_node %>
+log "Leving nova-compute service to be restarted by cluster resources"
+<% else %>
 log "Starting nova-compute service"
 systemctl restart openstack-nova-compute.service
+<% end %>
+
 
 <% if @cinder_volume %>
 log "Upgrading and setting cinder-volume configuration"
@@ -122,10 +133,6 @@ systemctl restart openstack-swift-account
 systemctl restart openstack-swift-object
 systemctl restart openstack-swift-container
 <% end %>
-
-# Remove temporary config options
-rm -f /etc/nova/nova.conf.d/200-crowbar-upgrade.conf
-rm -f /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf
 
 <% end %>
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
@@ -125,6 +125,10 @@ initiate_node_upgrade()
         default_package_config $c
     done
 
+    # Remove possibly existing temporary config files from the compute nodes
+    rm -f /etc/nova/nova.conf.d/200-crowbar-upgrade.conf
+    rm -f /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf
+
     # Signalize that the upgrade correctly ended
     echo "<%= @target_platform_version %>" >> $UPGRADEDIR/crowbar-upgrade-os-ok
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1380,6 +1380,21 @@ module Api
             "Check nova log files at '#{controller.name}' and '#{hostname}'."
           )
         end
+
+        if node[:pacemaker] && node[:pacemaker][:is_remote]
+          out = controller.run_ssh_cmd(
+            "crm --wait node ready remote-#{hostname}",
+            "60s"
+          )
+          unless out[:exit_code].zero?
+            raise_node_upgrade_error(
+              "Starting remote services at '#{hostname}' node has failed. " \
+              "Check /var/log/pacemaker.log at '#{controller.name}' and " \
+              "'#{hostname}' nodes for possible causes."
+            )
+          end
+        end
+
         node_api.save_node_state("compute", "upgraded")
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -916,7 +916,8 @@ module Api
 
         non_founder_nodes = ::Node.find(
           "pacemaker_founder:false AND " \
-          "pacemaker_config_environment:#{cluster}"
+          "pacemaker_config_environment:#{cluster} AND " \
+          "run_list_map:pacemaker-cluster-member"
         )
         non_founder_nodes.select! { |n| !n.upgraded? }
 

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -727,8 +727,10 @@ describe Api::Upgrade do
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow(Node).to(
-        receive(:find).with("pacemaker_founder:false AND pacemaker_config_environment:data").
-        and_return([Node.find_by_name("testing.crowbar.com")])
+        receive(:find).with(
+          "pacemaker_founder:false AND pacemaker_config_environment:data " \
+          "AND run_list_map:pacemaker-cluster-member"
+        ).and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow_any_instance_of(Node).to receive(:upgraded?).and_return(true)
       allow(Api::Upgrade).to receive(:upgrade_non_compute_nodes).and_return(true)


### PR DESCRIPTION
We should not manually restart services at remote nodes if these services are managed by pacemaker.

~TODO: after node upgrade, nova-compute is not immediately started (not with chef-client run on the node). It's probably started by chef-client run on cluster node, but I assume we cannot afford that.~

~crm status shows `cl-g-nova-compute` and `remote-d52-54-77-77-01-05` stopped for freshly upgraded node. So it should be possible to just restart these somehow?~

~`crm node ready` might help...~ -> implemented in 4th commit

