### PR TITLE
upgrade: Fix upgrade link

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -82,6 +82,9 @@ nav:
     ceph_pre_upgrade:
       order: 30
       route: 'ceph_pre_upgrade_path'
+    upgrade:
+      order: 40
+      route: '"/upgrade"'
   help:
     order: 80
     route: 'docs_path'

--- a/crowbar_framework/config/navigation.rb
+++ b/crowbar_framework/config/navigation.rb
@@ -39,7 +39,7 @@ SimpleNavigation::Configuration.run do |navigation|
       level2.item :repositories, t("nav.utils.repositories"), repositories_path
       level2.item :backup, t("nav.utils.backup"), backups_path
       level2.item :ceph_pre_upgrade, t("nav.utils.ceph_pre_upgrade"), ceph_pre_upgrade_path
-      level2.item :backup, t("nav.utils.upgrade"), "/upgrade"
+      level2.item :upgrade, t("nav.utils.upgrade"), "/upgrade"
       level2.item :logs, t("nav.utils.logs"), utils_path
     end
   end


### PR DESCRIPTION
**Why is this change necessary?**
Without proper entry in crowbar.yml the link would be removed by `barclamp_install`.

**How does it address the issue?**
Add upgrade entry in crowbar.yml and fix key in navigation.rb.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
this is a followup for PR #664
https://trello.com/c/cdtWLx6h/391-2-s58p5-add-the-upgrade-link-from-crowbar-ui