### PR TITLE
puma: Disable puma_worker_killer reaper logs

### DIFF
--- a/crowbar_framework/config/initializers/puma_worker_killer.rb
+++ b/crowbar_framework/config/initializers/puma_worker_killer.rb
@@ -4,5 +4,6 @@ PumaWorkerKiller.config do |config|
   config.frequency     = 60 # checking frequency in seconds
   config.percent_usage = 0.98 # RAM utilization
   config.rolling_restart_frequency = 60 * 60 * 12 # 12 hours in seconds
-  config.reaper_status_logs = true # enable logging
+  config.reaper_status_logs = false # setting this to false will not log lines like:
+  # PumaWorkerKiller: Consuming 100 mb with master and 2 workers.
 end


### PR DESCRIPTION
This change disables the puma reaper logs which look like
`PumaWorkerKiller: Consuming 100 mb with master and 2 workers.`.