### PR TITLE
upgrade: Precheck to make sure cinder is using correct backend

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -144,6 +144,18 @@ module Api
         ret
       end
 
+      # Check for a state of HA setup, which is a requirement for non-disruptive upgrade
+      def ha_config_check
+        prop = Proposal.where(barclamp: "cinder").first
+
+        backends = prop["attributes"]["cinder"]["volumes"].select do |volume|
+          backend_driver = volume["backend_driver"]
+          ["local", "raw"].include? backend_driver
+        end
+        return { cinder_wrong_backend: true } unless backends.empty?
+        {}
+      end
+
       protected
 
       def lib_path

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -813,6 +813,9 @@ en:
         ha_configured:
           help:
             default: 'Without HA setup, non-disruptive upgrade is not possible.'
+        cinder_wrong_backend:
+          error: 'Unsupported cinder backend detected. The Raw Devices and Local File backend cannot be used with non-disruptive upgrade.'
+          help: 'For non-disruptive upgrade, cinder cannot use Raw Devices or Local File as a backend. Adapt your Cinder configuration before proceeding with the upgrade.'
         ceph_not_healthy:
           error: |
             Ceph cluster health check has failed with:

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -136,6 +136,9 @@ describe Api::Upgrade do
         :health_check
       ).and_return({})
       allow(Api::Crowbar).to receive(
+        :ha_config_check
+      ).and_return({})
+      allow(Api::Crowbar).to receive(
         :compute_status
       ).and_return({})
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
@@ -938,6 +941,9 @@ describe Api::Upgrade do
       allow(Api::Crowbar).to(
         receive(:health_check).and_return({})
       )
+      allow(Api::Crowbar).to receive(
+        :ha_config_check
+      ).and_return({})
       allow(Api::Crowbar).to(
         receive(:compute_status).and_return({})
       )
@@ -961,6 +967,9 @@ describe Api::Upgrade do
       allow(Api::Crowbar).to(
         receive(:health_check).and_return({})
       )
+      allow(Api::Crowbar).to receive(
+        :ha_config_check
+      ).and_return({})
       allow(Api::Crowbar).to(
         receive(:compute_status).and_return({})
       )
@@ -975,6 +984,9 @@ describe Api::Upgrade do
       allow(Crowbar::Checks::Maintenance).to receive(
         :updates_status
       ).and_return(errors: ["Some Error"])
+      allow(Api::Crowbar).to receive(
+        :ha_config_check
+      ).and_return({})
       allow(Api::Pacemaker).to receive(
         :health_report
       ).and_return(crm_failures: "error", failed_actions: "error")


### PR DESCRIPTION
Backend for cinder cannot be raw or local for non-disruptive upgrade.

(cherry picked from commit 7281972c3b4a7d7fbc0d5308708a75c7696d124c)

Partial forward-port of https://github.com/crowbar/crowbar-core/pull/1119
I left out most of 1st commit, as in `master` we have that code in crowbar-ha (and it's not strictly needed, it was more cosmetic) 