### PR TITLE
dashboard: Show a warning when the product is EOL

### DIFF
--- a/crowbar_framework/config/branding.yml
+++ b/crowbar_framework/config/branding.yml
@@ -1,5 +1,5 @@
 # Copyright 2011-2013, Dell
-# Copyright 2013-2015, SUSE LINUX GmbH
+# Copyright 2013-2017, SUSE LINUX GmbH
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,3 +34,6 @@ provider: '<a href="https://crowbar.github.io/" target="_blank">Crowbar</a>'
 
 # The favicon that gets displayed on all pages.
 favicon: ''
+
+# The EOL date
+eol_date: ''

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -40,6 +40,7 @@ en:
       dependencies: 'Dependencies'
       nodes: 'Nodes'
       deploy_queue_empty: 'The deployment queue is currently empty.'
+
   dashboard:
     role:
       nodes: 'Nodes'
@@ -65,6 +66,7 @@ en:
       extended_clusters:
         one: 'There is %{count} cluster available in the system'
         other: 'There are %{count} clusters available in the system'
+    eol: 'This version of %{product} is out of general support since %{date}.'
 
   nav:
     nodes:
@@ -834,9 +836,9 @@ en:
         ceph_not_healthy:
           error: |
             Ceph cluster health check has failed with:
-            
+
             %{error}
-                       
+
             Make sure cluster is healthy before proceeding with the upgrade.
           help: 'Refer to the SUSE Enterprise Storage documentation for possible troubleshooting.'
         ceph_old_version:


### PR DESCRIPTION
When the product is EOL we should warn the customer that the product is
EOL and out of support.
