### PR TITLE
provisioner: Don't crash if a node is moved past discovery without an admin IP address

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -257,7 +257,6 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
       os = node[:provisioner][:default_os]
     end
 
-    node_ip = Barclamp::Inventory.get_network_by_type(mnode, "admin").address
     boot_device = mnode.fetch(:crowbar_wall, {})[:boot_device]
 
     append << node[:provisioner][:available_oses][os][arch][:append_line]
@@ -372,7 +371,7 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
           boot_device: boot_device,
           raid_type: (mnode[:crowbar_wall][:raid_type] || "single"),
           raid_disks: (mnode[:crowbar_wall][:raid_disks] || []),
-          node_ip: node_ip,
+          node_ip: admin_ip_address,
           node_fqdn: mnode[:fqdn],
           node_hostname: mnode[:hostname],
           platform: target_platform_distro,

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -249,7 +249,12 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
   initrd = "initrd0.img"
   kernel = "vmlinuz0"
 
-  if new_group == "os_install"
+  if new_group == "os_install" && admin_data_net.nil?
+    Chef::Log.warn("#{mnode[:fqdn]}: no admin IP address allocated; " \
+                    "not proceeding with install process!")
+  end
+
+  if new_group == "os_install" && !admin_data_net.nil?
     # This eventually needs to be configurable on a per-node basis
     # We select the os based on the target platform specified.
     os = mnode[:target_platform]

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -235,6 +235,20 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
     end
   end
 
+  # Provide sane defaults (ie, discovery mode) for generating boot files.
+  # This makes it possible for nodes marked for installation to go back to
+  # discovery and follow (nearly) the whole process again, in case the install
+  # files cannot be generated due to some error that happened during discovery.
+  # Downside is that this may look like a discovery/reboot loop, but that's
+  # better than crashing chef on the admin server.
+  append_line = "#{node[:provisioner][:sledgehammer_append_line]} crowbar.hostname=#{mnode[:fqdn]} crowbar.state=#{new_group}"
+  install_name = new_group
+  install_label = "Crowbar Discovery Image (#{new_group})"
+  relative_to_pxelinux = "../"
+  relative_to_tftpboot = "discovery/#{arch}/"
+  initrd = "initrd0.img"
+  kernel = "vmlinuz0"
+
   if new_group == "os_install"
     # This eventually needs to be configurable on a per-node basis
     # We select the os based on the target platform specified.
@@ -434,16 +448,6 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
     relative_to_tftpboot = ""
     initrd = node[:provisioner][:available_oses][os][arch][:initrd]
     kernel = node[:provisioner][:available_oses][os][arch][:kernel]
-
-  else
-
-    append_line = "#{node[:provisioner][:sledgehammer_append_line]} crowbar.hostname=#{mnode[:fqdn]} crowbar.state=#{new_group}"
-    install_name = new_group
-    install_label = "Crowbar Discovery Image (#{new_group})"
-    relative_to_pxelinux = "../"
-    relative_to_tftpboot = "discovery/#{arch}/"
-    initrd = "initrd0.img"
-    kernel = "vmlinuz0"
 
   end
 


### PR DESCRIPTION
If the IP range for the admin network is too small, then an allocated node may not get an admin IP address. In that case, we should not crash (current behavior), nor should we proceed with the installation process.

Instead, we re-run discovery for that node to get that fixed (this will be fixed eventually, if a free IP address appears).