### PR TITLE
upgrade: Precheck for supported cluster configs

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -261,14 +261,22 @@ module Api
           "nova"
         ]
         roles_not_ha = []
+        roles_clusters = {}
+        clusters_roles = {}
+        clusters_roles.default = []
         barclamps.each do |barclamp|
           proposal = Proposal.where(barclamp: barclamp).first
           next if proposal.nil?
           proposal["deployment"][barclamp]["elements"].each do |role, elements|
             next unless clustered_roles.include? role
             elements.each do |element|
-              next if ServiceObject.is_cluster?(element)
-              roles_not_ha |= [role]
+              if ServiceObject.is_cluster?(element)
+                # currently roles can't be assigned to more than one cluster
+                roles_clusters[role] = element
+                clusters_roles[element] |= [role]
+              else
+                roles_not_ha |= [role]
+              end
             end
           end
         end
@@ -300,6 +308,48 @@ module Api
             end
           end
         end
+
+        # example inputs:
+        # roles_clusters = {
+        #   "neutron-server": "cluster:cluster1",
+        #   "neutron-network": "cluster:cluster1",
+        #   "database-server": "cluster:cluster2",
+        #   "rabbitmq-server": "cluster:cluster3"
+        # }
+        # clusters_roles = {
+        #   "cluster:cluster1": ["neutron-server", "neutron-network"],
+        #   "cluster:cluster2": ["database-server"],
+        #   "cluster:cluster3": ["rabbitmq-server"]
+        # }
+        deployment_supported =
+          case clusters_roles.length
+          when 0
+            # no clusters, no point complaining as this will be detected by other prechecks
+            true
+
+          when 1
+            # everything on one cluster = no problem
+            true
+
+          when 2
+            # neutron-network in separate cluster
+            true if clusters_roles[roles_clusters["neutron-network"]].length == 1 ||
+                # neutron-network + neutron-server in separate cluster
+                (clusters_roles[roles_clusters["neutron-network"]].length == 2 &&
+                roles_clusters["neutron-network"] == roles_clusters["neutron-server"]) ||
+                # database-server + rabbitmq-server in separate cluster
+                (clusters_roles[roles_clusters["database-server"]].length == 2 &&
+                roles_clusters["database-server"] == roles_clusters["rabbitmq-server"])
+
+          when 3
+            # neutron-network and database-server + rabbitmq-server in separate clusters
+            # rest of *-server roles is implicitly on the third cluster
+            true if clusters_roles[roles_clusters["neutron-network"]].length == 1 &&
+                clusters_roles[roles_clusters["database-server"]].length == 2 &&
+                roles_clusters["database-server"] == roles_clusters["rabbitmq-server"]
+          end
+        ret[:unsupported_cluster_setup] = true unless deployment_supported
+
         ret
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -407,6 +407,12 @@ module Api
             help: I18n.t("api.upgrade.prechecks.cinder_wrong_backend.help")
           }
         end
+        if check[:unsupported_cluster_setup]
+          ret[:unsupported_cluster_setup] = {
+            data: I18n.t("api.upgrade.prechecks.unsupported_cluster_setup.error"),
+            help: I18n.t("api.upgrade.prechecks.unsupported_cluster_setup.help")
+          }
+        end
         ret
       end
 

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -846,6 +846,9 @@ en:
         cinder_wrong_backend:
           error: 'Unsupported cinder backend detected. The Raw Devices and Local File backend cannot be used with non-disruptive upgrade.'
           help: 'For non-disruptive upgrade, cinder cannot use Raw Devices or Local File as a backend. Adapt your Cinder configuration before proceeding with the upgrade.'
+        unsupported_cluster_setup:
+          error: 'Your cluster/role configuration is not supported by the non-disruptive upgrade process.'
+          help: 'Please refer to the Deployment Guide for list of supported configurations.'
         swift_replicas:
           error: 'The number of replicas is bigger than the number of disks assigned for Swift.'
           help: 'Such configuration is not supported in Swift delivered with SOC 7. Adapt your Swift configuration before proceeding with the upgrade.'

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -412,6 +412,181 @@ describe Api::Crowbar do
         role_conflicts: { "testing.crowbar.com" => ["cinder-controller", "neutron-server"] }
       )
     end
