### PR TITLE
upgrade: After changing node state to ready, wait for nova-compute to start

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -6,8 +6,8 @@ module Crowbar
       @timeouts_config = begin
         YAML.load_file("/etc/crowbar/upgrade_timeouts.yml")
       rescue
-        Rails.logger.info(
-          "No user provided upgraed timeouts, proceeding with the default ones."
+        Rails.logger.debug(
+          "No user provided upgrade timeouts, proceeding with the default ones."
         )
         {}
       end
@@ -31,7 +31,8 @@ module Crowbar
         router_migration: @timeouts_config[:router_migration] || 600,
         lbaas_evacuation: @timeouts_config[:lbaas_evacuation] || 600,
         delete_pacemaker_resources: @timeouts_config[:delete_pacemaker_resources] || 300,
-        delete_cinder_services: @timeouts_config[:delete_cinder_services] || 300
+        delete_cinder_services: @timeouts_config[:delete_cinder_services] || 300,
+        wait_until_compute_started: @timeouts_config[:wait_until_compute_started] || 60
       }
     end
   end


### PR DESCRIPTION
It takes some time before nova-compute finishes starting.
So let's wait until we know it is running before proceeding with next
live-migration.

Followup after https://github.com/crowbar/crowbar-core/pull/1181
