### PR TITLE
Loosen crowbar/psql service dependencies

### DIFF
--- a/configs/crowbar-jobs.service
+++ b/configs/crowbar-jobs.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Crowbar Background jobs
 After=network.target syslog.target remote-fs.target chef-server.service crowbar.service
-Requires=postgresql.service
+Wants=postgresql.service
 
 [Service]
 Type=forking

--- a/configs/crowbar.service
+++ b/configs/crowbar.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Crowbar
 After=network.target syslog.target remote-fs.target chef-server.service
-Requires=apache2.service postgresql.service
+Requires=apache2.service
+Wants=postgresql.service
 Before=crowbar-jobs.service
 
 [Service]


### PR DESCRIPTION
**Why is this change necessary?**
With remote postgresql service, it's not possible for crowbar(-jobs) to `Require=` postgresql.

**How does it address the issue?**
Use `Wants=` which is a less strict alternative.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
See systemd docs for more details: https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Wants=