### PR TITLE
crowbar: Fix re-running chef after failure in apply_role for admin nodes

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1372,7 +1372,7 @@ class ServiceObject
         admin_list.each do |node|
           filename = "#{ENV['CROWBAR_LOG_DIR']}/chef-client/#{node}.log"
           pid = run_remote_chef_client(node, "chef-client", filename)
-          pids[node] = pid
+          pids[pid] = node
         end
         status = Process.waitall
         badones = status.select { |x| x[1].exitstatus != 0 }


### PR DESCRIPTION
When a chef call fails in apply_role, we try a second time to run chef.
However, for admin nodes, we were not remembering the pid/host pair
correctly, resulting in the second chef call to be invalid (for no
host).

This resulted in the creation of /var/log/crowbar/chef-client/.log,
which is a long-standing bug.