+
+    def barclamp_config_helper(attributes, deployment)
+      deployment.each do |bc, bc_data|
+        allow(Proposal).to(
+          receive(:where).with(barclamp: bc).and_return(
+            [{
+              "attributes" => attributes[bc],
+              "deployment" => { bc => { "elements" => bc_data } }
+            }]
+          )
+        )
+      end
+    end
+
+    it "succeeds when there are two clusters and one is dedicated to neutron" do
+      allow(Api::Crowbar).to(receive(:addon_installed?).and_return(true))
+      allow(NodeObject).to(receive(:find).with(
+        "pacemaker_founder:true AND pacemaker_config_environment:*"
+      ).and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([]))
+
+      barclamps_clusters = {
+        "database" => { "database-server" => ["cluster1"] },
+        "rabbitmq" => { "rabbitmq-server" => ["cluster1"] },
+        "keystone" => { "keystone-server" => ["cluster1"] },
+        "glance" => { "glance-server" => ["cluster1"] },
+        "cinder" => { "cinder-controller" => ["cluster1"] },
+        "neutron" => { "neutron-server" => ["cluster2"], "neutron-network" => ["cluster2"] },
+        "nova" => { "nova-controller" => ["cluster1"] }
+      }
+      barclamps_attributes = {
+        "cinder" => { "cinder" => { "volumes" => [] } }
+      }
+      barclamp_config_helper(barclamps_attributes, barclamps_clusters)
+
+      allow(ServiceObject).to(receive(:is_cluster?).and_return(true))
+
+      expect(subject.class.ha_config_check).to eq({})
+    end
+
+    it "succeeds when there are two clusters and one is dedicated to db" do
+      allow(Api::Crowbar).to(receive(:addon_installed?).and_return(true))
+      allow(NodeObject).to(receive(:find).with(
+        "pacemaker_founder:true AND pacemaker_config_environment:*"
+      ).and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([]))
+
+      barclamps_clusters = {
+        "database" => { "database-server" => ["cluster2"] },
+        "rabbitmq" => { "rabbitmq-server" => ["cluster2"] },
+        "keystone" => { "keystone-server" => ["cluster1"] },
+        "glance" => { "glance-server" => ["cluster1"] },
+        "cinder" => { "cinder-controller" => ["cluster1"] },
+        "neutron" => { "neutron-server" => ["cluster1"], "neutron-network" => ["cluster1"] },
+        "nova" => { "nova-controller" => ["cluster1"] }
+      }
+      barclamps_attributes = {
+        "cinder" => { "cinder" => { "volumes" => [] } }
+      }
+      barclamp_config_helper(barclamps_attributes, barclamps_clusters)
+
+      allow(ServiceObject).to(receive(:is_cluster?).and_return(true))
+
+      expect(subject.class.ha_config_check).to eq({})
+    end
+
+    it "succeeds when there are three clusters and they are db+apis+network" do
+      allow(Api::Crowbar).to(receive(:addon_installed?).and_return(true))
+      allow(NodeObject).to(receive(:find).with(
+        "pacemaker_founder:true AND pacemaker_config_environment:*"
+      ).and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([]))
+
+      barclamps_clusters = {
+        "database" => { "database-server" => ["cluster1"] },
+        "rabbitmq" => { "rabbitmq-server" => ["cluster1"] },
+        "keystone" => { "keystone-server" => ["cluster2"] },
+        "glance" => { "glance-server" => ["cluster2"] },
+        "cinder" => { "cinder-controller" => ["cluster2"] },
+        "neutron" => { "neutron-server" => ["cluster2"], "neutron-network" => ["cluster3"] },
+        "nova" => { "nova-controller" => ["cluster2"] }
+      }
+      barclamps_attributes = {
+        "cinder" => { "cinder" => { "volumes" => [] } }
+      }
+      barclamp_config_helper(barclamps_attributes, barclamps_clusters)
+
+      allow(ServiceObject).to(receive(:is_cluster?).and_return(true))
+
+      expect(subject.class.ha_config_check).to eq({})
+    end
+
+    it "fails when there are four clusters" do
+      allow(Api::Crowbar).to(receive(:addon_installed?).and_return(true))
+      allow(NodeObject).to(receive(:find).with(
+        "pacemaker_founder:true AND pacemaker_config_environment:*"
+      ).and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([]))
+
+      barclamps_clusters = {
+        "database" => { "database-server" => ["cluster1"] },
+        "rabbitmq" => { "rabbitmq-server" => ["cluster1"] },
+        "keystone" => { "keystone-server" => ["cluster2"] },
+        "glance" => { "glance-server" => ["cluster2"] },
+        "cinder" => { "cinder-controller" => ["cluster2"] },
+        "neutron" => { "neutron-server" => ["cluster2"], "neutron-network" => ["cluster3"] },
+        "nova" => { "nova-controller" => ["cluster4"] }
+      }
+      barclamps_attributes = {
+        "cinder" => { "cinder" => { "volumes" => [] } }
+      }
+      barclamp_config_helper(barclamps_attributes, barclamps_clusters)
+
+      allow(ServiceObject).to(receive(:is_cluster?).and_return(true))
+
+      expect(subject.class.ha_config_check).to have_key(:unsupported_cluster_setup)
+    end
+
+    it "fails when there are three clusters and db/api/network roles are mixed" do
+      allow(Api::Crowbar).to(receive(:addon_installed?).and_return(true))
+      allow(NodeObject).to(receive(:find).with(
+        "pacemaker_founder:true AND pacemaker_config_environment:*"
+      ).and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([]))
+
+      barclamps_clusters = {
+        "database" => { "database-server" => ["cluster1"] },
+        "rabbitmq" => { "rabbitmq-server" => ["cluster2"] },
+        "keystone" => { "keystone-server" => ["cluster3"] },
+        "glance" => { "glance-server" => ["cluster1"] },
+        "cinder" => { "cinder-controller" => ["cluster2"] },
+        "neutron" => { "neutron-server" => ["cluster3"], "neutron-network" => ["cluster1"] },
+        "nova" => { "nova-controller" => ["cluster2"] }
+      }
+      barclamps_attributes = {
+        "cinder" => { "cinder" => { "volumes" => [] } }
+      }
+      barclamp_config_helper(barclamps_attributes, barclamps_clusters)
+
+      allow(ServiceObject).to(receive(:is_cluster?).and_return(true))
+
+      expect(subject.class.ha_config_check).to have_key(:unsupported_cluster_setup)
+    end
+
+    it "fails when there are two clusters and roles assignment does not match supported patterns" do
+      allow(Api::Crowbar).to(receive(:addon_installed?).and_return(true))
+      allow(NodeObject).to(receive(:find).with(
+        "pacemaker_founder:true AND pacemaker_config_environment:*"
+      ).and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([]))
+
+      barclamps_clusters = {
+        "database" => { "database-server" => ["cluster1"] },
+        "rabbitmq" => { "rabbitmq-server" => ["cluster2"] },
+        "keystone" => { "keystone-server" => ["cluster1"] },
+        "glance" => { "glance-server" => ["cluster2"] },
+        "cinder" => { "cinder-controller" => ["cluster1"] },
+        "neutron" => { "neutron-server" => ["cluster2"], "neutron-network" => ["cluster1"] },
+        "nova" => { "nova-controller" => ["cluster2"] }
+      }
+      barclamps_attributes = {
+        "cinder" => { "cinder" => { "volumes" => [] } }
+      }
+      barclamp_config_helper(barclamps_attributes, barclamps_clusters)
+
+      allow(ServiceObject).to(receive(:is_cluster?).and_return(true))
+
+      expect(subject.class.ha_config_check).to have_key(:unsupported_cluster_setup)
+    end
   end
 
   context "with HA installed but not deployed" do


### PR DESCRIPTION
**Why is this change necessary?**
The non-disruptive process supports only limited number of cluster
configurations.

**How does it address the issue?**
 This precheck is there to verify that the detected configuration matches one of the whitelisted options.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/of0FMzfd/361-s57p6-5-add-upgrade-precheck-for-unusual-configs-that-might-not-work-for-our-process

![zrzut ekranu z 2017-03-24 09-59-04](https://cloud.githubusercontent.com/assets/2458112/24287314/7ac1e6a6-1079-11e7-9b18-59fabb81a64f.png)
