### PR TITLE
crowbar: Ensure run_list is how we want it to be

### DIFF
--- a/crowbar_framework/app/models/node_object.rb
+++ b/crowbar_framework/app/models/node_object.rb
@@ -706,21 +706,25 @@ class NodeObject < ChefObject
   end
 
   def add_to_run_list(rolename, priority, states = nil)
-    states = ["all"] unless states
-    crowbar["run_list_map"] = {} if crowbar["run_list_map"].nil?
-    val = { "states" => states, "priority" => priority }
-    crowbar["run_list_map"][rolename] = val
-    Rails.logger.debug("crowbar[run_list_map][#{rolename}] = #{val.inspect}")
-    Rails.logger.debug("current state is #{self.crowbar['state']}")
+    Rails.logger.debug("Ensuring #{name} has role #{rolename} with priority #{priority}")
+    save_it = false
 
-    # only rebuild the run_list if it effects the current state.
-    self.rebuild_run_list if states.include?("all") or states.include?(self.crowbar["state"])
+    crowbar["run_list_map"] ||= {}
+    if crowbar["run_list_map"][rolename] != { "priority" => priority }
+      crowbar["run_list_map"][rolename] = { "priority" => priority }
+      save_it = true
+    end
+    rebuild_run_list || save_it
   end
 
   def delete_from_run_list(rolename)
-    crowbar["run_list_map"] = {} if crowbar["run_list_map"].nil?
-    crowbar["run_list_map"][rolename] = { "states" => ["all"], "priority" => -1001 } unless crowbar["run_list_map"].nil?
-    crowbar_run_list.run_list_items.delete "role[#{rolename}]"
+    Rails.logger.debug("Ensuring #{name} doesn't have role #{rolename}")
+    crowbar["run_list_map"] ||= {}
+    if crowbar["run_list_map"].key?(rolename)
+      crowbar["run_list_map"].delete(rolename)
+      save_it = true
+    end
+    rebuild_run_list || save_it
   end
 
   def rebuild_run_list
@@ -740,12 +744,16 @@ class NodeObject < ChefObject
     end
     Rails.logger.debug("rebuilt run_list will be #{vals.inspect}")
 
+    old_run_list = crowbar_run_list.run_list_items.dup
+
     # Rebuild list
     crowbar_run_list.run_list_items.clear
     vals.each do |item|
       next if item[1]["priority"] == -1001 # Skip deleted items
       crowbar_run_list.run_list_items << "role[#{item[0]}]"
     end
+
+    old_run_list != crowbar_run_list.run_list_items
   end
 
   def run_list_to_roles

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1088,9 +1088,7 @@ class ServiceObject
 
             # An old node that is not in the new deployment, drop it
             unless new_nodes.include?(node_name)
-              @logger.debug "remove node #{node_name}"
-              pending_node_actions[node_name] = { remove: [], add: [] } if pending_node_actions[node_name].nil?
-
+              pending_node_actions[node_name] ||= { remove: [], add: [] }
               pending_node_actions[node_name][:remove] << role_name
 
               # Remove roles are  a way to "de-configure" things on the node
@@ -1138,12 +1136,9 @@ class ServiceObject
 
             all_nodes << node_name unless all_nodes.include?(node_name)
 
-            # A new node that we did not know before
-            unless old_nodes.include?(node_name)
-              @logger.debug "add node #{node_name}"
-              pending_node_actions[node_name] = { remove: [], add: [] } if pending_node_actions[node_name].nil?
-              pending_node_actions[node_name][:add] << role_name
-            end
+            pending_node_actions[node_name] ||= { remove: [], add: [] }
+            pending_node_actions[node_name][:add] << role_name
+
             nodes_in_batch << node_name unless nodes_in_batch.include?(node_name)
           end
         end
@@ -1232,40 +1227,22 @@ class ServiceObject
 
       # Remove the roles being lost
       rlist.each do |item|
-        next unless node.role? item
-        @logger.debug("AR: Removing role #{item} to #{node.name}")
-        node.delete_from_run_list item
-        save_it = true
+        save_it = node.delete_from_run_list(item) || save_it
       end
 
       # Add the roles being gained
       alist.each do |item|
-        next if node.role? item
         priority = runlist_priority_map[item] || local_chef_order
-        @logger.debug("AR: Adding role #{item} to #{node.name} with priority #{priority}")
-        node.add_to_run_list(item, priority, role_map[item])
-        save_it = true
+        save_it = node.add_to_run_list(item, priority) || save_it
       end
 
       # Make sure the config role is on the nodes in this barclamp, otherwise
       # remove it
-      # FIXME: All nodes is basically all new nodes, which should have an
-      # add/remove list, why do we need to add specifically the passed role?
       if all_nodes.include?(node.name)
-        # Add the config role
-        unless node.role?(role.name)
-          priority = runlist_priority_map[role.name] || local_chef_order
-          @logger.debug("AR: Adding role #{role.name} to #{node.name} with priority #{priority}")
-          node.add_to_run_list(role.name, priority, role_map[role.name])
-          save_it = true
-        end
+        priority = runlist_priority_map[role.name] || local_chef_order
+        save_it = node.add_to_run_list(role.name, priority) || save_it
       else
-        # Remove the config role
-        if node.role?(role.name)
-          @logger.debug("AR: Removing role #{role.name} to #{node.name}")
-          node.delete_from_run_list role.name
-          save_it = true
-        end
+        save_it = node.delete_from_run_list(role.name) || save_it
       end
 
       @logger.debug("AR: Saving node #{node.name}") if save_it
@@ -1435,8 +1412,7 @@ class ServiceObject
         # apply_role_pre_chef_call
         pre_cached_nodes[node_name] ||= NodeObject.find_node_by_name(node_name)
         node = pre_cached_nodes[node_name]
-        node.delete_from_run_list(role_to_remove)
-        node.save
+        node.save if node.delete_from_run_list(role_to_remove)
       end
     end
 
@@ -1506,15 +1482,8 @@ class ServiceObject
     end
 
     save_it = false
-    unless node.role?(newrole)
-      node.add_to_run_list(newrole, local_chef_order, role_map[newrole])
-      save_it = true
-    end
-
-    unless node.role?("#{barclamp}-config-#{instance}")
-      node.add_to_run_list("#{barclamp}-config-#{instance}", local_chef_order)
-      save_it = true
-    end
+    save_it = node.add_to_run_list(newrole, local_chef_order) || save_it
+    save_it = node.add_to_run_list("#{barclamp}-config-#{instance}", local_chef_order) || save_it
 
     if save_it
       @logger.debug("saving node")


### PR DESCRIPTION
When we add a role to a node, we need the role in the run_list_map and
in the run_list, but if it was in one or the other, we were not doing
anything. This resulted in semi-broken setups (which could happen due to
crashes, or manual editing) not getting fixed when re-applying a
barclamp.

Now, when we change the run_list, we really ensure that it's how we want
it to be.

(cherry picked from commit b341f0b9b7ec70e6b2131f94ef3f39e6da60a89b)