### PR TITLE
upgrade: Do not try to disable non-existing service

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -48,9 +48,7 @@ when "crowbar_upgrade"
 
   bash "disable_openstack_services" do
     code <<-EOF
-      for i in $(systemctl list-units openstack* --no-legend | cut -d" " -f1) \
-               drbd.service \
-               pacemaker.service;
+      for i in $(systemctl list-units openstack* drbd.service pacemaker.service --no-legend | cut -d" " -f1);
       do
         systemctl disable $i
       done


### PR DESCRIPTION
At SP2, systemctl disable complains when disabling service that is not installed.
This is normally not a problem, since we execute this code at SP1 (Cloud6)
nodes only, but it can fail in the corner case when user has Ceph nodes, upgrades them
(so they have SP2 and are staying in the crowbar-upgrade state) and the reapplies
some barclamp (e.g. for fixing some setting required for the Cloud upgrade).
