### PR TITLE
upgrade: Do not treat xen nodes upgradable in non-disruptive mode

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -127,7 +127,7 @@ template "/usr/sbin/crowbar-evacuate-host.sh" do
   only_if { roles.include? "nova-controller" }
 end
 
-compute_node = (roles & ["nova-compute-kvm", "nova-compute-xen"]).any?
+compute_node = roles.include? "nova-compute-kvm"
 cinder_volume = roles.include? "cinder-volume"
 neutron = search(:node, "run_list_map:neutron-server").first
 

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -208,13 +208,11 @@ module Api
           "trove-server"
         ]
         ret = {}
-        ["kvm", "xen"].each do |virt|
-          NodeObject.find("roles:nova-compute-#{virt}").each do |node|
-            conflict = node.roles & conflicting_roles
-            unless conflict.empty?
-              ret[:role_conflicts] ||= {}
-              ret[:role_conflicts][node.name] = conflict
-            end
+        NodeObject.find("roles:nova-compute-kvm").each do |node|
+          conflict = node.roles & conflicting_roles
+          unless conflict.empty?
+            ret[:role_conflicts] ||= {}
+            ret[:role_conflicts][node.name] = conflict
           end
         end
         ret
@@ -224,25 +222,24 @@ module Api
         ret = {}
         # Make sure that node with nova-compute is not upgraded before nova-controller
         nova_order = BarclampCatalog.run_order("nova")
-        ["kvm", "xen"].each do |virt|
-          NodeObject.find("roles:nova-compute-#{virt}").each do |node|
-            # nova-compute with nova-controller on one node is not non-disruptive,
-            # but at least it does not break the order
-            next if node.roles.include? "nova-controller"
-            next if ret.any?
-            wrong_roles = []
-            node.roles.each do |role|
-              # these storage roles are handled separately
-              next if ["cinder-volume", "swift-storage"].include? role
-              next if role.start_with?("nova-compute")
-              r = RoleObject.find_role_by_name(role)
-              next if r.proposal?
-              b = r.barclamp
-              next if BarclampCatalog.category(b) != "OpenStack"
-              wrong_roles.push role if BarclampCatalog.run_order(b) < nova_order
-            end
-            ret = { controller_roles: { node: node.name, roles: wrong_roles } } if wrong_roles.any?
+        ::Node.find("roles:nova-compute-*").each do |node|
+          # nova-compute with nova-controller on one node is not non-disruptive,
+          # but at least it does not break the order
+          next if node.roles.include? "nova-controller"
+          next if ret.any?
+          wrong_roles = []
+          node.roles.each do |role|
+            # these storage roles are handled separately
+            next if ["cinder-volume", "swift-storage"].include? role
+            # compute node roles are fine
+            next if role.start_with?("nova-compute") || role == "pacemaker-remote"
+            r = RoleObject.find_role_by_name(role)
+            next if r.proposal?
+            b = r.barclamp
+            next if BarclampCatalog.category(b) != "OpenStack"
+            wrong_roles.push role if BarclampCatalog.run_order(b) < nova_order
           end
+          ret = { controller_roles: { node: node.name, roles: wrong_roles } } if wrong_roles.any?
         end
         ret
       end

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1558,6 +1558,13 @@ module Api
             help: I18n.t("api.upgrade.prechecks.no_resources.help")
           }
         end
+        if check[:non_kvm_computes]
+          ret[:non_kvm_computes] = {
+            data: I18n.t("api.upgrade.prechecks.non_kvm_computes.error",
+              nodes: check[:non_kvm_computes].join(", ")),
+            help: I18n.t("api.upgrade.prechecks.non_kvm_computes.help")
+          }
+        end
         if check[:no_live_migration]
           ret[:no_live_migration] = {
             data: I18n.t("api.upgrade.prechecks.no_live_migration.error"),

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -804,10 +804,13 @@ en:
           help:
             default: 'Make sure clusters are healthy'
         no_resources:
-          help: 'Make sure you have enough compute nodes so the live migration of instances is possible.'
+          help: 'Make sure you have enough KVM compute nodes so the live migration of instances is possible.'
         no_live_migration:
           error: 'Live migration is not configured in nova barclamp.'
           help: 'Adapt the nova barclamp configuration to support live migration before proceeding with the upgrade.'
+        non_kvm_computes:
+          error: 'Found compute nodes different than KVM: %{nodes}.'
+          help: 'Non-disruptive upgrade is only possible with KVM compute nodes.'
         resources:
           help: 'Make sure you have enough compute nodes so the live migration of instances is possible.'
         ha_configured:

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -514,9 +514,6 @@ describe Api::Upgrade do
       allow(Node).to(
         receive(:find).with("roles:nova-compute-kvm").and_return([node1, node2])
       )
-      allow(Node).to(
-        receive(:find).with("roles:nova-compute-xen").and_return([])
-      )
 
       # parallel_upgrade_compute_nodes:
       allow(Api::Upgrade).to receive(:execute_scripts_and_wait_for_finish).with(
@@ -624,7 +621,7 @@ describe Api::Upgrade do
       # upgrade_non_compute_nodes:
       allow(Node).to(
         receive(:find).with(
-          "state:crowbar_upgrade AND NOT run_list_map:nova-compute-*"
+          "state:crowbar_upgrade AND NOT run_list_map:nova-compute-kvm"
         ).and_return([ceph, testing])
       )
       allow_any_instance_of(Api::Node).to receive(:save_node_state).with(
@@ -653,9 +650,6 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to receive(:do_controllers_substep).and_return(true)
       allow(Node).to(
         receive(:find).with("roles:nova-compute-kvm").and_return([])
-      )
-      allow(Node).to(
-        receive(:find).with("roles:nova-compute-xen").and_return([])
       )
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :start_step
@@ -760,7 +754,6 @@ describe Api::Upgrade do
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow_any_instance_of(Node).to receive(:upgraded?).and_return(true)
-      allow(Node).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow(Api::Upgrade).to receive(:upgrade_all_compute_nodes).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :progress
@@ -783,7 +776,6 @@ describe Api::Upgrade do
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow_any_instance_of(Node).to receive(:upgraded?).and_return(true)
-      allow(Node).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :progress
       ).and_return(remaining_nodes: 0)
@@ -800,7 +792,6 @@ describe Api::Upgrade do
         receive(:find).with("roles:nova-compute-kvm").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
-      allow(Node).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow(Node).to(
         receive(:find).with("roles:nova-controller").
         and_return([Node.find_by_name("testing.crowbar.com")])


### PR DESCRIPTION
If they are any XEN compute nodes, the would be upgraded in normal
mode only.

Other 2 commits are port of https://github.com/crowbar/crowbar-core/pull/1189