### PR TITLE
Revert "Revert "upgrade: Precheck to make sure cinder is using correc…

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -384,6 +384,12 @@ module Api
             help: I18n.t("api.upgrade.prechecks.ha_configured.help.default")
           }
         end
+        if check[:cinder_wrong_backend]
+          ret[:cinder_wrong_backend] = {
+            data: I18n.t("api.upgrade.prechecks.cinder_wrong_backend.error"),
+            help: I18n.t("api.upgrade.prechecks.cinder_wrong_backend.help")
+          }
+        end
         if check[:roles_not_ha]
           ret[:roles_not_ha] = {
             data: I18n.t("api.upgrade.prechecks.roles_not_ha.error",

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -834,6 +834,9 @@ en:
           not_configured: 'No Pacemaker cluster is configured.'
           help:
             default: 'Without HA setup, non-disruptive upgrade is not possible.'
+        cinder_wrong_backend:
+          error: 'Unsupported cinder backend detected. The Raw Devices and Local File backend cannot be used with non-disruptive upgrade.'
+          help: 'For non-disruptive upgrade, cinder cannot use Raw Devices or Local File as a backend. Adapt your Cinder configuration before proceeding with the upgrade.'
         roles_not_ha:
           error: 'These roles are not deployed in a cluster: %{roles}.'
           help: 'For non-disruptive upgrade, controller roles must be deployed in HA cluser.'

--- a/crowbar_framework/spec/fixtures/data_bags/template-cinder.json
+++ b/crowbar_framework/spec/fixtures/data_bags/template-cinder.json
@@ -1,0 +1,188 @@
+{
+  "id": "template-cinder",
+  "description": "Installation for Cinder",
+  "attributes": {
+    "cinder": {
+      "debug": false,
+      "verbose": true,
+      "max_header_line": 16384,
+      "use_syslog": false,
+      "rabbitmq_instance": "none",
+      "keystone_instance": "none",
+      "glance_instance": "none",
+      "database_instance": "none",
+      "service_user": "cinder",
+      "service_password": "",
+      "max_pool_size": 30,
+      "max_overflow": 10,
+      "pool_timeout": 30,
+      "rpc_response_timeout": 60,
+      "use_multi_backend": true,
+      "use_multipath": false,
+      "volume_defaults": {
+        "raw": {
+          "volume_name": "cinder-volumes",
+          "cinder_raw_method": "first"
+        },
+        "local": {
+          "volume_name": "cinder-volumes",
+          "file_name": "/var/lib/cinder/volume.raw",
+          "file_size": 2000
+        },
+        "eqlx": {
+          "san_ip": "192.168.124.11",
+          "san_login": "grpadmin",
+          "san_password": "12345",
+          "san_thin_provision": false,
+          "eqlx_group_name": "group-0",
+          "eqlx_use_chap": false,
+          "eqlx_chap_login": "chapadmin",
+          "eqlx_chap_password": "12345",
+          "eqlx_cli_timeout": 30,
+          "eqlx_pool": "default"
+        },
+        "netapp": {
+          "storage_family": "ontap_7mode",
+          "storage_protocol": "iscsi",
+          "nfs_shares": "",
+          "vserver": "",
+          "netapp_server_hostname": "192.168.124.11",
+          "netapp_server_port": 443,
+          "netapp_login": "admin",
+          "netapp_password": "",
+          "netapp_vfiler": "",
+          "netapp_transport_type": "https",
+          "netapp_volume_list": ""
+        },
+        "emc": {
+          "ecom_server_ip": "192.168.124.11",
+          "ecom_server_port": 0,
+          "ecom_server_username": "admin",
+          "ecom_server_password": "",
+          "ecom_server_portgroups": [ "OS-PORTGROUP1-PG", "OS-PORTGROUP2-PG" ],
+          "ecom_server_array": "111111111111",
+          "ecom_server_pool": "FC_GOLD1",
+          "ecom_server_policy": "GOLD1"
+        },
+        "eternus": {
+          "protocol": "fc",
+          "ip": "",
+          "port": 5988,
+          "user": "",
+          "password": "",
+          "pool": "",
+          "iscsi_ip": ""
+        },
+        "nfs": {
+          "nfs_shares": "",
+          "nfs_mount_options": ""
+        },
+        "rbd": {
+          "use_crowbar": true,
+          "config_file": "/etc/ceph/ceph.conf",
+          "admin_keyring": "/etc/ceph/ceph.client.admin.keyring",
+          "pool": "volumes",
+          "user": "cinder",
+          "secret_uuid": ""
+        },
+        "vmware": {
+          "host": "",
+          "user": "",
+          "password": "",
+          "cluster_name": [],
+          "volume_folder": "cinder-volume",
+          "ca_file": "",
+          "insecure": false
+        },
+        "hitachi": {
+          "storage_protocol": "fc",
+          "hitachi_add_chap_user": false,
+          "hitachi_async_copy_check_interval": 10,
+          "hitachi_auth_method": "None",
+          "hitachi_auth_password": "HBSD-CHAP-password",
+          "hitachi_auth_user": "HBSD-CHAP-user",
+          "hitachi_copy_check_interval": 3,
+          "hitachi_copy_speed": 3,
+          "hitachi_default_copy_method": "FULL",
+          "hitachi_group_range": "None",
+          "hitachi_group_request": false,
+          "hitachi_horcm_add_conf": true,
+          "hitachi_horcm_numbers": "200,201",
+          "hitachi_horcm_password": "None",
+          "hitachi_horcm_resource_lock_timeout": 600,
+          "hitachi_horcm_user": "None",
+          "hitachi_ldev_range": "None",
+          "hitachi_pool_id": "None",
+          "hitachi_serial_number": "None",
+          "hitachi_target_ports": "None",
+          "hitachi_thin_pool_id": "None",
+          "hitachi_unit_name": "None",
+          "hitachi_zoning_request": false
+        },
+        "manual": {
+          "driver": "",
+          "config": ""
+        }
+      },
+      "volumes": [
+        {
+          "backend_driver": "raw",
+          "backend_name": "default",
+          "raw": {
+              "volume_name": "cinder-volumes",
+              "cinder_raw_method": "first"
+          }
+        }
+      ],
+      "api": {
+        "protocol": "http",
+        "bind_open_address": true,
+        "bind_port": 8776
+      },
+      "strict_ssh_host_key_policy": false,
+      "default_availability_zone": "",
+      "default_volume_type": "",
+      "ssl": {
+        "certfile": "/etc/cinder/ssl/certs/signing_cert.pem",
+        "keyfile": "/etc/cinder/ssl/private/signing_key.pem",
+        "generate_certs": false,
+        "insecure": false,
+        "cert_required": false,
+        "ca_certs": "/etc/cinder/ssl/certs/ca.pem"
+      },
+      "db": {
+        "password": "",
+        "user": "cinder",
+        "database": "cinder"
+      }
+    }
+  },
+  "deployment": {
+    "cinder": {
+      "crowbar-revision": 0,
+      "crowbar-applied": false,
+      "schema-revision": 50,
+      "element_states": {
+          "cinder-controller": [ "readying", "ready", "applying" ],
+          "cinder-volume": [ "readying", "ready", "applying" ]
+      },
+      "elements": {},
+      "element_order": [
+          [ "cinder-controller" ],
+          [ "cinder-volume" ]
+      ],
+      "element_run_list_order": {
+          "cinder-controller": 92,
+          "cinder-volume": 93
+      },
+      "config": {
+        "environment": "cinder-base-config",
+        "mode": "full",
+        "transitions": false,
+        "transition_list": [
+        ]
+      }
+    }
+  }
+}
+

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -3,6 +3,10 @@ require "spec_helper"
 describe Api::Crowbar do
   let(:pid) { rand(20000..30000) }
   let(:admin_node) { NodeObject.find_node_by_name("admin") }
+  let(:cinder_proposal) do
+    Proposal.where(barclamp: "cinder", name: "default").create(barclamp: "cinder", name: "default")
+  end
+
   let!(:crowbar_upgrade_status) do
     JSON.parse(
       File.read(
@@ -347,8 +351,55 @@ describe Api::Crowbar do
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(["nova-compute-kvm", "cinder-volume", "swift-storage"])
       )
+      cinder_proposal.raw_data["attributes"] = {
+        "cinder" => { "volumes" => [] }
+      }
+      allow(Proposal).to(receive(:where).and_return([]))
+      allow(Proposal).to(receive(:where).with(barclamp: "cinder").and_return([cinder_proposal]))
 
       expect(subject.class.ha_config_check).to eq({})
+    end
+
+    it "succeeds to confirm that HA is deployed with correct cinder backend" do
+      allow(Api::Crowbar).to(receive(:addon_installed?).and_return(true))
+      allow(NodeObject).to(
+        receive(:find).with(
+          "pacemaker_founder:true AND pacemaker_config_environment:*"
+        ).and_return([node])
+      )
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
+      allow_any_instance_of(NodeObject).to(
+        receive(:roles).and_return(["nova-compute-kvm", "cinder-volume", "swift-storage"])
+      )
+      cinder_proposal.raw_data["attributes"] = {
+        "cinder" => { "volumes" => [{ "backend_driver" => "rbd" }] }
+      }
+      allow(Proposal).to(receive(:where).and_return([]))
+      allow(Proposal).to(receive(:where).with(barclamp: "cinder").and_return([cinder_proposal]))
+
+      expect(subject.class.ha_config_check).to eq({})
+    end
+
+    it "fails when finding out cinder is using raw backend" do
+      allow(Api::Crowbar).to(receive(:addon_installed?).and_return(true))
+      allow(NodeObject).to(
+        receive(:find).with(
+          "pacemaker_founder:true AND pacemaker_config_environment:*"
+        ).and_return([node])
+      )
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
+      allow_any_instance_of(NodeObject).to(
+        receive(:roles).and_return(["nova-compute-kvm", "cinder-volume", "swift-storage"])
+      )
+      cinder_proposal.raw_data["attributes"] = {
+        "cinder" => { "volumes" => [{ "backend_driver" => "raw" }] }
+      }
+      allow(Proposal).to(receive(:where).and_return([]))
+      allow(Proposal).to(receive(:where).with(barclamp: "cinder").and_return([cinder_proposal]))
+
+      expect(subject.class.ha_config_check).to eq(cinder_wrong_backend: true)
     end
 
     it "fails when controller role is deployed to compute node" do
@@ -363,6 +414,11 @@ describe Api::Crowbar do
           ["cinder-controller", "nova-compute-kvm", "neutron-server"]
         )
       )
+      cinder_proposal.raw_data["attributes"] = {
+        "cinder" => { "volumes" => [{ "backend_driver" => "rbd" }] }
+      }
+      allow(Proposal).to(receive(:where).and_return([]))
+      allow(Proposal).to(receive(:where).with(barclamp: "cinder").and_return([cinder_proposal]))
 
       expect(subject.class.ha_config_check).to eq(
         role_conflicts: { "testing.crowbar.com" => ["cinder-controller", "neutron-server"] }


### PR DESCRIPTION
…t backend""

This reverts commit 26a195da0d22fb99efc127542a2b1e28c8049c72.

The required changes have been merged into the CI. It should now be safe
to re-enable this precheck.

