### PR TITLE
Remove SES5 references; support SES4 which is based on SP2.

### DIFF
--- a/crowbar_framework/config/repos-cloud.yml
+++ b/crowbar_framework/config/repos-cloud.yml
@@ -347,26 +347,6 @@ suse-12.3:
       url:
       smt_path: "SUSE/Updates/SLE-HA/12-SP3/aarch64/update"
       ask_on_error: false
-    suse-enterprise-storage-5-pool:
-      name: "SUSE-Enterprise-Storage-5-Pool"
-      required: "optional"
-      features: ["ceph"]
-      repomd:
-        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP3:Update:Products:SES5/ses/5/POOL/aarch64"
-        fingerprint: ""
-      url:
-      smt_path: "SUSE/Products/Storage/5/aarch64/product"
-      ask_on_error: false
-    suse-enterprise-storage-5-updates:
-      name: "SUSE-Enterprise-Storage-5-Updates"
-      required: "optional"
-      features: ["ceph"]
-      repomd:
-        tag: "obsrepository://build.suse.de/SUSE:Updates:Storage:5:aarch64/update"
-        fingerprint: ""
-      url:
-      smt_path: "SUSE/Updates/Storage/5/aarch64/update"
-      ask_on_error: false
     ptf:
       name: "PTF"
       required: "recommended"
@@ -444,25 +424,6 @@ suse-12.3:
       url:
       smt_path: "SUSE/Updates/SLE-HA/12-SP3/x86_64/update"
       ask_on_error: false
-    suse-enterprise-storage-5-pool:
-      name: "SUSE-Enterprise-Storage-5-Pool"
-      required: "optional"
-      features: ["ceph"]
-      repomd:
-        tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP3:Update:Products:SES5/ses/5/POOL/x86_64"
-        fingerprint: ""
-      url:
-      smt_path: "SUSE/Products/Storage/5/x86_64/product"
-      ask_on_error: false
-    suse-enterprise-storage-5-updates:
-      name: "SUSE-Enterprise-Storage-5-Updates"
-      required: "optional"
-      features: ["ceph"]
-      repomd:
-        tag: "obsrepository://build.suse.de/SUSE:Updates:Storage:5:x86_64/update"
-        fingerprint: ""
-      url:
-      smt_path: "SUSE/Updates/Storage/5/x86_64/update"
     ptf:
       name: "PTF"
       required: "recommended"

--- a/crowbar_framework/lib/crowbar/product.rb
+++ b/crowbar_framework/lib/crowbar/product.rb
@@ -29,7 +29,7 @@ module Crowbar
 
     def self.ses_platform
       # Returns the platform used for SES
-      "suse-12.3"
+      "suse-12.2"
     end
   end
 end


### PR DESCRIPTION
SUSE Enterprise Storage 5 (SES5) is only built for SP3, while
SES4 is only built for SP2.
Only SES4 is deployable with crowbar.


(We tried to switch everything to SP3 in https://github.com/crowbar/crowbar-core/pull/1247)


~Also this (or some extension of it) will be needed https://github.com/SUSE-Cloud/automation/pull/2002~