### PR TITLE
[stable/3.0] network: Correct checking for per-bond settings

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -182,10 +182,10 @@ node["crowbar"]["network"].keys.sort{|a,b|
     # We want a bond.  Figure out what mode it should be.  Default to 5
     team_mode = conduit_map[conduit]["team_mode"] ||
       (node["network"]["teaming"] && node["network"]["teaming"]["mode"]) || 5
-    miimon = conduit_map[network.conduit]["team_miimon"] ||
+    miimon = conduit_map[conduit]["team_miimon"] ||
       (node["network"]["teaming"] &&
        node["network"]["teaming"]["miimon"]) || 100
-    xmit_hash_policy = conduit_map[network.conduit]["team_xmit_hash_policy"] ||
+    xmit_hash_policy = conduit_map[conduit]["team_xmit_hash_policy"] ||
       (node["network"]["teaming"] &&
        node["network"]["teaming"]["xmit_hash_policy"]) || "layer2"
     # See if a bond that matches our specifications has already been created,


### PR DESCRIPTION
When 08559ef4d6d0c32fd1244b2cdaccf0cb41947553 was cherry-picked from
stable/4.0, it missed one change -- network.conduit is not defined in
stable/3.0, and is instead named conduit.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
