### PR TITLE
upgrade: Download the latest crowbar_join from the server

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -233,5 +233,7 @@ template "/usr/sbin/crowbar-chef-upgraded.sh" do
   mode "0775"
   owner "root"
   group "root"
-  action :create
+  variables(
+    crowbar_join: "#{web_path}/crowbar_join.sh"
+  )
 end

--- a/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
@@ -26,8 +26,12 @@ if [[ -f $UPGRADEDIR/crowbar-chef-upgraded-ok ]] ; then
     exit 0
 fi
 
+# Download the latest crowbar-join from the server
+curl -s -o /usr/sbin/crowbar_join_tmp <%= @crowbar_join %>
+
 # Move node to ready state and execute chef-client for the first time
-crowbar_join --start
+chmod +x /usr/sbin/crowbar_join_tmp
+/usr/sbin/crowbar_join_tmp --start
 
 ret=$?
 if [ $ret != 0 ] ; then
@@ -35,6 +39,8 @@ if [ $ret != 0 ] ; then
     echo $ret > $UPGRADEDIR/crowbar-chef-upgraded-failed
     exit $ret
 fi
+
+rm -f /usr/sbin/crowbar_join_tmp
 
 systemctl start cron
 systemctl enable cron


### PR DESCRIPTION
Download and execute latest crowbar_join from the provisioner server
so it is not rewritten during chef-client run.
