### PR TITLE
crowbar: Change version to 5.0

### DIFF
--- a/crowbar_framework/config/crowbar.env
+++ b/crowbar_framework/config/crowbar.env
@@ -1,4 +1,4 @@
-export CROWBAR_VERSION=4.0
+export CROWBAR_VERSION=5.0
 export CROWBAR_LOG_DIR=/var/log/crowbar
 
 export CHEF_CLIENT_KEY=/opt/dell/crowbar_framework/config/client.pem


### PR DESCRIPTION
Crowbar 5.0 development started, which will be shipped in Cloud 8.
