### PR TITLE
Unclaimed disks: improve handling of multipath devices (bsc#1031065)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,26 @@
 language: ruby
 sudo: false
 
-rvm:
-  - 2.1.0
+rvm: 2.1.0
 
-env:
-  - SKIP_CHECKS=yes
+env: SKIP_CHECKS=yes
+
+matrix:
+  include:
+    - gemfile: crowbar_framework/Gemfile
+      script:
+       - cd crowbar_framework
+       - bin/bundle install
+       - bin/rake db:create db:migrate
+       - bundle exec rake spec brakeman:run
+       # ignore rest-client issues, chef 10 requires that
+       - bin/bundle exec bundle-audit update
+       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 OSVDB-117461
+    - gemfile: chef/cookbooks/barclamp/Gemfile
+      script:
+       - cd chef/cookbooks/barclamp && bundle exec rake
 
 addons:
   apt:
     packages:
       - libarchive-dev
-
-gemfile: crowbar_framework/Gemfile
-
-install:
-  - cd crowbar_framework
-  - bin/bundle install
-  - bin/rake db:create db:migrate
-
-script:
-  - bin/rake spec brakeman:run
-
-  # ignore rest-client issues, chef 10 requires that
-  - bin/bundle exec bundle-audit update
-  - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 OSVDB-117461

--- a/chef/cookbooks/barclamp/.rspec
+++ b/chef/cookbooks/barclamp/.rspec
@@ -1,0 +1,2 @@
+--colour
+--format documentation

--- a/chef/cookbooks/barclamp/Gemfile
+++ b/chef/cookbooks/barclamp/Gemfile
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gem "rack", "< 2.0.0"
+gem "rake"
+
+group :test, :development do
+  gem "chefspec", "~> 3.0"
+  gem "rspec-expectations", "~> 2.14.0"
+end

--- a/chef/cookbooks/barclamp/Rakefile
+++ b/chef/cookbooks/barclamp/Rakefile
@@ -1,0 +1,6 @@
+task default: "spec"
+
+task :spec do
+  sh "rspec"
+end
+

--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -150,7 +150,11 @@ module BarclampLibrary
               %x{lsblk #{d.name.gsub(/!/, "/")} --noheadings --output MOUNTPOINT | grep -q -v ^$}
               next if $?.exitstatus == 0
             end
-            d.fixed and not d.claimed?
+            # skip claimed disks and multipath devices held by holders
+            # but include both fixed disks and multipath devices
+            device_type_claimable = d.fixed || d.multipath?
+            in_use = d.claimed? || d.held_by_multipath?
+            device_type_claimable && !in_use
           end
         end
 
@@ -158,6 +162,12 @@ module BarclampLibrary
           all(node).select do |d|
             d.claimed? and d.owner == owner
           end
+        end
+
+        def self.multipath?(device)
+          uuid_path = "/sys/block/#{device}/dm/uuid"
+          return false unless File.exist?(uuid_path)
+          File.open(uuid_path) { |f| f.read(7).start_with?("mpath-") }
         end
 
         # can be /dev/hda, /dev/sda or /dev/cciss/c0d0
@@ -201,6 +211,35 @@ module BarclampLibrary
         def usage
           Chef::Log.error("Usage method for disks is deprecated!  Please update your code to use owner")
           self.owner
+        end
+
+        def multipath?
+          self.class.multipath?(@device)
+        end
+
+        def held_by_multipath?
+          # We need to check if the holders of a device (if it has any)
+          # are multipath-capable, for example:
+          #
+          # root@d52-54-77-77-01-01:~ # multipath -ll
+          # 0QEMU_QEMU_HARDDISK_00002 dm-1 QEMU,QEMU HARDDISK
+          # size=10G features='0' hwhandler='0' wp=rw
+          # -+- policy='service-time 0' prio=1 status=active
+          # - 0:0:0:2 sdc 8:32   active ready running
+          # -+- policy='service-time 0' prio=1 status=enabled
+          # - 0:0:0:3 sdb 8:16   active ready running
+          #
+          # sdb and sdc are paths of dm-1:
+          # root@d52-54-77-77-01-01:~ # ls /sys/block/sdb/holders/
+          # dm-1
+          # root@d52-54-77-77-01-01:~ # ls /sys/block/sdc/holders/
+          # dm-1
+          #
+          # in this case this method should return false for sdb and sdc as we dont want
+          # those disks to appear available, instead we want dm-1 to be made available
+          ::Dir.entries("/sys/block/#{@device}/holders").any? do |holder|
+            self.class.multipath?(holder)
+          end
         end
 
         def fixed

--- a/chef/cookbooks/barclamp/spec/libraries/barclamp_library_spec.rb
+++ b/chef/cookbooks/barclamp/spec/libraries/barclamp_library_spec.rb
@@ -1,0 +1,64 @@
+require "spec_helper"
+
+require_relative "../../libraries/barclamp_library"
+
+describe BarclampLibrary::Barclamp::Inventory::Disk do
+
+  before(:each) do
+    @chef_run = ::ChefSpec::Runner.new
+    @node = @chef_run.node
+    @node.default[:block_device] = {
+      dm0: { removable: "0" },
+      xvd1: { removable: "0" },
+      xvd2: { removable: "1" }
+    }
+  end
+
+  specify "#unclaimed returns the proper number of unclaimed devices" do
+    a = BarclampLibrary::Barclamp::Inventory::Disk
+    expect(a).to receive(:`).exactly(5).times.and_return(`exit 1`)
+    expect(::File).to receive(:exist?).with("/sys/block/dm0/dm/uuid").and_return(true)
+    expect(::File).to receive(:exist?).with("/sys/block/xvd2/dm/uuid").and_return(false)
+    expect(::File).to receive(:exist?).with("/sys/block/sr0/dm/uuid").and_return(false)
+    expect(::File).to receive(:open).exactly(1).times.with(
+      "/sys/block/dm0/dm/uuid"
+    ).and_yield(StringIO.new("mpath-test"))
+    # return holders
+    expect(::Dir).to receive(:entries).exactly(5).times.and_return([])
+    expect(a.unclaimed(@node).length).to eq(3)
+  end
+
+  describe "multipath features" do
+    specify "#multipath? fails with no device given" do
+      expect { BarclampLibrary::Barclamp::Inventory::Disk.multipath? }.to raise_error(ArgumentError)
+    end
+
+    specify "#multipath returns true if it find the mpath device uuid" do
+      expect(::File).to receive(:exist?).exactly(1).times.and_return(true)
+      expect(::File).to receive(:open).exactly(1).times.and_yield(StringIO.new("mpath-"))
+      expect(
+        BarclampLibrary::Barclamp::Inventory::Disk.multipath?("test")
+      ).to be(true)
+    end
+
+    specify "#multipath returns false if it doesnt find the mpath device uuid" do
+      expect(::File).to receive(:exist?).exactly(1).times.and_return(true)
+      expect(::File).to receive(:open).exactly(1).times.and_yield(StringIO.new("uuid"))
+      expect(
+        BarclampLibrary::Barclamp::Inventory::Disk.multipath?("test")
+      ).to be(false)
+    end
+
+    specify "#held_by_multipath? calls multipath? on each holder" do
+      expect(::Dir).to receive(:entries).exactly(1).times.and_return(["subtest1", "subtest2"])
+      expect(
+        BarclampLibrary::Barclamp::Inventory::Disk
+      ).to receive(:multipath?).exactly(1).times.with("subtest1")
+      expect(
+        BarclampLibrary::Barclamp::Inventory::Disk
+      ).to receive(:multipath?).exactly(1).times.with("subtest2")
+      a = BarclampLibrary::Barclamp::Inventory::Disk.new(@node, "test")
+      expect(a.held_by_multipath?).to be(false)
+    end
+  end
+end

--- a/chef/cookbooks/barclamp/spec/spec_helper.rb
+++ b/chef/cookbooks/barclamp/spec/spec_helper.rb
@@ -1,0 +1,50 @@
+require "chefspec"
+
+ENV["RSPEC_RUNNING"] = "true"
+
+RSpec.configure do |config|
+  # config.mock_with :rspec do |mocks|
+  #   # This option should be set when all dependencies are being loaded
+  #   # before a spec run, as is the case in a typical spec helper. It will
+  #   # cause any verifying double instantiation for a class that does not
+  #   # exist to raise, protecting against incorrectly spelt names.
+  #   mocks.verify_doubled_constant_names = true
+  # end
+
+  # Specify the path for Chef Solo to find cookbooks (default: [inferred from
+  # the location of the calling spec file])
+  this_dir = File.dirname(__FILE__)
+  config.cookbook_path = [
+    File.expand_path("../..", this_dir),
+    File.expand_path("fixtures/cookbooks", this_dir),
+  ]
+
+  # Specify the path for Chef Solo to find roles (default: [ascending search])
+  # config.role_path = '/var/roles'
+
+  # Specify the Chef log_level (default: :warn)
+  config.log_level = ENV["CHEF_LOG_LEVEL"].to_sym if ENV["CHEF_LOG_LEVEL"]
+
+  # Specify the path to a local JSON file with Ohai data (default: nil)
+  # config.path = 'ohai.json'
+
+  # Specify the operating platform to mock Ohai data from (default: nil)
+  config.platform = "suse"
+
+  # Specify the operating version to mock Ohai data from (default: nil)
+  config.version = "12.2"
+
+  # Disable deprecated "should" syntax
+  # https://github.com/rspec/rspec-expectations/blob/master/Should.md
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+
+  config.run_all_when_everything_filtered = true
+  config.filter_run focus: true
+end
+
+if ENV["RUBYDEPS"]
+  require "rubydeps"
+  Rubydeps.start
+end


### PR DESCRIPTION
dm_multipath devices were being skipped while its paths were being included
in the array of unclaimed devices, allowing the DRBD recipe to claim them
and later fail while running pvcreate.

Introduce two new methods in Disk for checking whether the device (or its
holder) is named as "mpath-*".