### PR TITLE
bind: set transfer-source to avoid xfer failures (bsc#1036601)

### DIFF
--- a/chef/cookbooks/bind9/templates/default/named.conf.default-zones.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.default-zones.erb
@@ -9,6 +9,7 @@ zone "0.in-addr.arpa" {
 <% else -%>
         type slave;
         masters { <%= @master_ip -%>; };
+        transfer-source <%= @admin_addr -%>;
         file "/etc/bind/slave/db.0";
 <% end %>
 };
@@ -20,6 +21,7 @@ zone "255.in-addr.arpa" {
 <% else -%>
         type slave;
         masters { <%= @master_ip -%>; };
+        transfer-source <%= @admin_addr -%>;
         file "/etc/bind/slave/db.255";
 <% end %>
 };

--- a/chef/cookbooks/bind9/templates/default/zone.erb
+++ b/chef/cookbooks/bind9/templates/default/zone.erb
@@ -13,6 +13,7 @@ zone "<%= zonefile_entry -%>" {
     type slave;
     notify no;
     masters { <%= @master_ip -%>; };
+    transfer-source <%= @admin_addr -%>;
     file "/etc/bind/slave/db.<%= zonefile_entry -%>";
 };
 <%   end %>


### PR DESCRIPTION
Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**
http://bugzilla.suse.com/show_bug.cgi?id=1036601

**How does it address the issue?**
Tells bind to use the admin IP as source for zone transfers, even if VIPs from pacemaker are the primary addr at the moment.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
