### PR TITLE
upgrade: Remove success indication for crowbar_join run when node is not ready

### DIFF
--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -110,6 +110,9 @@ module Api
       if @node.ready_after_upgrade?
         Rails.logger.info("Initial chef-client run was successful.")
       else
+        # Script -ok file indicates success, but node is in problematic state
+        # so let's remove the indication so the step could be run again
+        @node.delete_script_exit_files("/usr/sbin/crowbar-chef-upgraded.sh")
         Api::Upgrade.raise_node_upgrade_error(
           "Possible error during initial chef-client run at node #{@node.name}. " \
           "Node is currently in state #{@node.state}. " \


### PR DESCRIPTION
It may happen that the script executing crowbar_join succeeded,
although the chef-client run left the node in non-ready state.
In such case, remove the indication, so the step could be restarted,
otherwise it would be skipped during restart.
