### PR TITLE
upgrade: Remove checking for XEN nodes

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -211,14 +211,15 @@ module Api
 
       def compute_status
         ret = {}
-        ["kvm", "xen"].each do |virt|
-          compute_nodes = NodeObject.find("roles:nova-compute-#{virt}")
-          next unless compute_nodes.size == 1
-          ret[:no_resources] ||= []
-          ret[:no_resources].push(
-            "Found only one compute node of #{virt} type; non-disruptive upgrade is not possible"
-          )
+        compute_nodes = NodeObject.find("roles:nova-compute-kvm")
+        if compute_nodes.size == 1
+          ret[:no_resources] =
+            "Found only one KVM compute node; non-disruptive upgrade is not possible"
         end
+        non_kvm_nodes = NodeObject.find(
+          "roles:nova-compute-* AND NOT roles:nova-compute-kvm"
+        ).map(&:name)
+        ret[:non_kvm_computes] = non_kvm_nodes unless non_kvm_nodes.empty?
         nova = NodeObject.find("roles:nova-controller").first
         ret[:no_live_migration] = true if nova && !nova["nova"]["use_migration"]
         ret

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -300,13 +300,11 @@ module Api
           "trove-server"
         ]
         ret = {}
-        ["kvm", "xen"].each do |virt|
-          NodeObject.find("roles:nova-compute-#{virt}").each do |node|
-            conflict = node.roles & conflicting_roles
-            unless conflict.empty?
-              ret[:role_conflicts] ||= {}
-              ret[:role_conflicts][node.name] = conflict
-            end
+        NodeObject.find("roles:nova-compute-kvm").each do |node|
+          conflict = node.roles & conflicting_roles
+          unless conflict.empty?
+            ret[:role_conflicts] ||= {}
+            ret[:role_conflicts][node.name] = conflict
           end
         end
 
@@ -358,26 +356,24 @@ module Api
         ret = {}
         # Make sure that node with nova-compute is not upgraded before nova-controller
         nova_order = BarclampCatalog.run_order("nova")
-        ["kvm", "xen"].each do |virt|
-          NodeObject.find("roles:nova-compute-#{virt}").each do |node|
-            # nova-compute with nova-controller on one node is not non-disruptive,
-            # but at least it does not break the order
-            next if node.roles.include? "nova-controller"
-            next if ret.any?
-            wrong_roles = []
-            node.roles.each do |role|
-              # these storage roles are handled separately
-              next if ["cinder-volume", "swift-storage"].include? role
-              # compute node roles are fine
-              next if role.start_with?("nova-compute") || role == "pacemaker-remote"
-              r = RoleObject.find_role_by_name(role)
-              next if r.proposal?
-              b = r.barclamp
-              next if BarclampCatalog.category(b) != "OpenStack"
-              wrong_roles.push role if BarclampCatalog.run_order(b) < nova_order
-            end
-            ret = { controller_roles: { node: node.name, roles: wrong_roles } } if wrong_roles.any?
+        NodeObject.find("roles:nova-compute-*").each do |node|
+          # nova-compute with nova-controller on one node is not non-disruptive,
+          # but at least it does not break the order
+          next if node.roles.include? "nova-controller"
+          next if ret.any?
+          wrong_roles = []
+          node.roles.each do |role|
+            # these storage roles are handled separately
+            next if ["cinder-volume", "swift-storage"].include? role
+            # compute node roles are fine
+            next if role.start_with?("nova-compute") || role == "pacemaker-remote"
+            r = RoleObject.find_role_by_name(role)
+            next if r.proposal?
+            b = r.barclamp
+            next if BarclampCatalog.category(b) != "OpenStack"
+            wrong_roles.push role if BarclampCatalog.run_order(b) < nova_order
           end
+          ret = { controller_roles: { node: node.name, roles: wrong_roles } } if wrong_roles.any?
         end
         ret
       end

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -463,6 +463,13 @@ module Api
             help: I18n.t("api.upgrade.prechecks.no_resources.help")
           }
         end
+        if check[:non_kvm_computes]
+          ret[:non_kvm_computes] = {
+            data: I18n.t("api.upgrade.prechecks.non_kvm_computes.error",
+              nodes: check[:non_kvm_computes].join(", ")),
+            help: I18n.t("api.upgrade.prechecks.non_kvm_computes.help")
+          }
+        end
         if check[:no_live_migration]
           ret[:no_live_migration] = {
             data: I18n.t("api.upgrade.prechecks.no_live_migration.error"),

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -823,10 +823,13 @@ en:
           help:
             default: 'Make sure clusters are healthy'
         no_resources:
-          help: 'Make sure you have enough compute nodes so the live migration of instances is possible.'
+          help: 'Make sure you have enough KVM compute nodes so the live migration of instances is possible.'
         no_live_migration:
           error: 'Live migration is not configured in nova barclamp.'
           help: 'Adapt the nova barclamp configuration to support live migration before proceeding with the upgrade.'
+        non_kvm_computes:
+          error: 'Found compute nodes different than KVM: %{nodes}.'
+          help: 'Non-disruptive upgrade is only possible with KVM compute nodes.'
         resources:
           help: 'Make sure you have enough compute nodes so the live migration of instances is possible.'
         ha_configured:

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -346,7 +346,6 @@ describe Api::Crowbar do
         receive(:find).with("pacemaker_founder:true AND pacemaker_config_environment:*").
         and_return([node])
       )
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(["nova-compute-kvm", "cinder-volume", "swift-storage"])
@@ -371,7 +370,6 @@ describe Api::Crowbar do
       allow(Proposal).to(receive(:where).and_return([]))
       allow(Proposal).to(receive(:where).with(barclamp: "cinder").and_return([cinder_proposal]))
 
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(["nova-compute-kvm", "cinder-volume", "swift-storage"])
@@ -400,7 +398,6 @@ describe Api::Crowbar do
       allow(NodeObject).to(receive(:find).with(
         "pacemaker_founder:true AND pacemaker_config_environment:*"
       ).and_return([node]))
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
@@ -616,8 +613,7 @@ describe Api::Crowbar do
 
   context "with correct barclamps deployment" do
     it "passes with nice compute nodes" do
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
           ["nova-compute-kvm", "cinder-volume", "swift-storage"]
@@ -629,8 +625,7 @@ describe Api::Crowbar do
     end
 
     it "passes with remote compute node" do
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
           ["nova-compute-kvm", "pacemaker-remote"]
@@ -642,8 +637,7 @@ describe Api::Crowbar do
     end
 
     it "passes with compute node together with nova-controller " do
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
           ["nova-compute-kvm", "cinder-controller", "nova-controller"]
@@ -657,8 +651,7 @@ describe Api::Crowbar do
 
   context "with broken barclamps deployment" do
     it "fails when cinder-controller is on compute node" do
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
           ["nova-compute-kvm", "cinder-controller"]


### PR DESCRIPTION
1. Precheck for presence of non-KVM nodes
2. Remove rest of XEN specific searches
3. Deployment check needs to check all compute nodes (relevant for disruptive upgrade)