### PR TITLE
chef: Fix chef-solr downgrade migration (bsc#1037784)

### DIFF
--- a/chef/data_bags/crowbar/migrate/crowbar/102_chef-solr.rb
+++ b/chef/data_bags/crowbar/migrate/crowbar/102_chef-solr.rb
@@ -12,14 +12,6 @@ def upgrade(ta, td, a, d)
 end
 
 def downgrade(ta, td, a, d)
-  unless ta["chef"].key?("solr_heap")
-    a.delete["chef"]["solr_heap"]
-  end
-  unless ta["chef"].key?("solr_tmpfs")
-    a.delete["chef"]["solr_tmpfs"]
-  end
-  unless ta["chef"]
-    a.delete["chef"]
-  end
+  a.delete("chef") unless ta.key?("chef")
   return a, d
 end


### PR DESCRIPTION
We can delete the chef element directly as we add it this migration,
there is no need to delete the other elements first. Also the syntax was
wrong.