### PR TITLE
network: Use wicked to control bond slaves (bsc#1035127)

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -566,7 +566,6 @@ class ::Nic
       usurp(slave)
       slave.down
       sysfs_put("bonding/slaves","+#{slave}")
-      slave.up
       slave
     end
 

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -209,6 +209,12 @@ sorted_networks.each do |network|
     ifs[bond.name]["addresses"] ||= Array.new
     ifs[bond.name]["slaves"] = Array.new
     base_ifs.each do |i|
+      # If the slave isn't already a member of this bond, it may be configured
+      # with an IP or DHCP, and we don't want wicked to re-apply it when the
+      # interface is brought back up.
+      unless bond.slaves.include? i
+        ::Kernel.system("wicked ifdown #{i.name}")
+      end
       bond.add_slave i
       ifs[bond.name]["slaves"] << i.name
       ifs[i.name]["slave"] = true
@@ -565,7 +571,9 @@ when "suse"
         nic: nic,
         pre_up_script: pre_up_script
       })
+      notifies :create, "ruby_block[wicked-ifup-required]", :immediately
     end
+
     if ifs[nic.name]["gateway"]
       template "/etc/sysconfig/network/ifroute-#{nic.name}" do
         source "suse-route.erb"
@@ -579,6 +587,30 @@ when "suse"
         action :delete
       end
     end
+  end
+
+  run_wicked_ifup = false
+
+  # This, when notified by the above "ifcfg" templates, sets run_wicked_ifup
+  # to true (which was initialized to false in the compile phase).
+  # run_wicked_ifup is later used as an "only_if" guard for the
+  # "wicked ifup all" call that is needs to happen when any of the config
+  # files got updated. The purpose of doing it this way (instead of notifying
+  # the "wicked-ifup-all" resource directly), is to make sure that the
+  # ifup is only run once after all ifcfg file have been updated and
+  # independent of how many of them were changed.
+  ruby_block "wicked-ifup-required" do
+    block do
+      run_wicked_ifup = true
+    end
+    action :nothing
+  end
+
+  # Mark all configured interfaces as up, so wicked will keep them that way.
+  bash "wicked-ifup-all" do
+    action :run
+    code "wicked ifup all"
+    only_if { run_wicked_ifup }
   end
 
   # Avoid running the wicked related thing on SLE11 nodes


### PR DESCRIPTION
Currently, when adding slaves to a bond, the interface will be brought
down and then back up. If wicked is not told about this state of
affairs, wicked will add the configured IP address back onto the
interface when it is bought back up.
    
To counteract this, we run wicked ifdown for any slave interface, and
then run wicked ifup once the template files have been written.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
