### PR TITLE
upgrade: Make sure to upgrade all nodes in normal node

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1154,11 +1154,7 @@ module Api
       # This has to be done before compute nodes upgrade, so the live migration
       # can use fully upgraded cinder stack.
       def upgrade_non_compute_nodes
-        # For :normal mode, there should be no node left in the phase
-        # All of such nodes should be upgraded during the first round when we were upgrading
-        # by the barclamps order.
-        return if upgrade_mode == :normal
-        ::Node.find("state:crowbar_upgrade AND NOT run_list_map:nova-compute-kvm").each do |node|
+        ::Node.find("state:crowbar_upgrade AND NOT run_list_map:nova-compute-*").each do |node|
           upgrade_one_node node.name
         end
         save_nodes_state([], "", "")

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -621,7 +621,7 @@ describe Api::Upgrade do
       # upgrade_non_compute_nodes:
       allow(Node).to(
         receive(:find).with(
-          "state:crowbar_upgrade AND NOT run_list_map:nova-compute-kvm"
+          "state:crowbar_upgrade AND NOT run_list_map:nova-compute-*"
         ).and_return([ceph, testing])
       )
       allow_any_instance_of(Api::Node).to receive(:save_node_state).with(


### PR DESCRIPTION
**Why is this change necessary?**

We've met some situations where the node was not upgraded during the controller phase, but was also missing nova-compute role. The effect was that such node was not upgraded at all.

UPDATE: Bug 1035528 is dedicated to this situation I was referring to
