### PR TITLE
apache: Set timeout to 3600 to sync with the common crowbar timeout

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-rails.conf.partial.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-rails.conf.partial.erb
@@ -1,3 +1,3 @@
-ProxyPass / http://127.0.0.1:<%= @port %>/ timeout=1500 Keepalive=On
+ProxyPass / http://127.0.0.1:<%= @port %>/ timeout=3600 Keepalive=On
 ProxyPassReverse / http://127.0.0.1:<%= @port %>/
 SetEnv proxy-initial-not-pooled 1

--- a/configs/crowbar-rails.conf.partial
+++ b/configs/crowbar-rails.conf.partial
@@ -1,3 +1,3 @@
-ProxyPass / http://127.0.0.1:3000/ timeout=1500 Keepalive=On
+ProxyPass / http://127.0.0.1:3000/ timeout=3600 Keepalive=On
 ProxyPassReverse / http://127.0.0.1:3000/
 SetEnv proxy-initial-not-pooled 1


### PR DESCRIPTION
**Why is this change necessary?**

At the moment we have several different timeouts in crowbar (apache, pume, old CLI, new CLI).

**How does it address the issue?**

Syncing the timeout to one common timeout (60min).

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**

https://github.com/SUSE-Cloud/automation/pull/1859
