### PR TITLE
provisioner: disable zypper repo auto-refresh delay

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -308,6 +308,13 @@ if node[:platform_family] == "suse" && !node.roles.include?("provisioner-server"
   end
 
   if node[:platform_family] == "suse"
+    template "/etc/zypp.conf" do
+      source "zypp.conf.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+    end
+
     # make sure the repos are properly setup
     repos = Provisioner::Repositories.get_repos(node[:platform], node[:platform_version], node[:kernel][:machine])
     for name, attrs in repos

--- a/chef/cookbooks/provisioner/templates/default/zypp.conf.erb
+++ b/chef/cookbooks/provisioner/templates/default/zypp.conf.erb
@@ -1,0 +1,1 @@
+repo.refresh.delay = 0

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -277,6 +277,8 @@ fi
 # Setup the repos
 # ---------------
 
+grep '^\s*repo\.refresh\.delay' /etc/zypp/zypp.conf > /dev/null || echo 'repo.refresh.delay = 0' >> /etc/zypp/zypp.conf
+
 <% @repos.keys.sort.each do |name| %>
 zypper -n ar "<%= @repos[name][:url] %>" "<%= name %>"
   <% unless @repos[name][:priority] == 99 -%>


### PR DESCRIPTION
Disable the global zypper repository auto-refresh time
delay by setting repo.refresh.delay to 0 in zypp.conf.

Update the crowbar_register generated script to do the same.

Zypper repos are refreshed on-demand and the updater barclamp
doesn't risk having to work with stale repo contents.

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1030462
