### PR TITLE
updater: refresh PTF repository (bsc#1030462) 

### DIFF
--- a/chef/cookbooks/updater/recipes/default.rb
+++ b/chef/cookbooks/updater/recipes/default.rb
@@ -40,6 +40,11 @@ if !node[:updater].key?(:one_shot_run) || !node[:updater][:one_shot_run]
       zypper_command += " --auto-agree-with-licenses"
     end
 
+    execute "refresh PTF repository" do
+      command "zypper --non-interactive --gpg-auto-import-keys refresh -fr PTF"
+      ignore_failure true
+    end
+
     # Butt-ugly, enhance Chef::Provider::Package::Zypper later on...
     ruby_block "running \"#{zypper_command}\"" do
       block do


### PR DESCRIPTION
Force a refresh for the PTF repository in the updater barclamp
before updating, to make sure that PTF packages are picked up
regardless of the minimum repository auto-refresh delay.

Fixes [bsc#1030462](https://bugzilla.suse.com/show_bug.cgi?id=1030462)
