### PR TITLE
Skip populating node_attr_cache for nil nodes

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1175,6 +1175,7 @@ class ServiceObject
 
     # Cache attributes that are useful later on
     pre_cached_nodes.each do |node_name, node|
+      next if node.nil?
       node_attr_cache[node_name] = {
         "alias" => node.alias,
         "windows" => node[:platform_family] == "windows",


### PR DESCRIPTION
`pre_cached_nodes` can contain nil nodes, so their attributes cannot be
put into `node_attr_cache`, skipping them.