### PR TITLE
upgrade: evacuate LBaaSv2 loadbalancers

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -186,6 +186,32 @@ template "/usr/sbin/crowbar-router-migration.sh" do
   action :create
 end
 
+template "/etc/neutron/lbaas-connection.conf" do
+  source "lbaas-connection.conf"
+  mode "0640"
+  owner "root"
+  group "root"
+  action :create
+  variables(
+    lazy do
+      { sql_connection: node[:neutron][:db][:sql_connection] }
+    end
+  )
+  only_if { roles.include? "neutron-network" }
+end
+
+template "/usr/sbin/crowbar-lbaas-evacuation.sh" do
+  source "crowbar-lbaas-evacuation.sh.erb"
+  mode "0755"
+  owner "root"
+  group "root"
+  action :create
+  variables(
+    use_ha: use_ha
+  )
+  only_if { roles.include? "neutron-network" }
+end
+
 has_drbd = use_ha && node.fetch("drbd", {}).fetch("rsc", {}).any?
 
 template "/usr/sbin/crowbar-post-upgrade.sh" do

--- a/chef/cookbooks/crowbar/templates/default/crowbar-lbaas-evacuation.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-lbaas-evacuation.sh.erb
@@ -1,0 +1,51 @@
+#!/bin/bash
+#
+# This script migrates all neutron lbaasv2 loadbalancers from the node
+# that is passed in via the command line argument.
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+hostname=$1
+if [[ "$2" = "delete-ns" ]]; then
+    delete_ns="--delete_namespaces --nosource_agent_restart"
+else
+    delete_ns=""
+fi
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-lbaas-evacuation-failed
+
+if systemctl --quiet is-active  openstack-neutron-lbaasv2-agent.service; then
+    log "Evacuating neutron-lbaasv2-agent on $hostname"
+    use_crm=<%= @use_ha ? "--use_crm" : "" %>
+    /usr/bin/neutron-evacuate-lbaasv2-agent $use_crm $delete_ns \
+        --host $hostname \
+        --config-file /etc/neutron/lbaas-connection.conf \
+        --config-file /etc/neutron/neutron.conf
+
+    ret=$?
+    if [ $ret != 0 ] ; then
+        log "Failed to evacuate lbaasv2 agent on host: $hostname"
+        log $ret > $UPGRADEDIR/crowbar-lbaas-evacuation-failed
+        exit $ret
+    fi
+else
+    log "Nothing to do, openstack-neutron-lbaasv2-agent is not running."
+fi
+
+touch $UPGRADEDIR/crowbar-lbaas-evacuation-ok
+log "$BASH_SOURCE is finished."

--- a/chef/cookbooks/crowbar/templates/default/lbaas-connection.conf
+++ b/chef/cookbooks/crowbar/templates/default/lbaas-connection.conf
@@ -1,0 +1,2 @@
+[database]
+connection = <%= @sql_connection %>

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1100,7 +1100,7 @@ module Api
         save_node_action("evacuating loadbalancers")
         controller.wait_for_script_to_finish(
           "/usr/sbin/crowbar-lbaas-evacuation.sh",
-          timeouts[:router_migration],
+          timeouts[:lbaas_evacuation],
           args
         )
         Rails.logger.info("Migrating loadbalancers away from #{hostname} was successful.")

--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -29,6 +29,7 @@ module Crowbar
         evacuate_host: @timeouts_config[:evacuate_host] || 300,
         chef_upgraded: @timeouts_config[:chef_upgraded] || 900,
         router_migration: @timeouts_config[:router_migration] || 600,
+        lbaas_evacuation: @timeouts_config[:lbaas_evacuation] || 600,
         delete_pacemaker_resources: @timeouts_config[:delete_pacemaker_resources] || 300,
         delete_cinder_services: @timeouts_config[:delete_cinder_services] || 300
       }

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -75,11 +75,7 @@ describe Api::UpgradeController, type: :request do
       allow_any_instance_of(CrowbarService).to receive(
         :prepare_nodes_for_os_upgrade
       ).and_return(true)
-      allow_any_instance_of(Node).to receive(:ssh_cmd).and_return(
-        stdout: "",
-        tderr: "",
-        exit_code: 0
-      )
+      allow_any_instance_of(Node).to receive(:ssh_cmd).and_return([200, {}])
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
@@ -102,6 +98,7 @@ describe Api::UpgradeController, type: :request do
         tderr: "",
         exit_code: 0
       )
+      allow_any_instance_of(Node).to receive(:ssh_cmd).and_return([200, {}])
       allow(Api::Upgrade).to receive(:upgrade_controller_nodes).and_return(true)
       allow(Api::Upgrade).to receive(:upgrade_compute_nodes).and_return(true)
       allow(Api::Upgrade).to receive(:finalize_nodes_upgrade).and_return(true)

--- a/crowbar_framework/spec/lib/crowbar/upgrade_timeouts_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_timeouts_spec.rb
@@ -22,7 +22,7 @@ describe Crowbar::UpgradeTimeouts do
     # Generic checker for all values that should always exists
     [
       :prepare_repositories, :pre_upgrade, :upgrade_os, :post_upgrade,
-      :evacuate_host, :chef_upgraded, :router_migration,
+      :evacuate_host, :chef_upgraded, :router_migration, :lbaas_evacuation,
       :delete_pacemaker_resources, :delete_cinder_services
     ].each do |k|
       expect(values[k]).not_to be_nil
@@ -52,6 +52,7 @@ describe Crowbar::UpgradeTimeouts do
             evacuate_host: 1,
             chef_upgraded: 1,
             router_migration: 1,
+            lbaas_evacuation: 1,
             delete_pacemaker_resources: 1,
             delete_cinder_services: 1
           }


### PR DESCRIPTION
When evacuating the neutron routers from a network node before upgrading
it also evacuate any existing LBaaSv2 load balancers.

This needs: https://github.com/SUSE-Cloud/cookbook-openstack-network/pull/29