### PR TITLE
network: Also remove optional keys during downgrade

### DIFF
--- a/chef/data_bags/crowbar/migrate/network/101_add_bonding_miimon_xmit_hash_policy.rb
+++ b/chef/data_bags/crowbar/migrate/network/101_add_bonding_miimon_xmit_hash_policy.rb
@@ -15,5 +15,9 @@ def downgrade(ta, td, a, d)
   unless ta["teaming"].key? "xmit_hash_policy"
     a["teaming"].delete "xmit_hash_policy"
   end
+  a["conduit_map"].each do |conduit|
+    a["conduit_map"][conduit].delete "team_miimon"
+    a["conduit_map"][conduit].delete "team_xmit_hash_policy"
+  end
   return a, d
 end


### PR DESCRIPTION
When downgrading the schema after applying xmit_hash_policy, we should
iterate over the conduits defined and remove team_miimon and
team_xmit_hash_policy if they exist.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

I'm not 100% certain it is, but it addresses a bug in the original migration as it landed.

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
