### PR TITLE
crowbar: Call chef-client instead of single_chef_client.sh on apply

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1371,7 +1371,7 @@ class ServiceObject
         )
         admin_list.each do |node|
           filename = "#{ENV['CROWBAR_LOG_DIR']}/chef-client/#{node}.log"
-          pid = run_remote_chef_client(node, Rails.root.join("..", "bin", "single_chef_client.sh").expand_path.to_s, filename)
+          pid = run_remote_chef_client(node, "chef-client", filename)
           pids[node] = pid
         end
         status = Process.waitall
@@ -1383,7 +1383,7 @@ class ServiceObject
               node = pids[baddie[0]]
               @logger.warn("Re-running chef-client (admin) again for a failure: #{node} #{@bc_name} #{inst}")
               filename = "#{ENV['CROWBAR_LOG_DIR']}/chef-client/#{node}.log"
-              pid = run_remote_chef_client(node, Rails.root.join("..", "bin", "single_chef_client.sh").expand_path.to_s, filename)
+              pid = run_remote_chef_client(node, "chef-client", filename)
               pids[pid] = node
             end
             status = Process.waitall


### PR DESCRIPTION
For admin nodes, we were calling single_chef_client.sh. The problem is
that this calls looper_chef_client.sh and can enter a never-ending loop
if looper_chef_client.sh was not run before, or if
/var/run/crowbar/looper-chef-client.lock is not existing. The latter
condition is true whenever the crowbar service is restarted.

This basically means that if applying a proposal that involves the admin
server after the crowbar service has been restarted, we can have this
block for quite some time.

It turns out that we don't need to call single_chef_client.sh anymore
and can use chef-client directly instead: single_chef_client.sh was
created in the days where chef had no locking to avoid concurrent runs,
since the admin server had some other chef runs started by crowbar (on
transitions, for instance). This has been fixed since a long time now,
so there's no reason to continue this.

This was fixed in master with afe7d80e0ed6b6af7fae7f95893ae40712bb8b79
already, but cherry-picking this results in lots of conflicts due to
other changes that we can't backport at the moment. Instead of an
unclean cherry-pick, we go for the easy patch in case we decide to
backport other changes later on too.