### PR TITLE
upgrade: Fix prechecks after prepare

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -202,10 +202,12 @@ module Api
 
           # So lbaas v1 is configured, let's find out if it is actually used
           neutron = NodeObject.find("roles:neutron-server").first
-          out = neutron.run_ssh_cmd(
-            "source /root/.openrc; neutron lb-pool-list -f value -c id"
-          )
-          ret[:lbaas_v1] = true unless out[:stdout].nil? || out[:stdout].empty?
+          unless neutron.nil?
+            out = neutron.run_ssh_cmd(
+              "source /root/.openrc; neutron lb-pool-list -f value -c id"
+            )
+            ret[:lbaas_v1] = true unless out[:stdout].nil? || out[:stdout].empty?
+          end
         end
         ret
       end


### PR DESCRIPTION
**Why is this change necessary?**
After prepare call, nodes can't be found using roles anymore. Some of the prechecks which rely on this are not prepared to not find the nodes they expect.

**How does it address the issue?**
Code relying on nodes found by role is guarded with additional condition.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
Problem was reported in commends under https://bugzilla.suse.com/show_bug.cgi?id=1032377