### PR TITLE
[stable/4.0] ipmi: Add support for bmc_interface (bsc#1046567)

### DIFF
--- a/chef/data_bags/crowbar/migrate/ipmi/101_bmc_interface.rb
+++ b/chef/data_bags/crowbar/migrate/ipmi/101_bmc_interface.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "bmc_interface"
+    a["bmc_interface"] = ta["bmc_interface"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete "bmc_interface"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ipmi.json
+++ b/chef/data_bags/crowbar/template-ipmi.json
@@ -3,19 +3,20 @@
   "description": "The default proposal for the ipmi barclamp",
   "attributes": {
     "ipmi": {
-	  "bmc_enable" : false,
-	  "bmc_user": "root",
-	  "bmc_password": "cr0wBar!",
+      "bmc_enable" : false,
+      "bmc_user": "root",
+      "bmc_password": "cr0wBar!",
+      "bmc_interface": "lanplus",
       "ignore_address_suggestions": false,
       "use_dhcp": false,
-	  "debug": false
-	 }
+      "debug": false
+    }
   },
   "deployment": {
     "ipmi": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 101,
       "element_states": {
         "ipmi": [ "discovering", "hardware-installing", "readying" ],
         "bmc-nat-router": [ "readying", "ready", "applying" ],
@@ -38,7 +39,7 @@
           "hardware-installing",
           "installed",
           "readying"
-	]
+        ]
       } 
     }
   }

--- a/chef/data_bags/crowbar/template-ipmi.schema
+++ b/chef/data_bags/crowbar/template-ipmi.schema
@@ -7,6 +7,7 @@
             "bmc_enable": { "type": "bool", "required": true},
             "bmc_user": { "type": "str", "required": true },
             "bmc_password": { "type": "str", "required": true },
+            "bmc_interface": { "type": "str", "required": true },
             "use_dhcp":  { "type": "bool", "required": true},
             "ignore_address_suggestions": { "type": "bool", "required": true },
             "debug":  { "type": "bool", "required": true}

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -813,6 +813,10 @@ class Node < ChefObject
     @node["ipmi"]["bmc_password"] rescue nil
   end
 
+  def get_bmc_interface
+    @node["ipmi"]["bmc_interface"] rescue "lanplus"
+  end
+
   # ssh to the node and wait until the command exits
   def run_ssh_cmd(cmd, timeout = "15s", kill_after = "5s")
     args = ["sudo", "-i", "-u", "root", "--", "timeout", "-k", kill_after, timeout,
@@ -979,7 +983,7 @@ class Node < ChefObject
 
   def bmc_cmd(cmd)
     if bmc_address.nil? || get_bmc_user.nil? || get_bmc_password.nil? ||
-        !system("ipmitool", "-I", "lanplus", "-H", bmc_address, "-U", get_bmc_user, "-P", get_bmc_password, cmd)
+        !system("ipmitool", "-I", get_bmc_interface, "-H", bmc_address, "-U", get_bmc_user, "-P", get_bmc_password, cmd)
       case cmd
       when "power cycle"
         ssh_command = "/sbin/reboot -f"

--- a/crowbar_framework/app/views/barclamp/ipmi/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/ipmi/_edit_attributes.html.haml
@@ -6,6 +6,7 @@
     = boolean_field :bmc_enable
     = string_field :bmc_user
     = password_field :bmc_password
+    = string_field :bmc_interface
     = boolean_field :use_dhcp
     = boolean_field :ignore_address_suggestions
     = boolean_field :debug

--- a/crowbar_framework/config/locales/ipmi/en.yml
+++ b/crowbar_framework/config/locales/ipmi/en.yml
@@ -22,6 +22,7 @@ en:
         bmc_enable: 'Enable BMC'
         bmc_user: 'BMC User'
         bmc_password: 'BMC Password'
+        bmc_interface: 'BMC Interface'
         use_dhcp: 'BMC Should Use DHCP (Not explicitly assigned)'
         ignore_address_suggestions: 'Ignore Already Configured Address'
         debug: 'Enable Barclamp Debug'


### PR DESCRIPTION
Add support for specifying the bmc_interface type in the IPMI barclamp.
The interface was always hardcoded to lanplus, so provide that as the
default.

Drive-by converting tabs to spaces in the JSON template file.

Co-Authored-By: Eugen Block <e.block@suse.com>
(cherry picked from commit aa5972d9a48b590d37ca53f9e2fc174ac082b11c)

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
