### PR TITLE
Fix schema migration for remote PSQL

### DIFF
--- a/crowbar_framework/lib/schema_migration.rb
+++ b/crowbar_framework/lib/schema_migration.rb
@@ -27,7 +27,8 @@ module SchemaMigration
   def self.run_for_bc bc_name
     return unless File.exist?("/var/lib/crowbar/install/crowbar-installed-ok")
     return if File.exist?("/var/run/crowbar/admin-server-upgrading")
-    unless system("systemctl is-active postgresql")
+    db_host = Rails.configuration.database_configuration[Rails.env]["host"]
+    if ["localhost", "127.0.0.1"].include?(db_host) && !system("systemctl is-active postgresql")
       raise "Cannot run schema migrations for #{bc_name}. Database server is not running"
     end
 


### PR DESCRIPTION
**Why is this change necessary?**
Schema migration code checked for local postgresql service even if
the actual config used remote database.

**How does it address the issue?**
Simple check was added for the database host configured in the application.
