### PR TITLE
dns: Disable domain field in UI (bsc#1033537)

### DIFF
--- a/crowbar_framework/app/views/barclamp/dns/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/dns/_edit_attributes.html.haml
@@ -3,7 +3,14 @@
     = header show_raw_deployment?, true
 
   .panel-body
-    = string_field :domain
+
+    %fieldset
+    - if @proposal.active?
+      = string_field :domain, :disabled => "disabled"
+      .alert.alert-info
+        = t('.domain_hint')
+    - else
+      = string_field :domain
 
     %fieldset
       %legend

--- a/crowbar_framework/config/locales/dns/en.yml
+++ b/crowbar_framework/config/locales/dns/en.yml
@@ -20,6 +20,7 @@ en:
     dns:
       edit_attributes:
         domain: 'Domain'
+        domain_hint: 'Changing the domain after initial deployment is not supported.'
         ip_list_hint: 'A comma-separated list of IP Addresses'
         server_hint: 'At least one nameserver or one node with the dns-server role must be specified.'
 


### PR DESCRIPTION
The domain field should not be changed after deployment. Chef uses this
field to identify nodes, including the admin node, and changing it
causes crowbar and chef to be able to unable to fetch data about a node.
This changes makes the field in the DNS barclamp UI disabled and adds a
note about it to discourage trying to make this change.