### PR TITLE
crowbar: use the default cookbook path in the knife.rb file

### DIFF
--- a/chef/cookbooks/crowbar/files/default/knife.rb
+++ b/chef/cookbooks/crowbar/files/default/knife.rb
@@ -1,2 +1,3 @@
 node_name "chef-webui"
 client_key "/etc/chef/webui.pem"
+cookbook_path ["/opt/dell/chef/cookbooks"]


### PR DESCRIPTION
Just a small QOL patch.

Before we would need to specify with the "-o" option
the full path to the cookbook location in the local machine
when dealing with cookbook uploads.
As this location is fixed, we can just add it to the knife.rb
file and avoid specifying it.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.