### PR TITLE
upgrade: Do not skip non-kvm nodes

### DIFF
--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -512,7 +512,7 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to receive(:do_controllers_substep).and_return(true)
 
       allow(Node).to(
-        receive(:find).with("roles:nova-compute-kvm").and_return([node1, node2])
+        receive(:find).with("roles:nova-compute-*").and_return([node1, node2])
       )
 
       # parallel_upgrade_compute_nodes:


### PR DESCRIPTION
When non-kvm compute nodes do not have other role
(that would group them with 'controller' or 'other' nodes)
we need to remember to upgrade them during compute_nodes substep.

We didn't see this before probably because xen nodes in other tests had some additional role, so they were upgraded before the real compute_nodes substep (which is not a problem in "normal" mode).