### PR TITLE
Fix node bulk edit to save only the changed nodes (bsc#1008838)

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -139,7 +139,7 @@ class NodesController < ApplicationController
               dirty = true
             end
 
-            unless is_allocated
+            unless is_allocated || node.admin?
               unless node.target_platform == node_attributes["target_platform"]
                 node.target_platform = node_attributes["target_platform"]
                 dirty = true
@@ -156,9 +156,11 @@ class NodesController < ApplicationController
               dirty = true
             end
 
-            unless node.public_name == node_attributes["public_name"]
-              node.force_public_name = node_attributes["public_name"]
-              dirty = true
+            unless node.public_name.blank? && node_attributes["public_name"].blank?
+              unless node.public_name == node_attributes["public_name"]
+                node.force_public_name = node_attributes["public_name"]
+                dirty = true
+              end
             end
 
             unless node.intended_role == node_attributes["intended_role"]


### PR DESCRIPTION
We were not excluding the admin node from the target_platform and license_key checks as
it doesnt have an allocated value sent on POST.
Also, we didnt check for a blank value (nil or empty or "") in the public_name values.
Both of this issues triggered a save of all nodes, even if the values were the same.
