### PR TITLE
upgrade: Log api exceptions to production.log

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -56,6 +56,7 @@ class Api::UpgradeController < ApiController
   def prechecks
     render json: Api::Upgrade.checks
   rescue StandardError => e
+    log_exception(e)
     render json: {
       errors: {
         prechecks: {
@@ -89,6 +90,7 @@ class Api::UpgradeController < ApiController
       }
     }, status: :locked
   rescue StandardError => e
+    log_exception(e)
     render json: {
       errors: {
         cancel: {
@@ -114,8 +116,17 @@ class Api::UpgradeController < ApiController
     else
       render json: check
     end
-  rescue Crowbar::Error::UpgradeError,
-         StandardError => e
+  rescue Crowbar::Error::UpgradeError => e
+    render json: {
+      errors: {
+        repocheck_crowbar: {
+          data: e.message,
+          help: I18n.t("api.upgrade.adminrepocheck.help.default")
+        }
+      }
+    }, status: :unprocessable_entity
+  rescue StandardError => e
+    log_exception(e)
     render json: {
       errors: {
         repocheck_crowbar: {


### PR DESCRIPTION
**Why is this change necessary?**
Exceptions are caught in api endpoints to return proper json responses instead of default 500.html. This disables default exception handling and doesn't log the backtraces to production.log.

**How does it address the issue?**
The backtraces need to be manualy logged to not lose this information. Already existing function log_exception() was used for logging.
