### PR TITLE
Revert wicked ifreload related changes (bsc#1032751)

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -518,7 +518,6 @@ when "suse"
         nic: nic,
         pre_up_script: pre_up_script
       })
-      notifies :create, "ruby_block[wicked-ifreload-required]", :immediately
     end
     if ifs[nic.name]["gateway"]
       template "/etc/sysconfig/network/ifroute-#{nic.name}" do
@@ -527,42 +526,12 @@ when "suse"
                     interfaces: ifs,
                     nic: nic
                   })
-        notifies :create, "ruby_block[wicked-ifreload-required]", :immediately
       end
     else
       file "/etc/sysconfig/network/ifroute-#{nic.name}" do
         action :delete
       end
     end
-  end
-
-  run_wicked_ifreload = false
-
-  # This, when notified by the above "ifcfg" templates, sets run_wicked_ifreload
-  # to true (which was initialized to false in the compile phase).
-  # run_wicked_ifreload is later used as a "only_if" guard for the
-  # "wicked ifreload all" call that is needs to happen when any of the config
-  # files got updated. The purpose of doing it this way (instead of notifying the
-  # "wicked-ifreload-all" resource directly), is to make sure that the
-  # ifrelaod is only run once after all ifcfg file have been update and
-  # independent of how many of them were changed.
-  ruby_block "wicked-ifreload-required" do
-    block do
-      run_wicked_ifreload = true
-    end
-    action :nothing
-  end
-
-  bash "wicked-ifreload-all" do
-    action :run
-    code <<-EOF
-      wicked ifcheck --changed --quiet all
-      rc=$?
-      if [[ $rc != 0 ]]; then
-        wicked ifreload all
-      fi
-    EOF
-    only_if { run_wicked_ifreload }
   end
 
   # Avoid running the wicked related thing on SLE11 nodes


### PR DESCRIPTION
Calling ifreload here seems to have been a bad idea as it cause various
issue in HA setups:
- pacemaker mananged VIPs assigned to any of the reloaded interfaces are
  temporary lost, Causing resource failures in the cluster.
- reloading an interface causes a small network outage that can
  de-stabilize the cluster, leading to fenced nodes and other bad
  things.

https://bugzilla.suse.com/show_bug.cgi?id=1032751
(cherry picked from commit 41e310cf21642cf0dc2f2fa0b7294c1db7821b59)