### PR TITLE
Use threads to acquire/release locks in apply_role

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1207,15 +1207,15 @@ class ServiceObject
       reason = "apply_role(#{role.name}, #{inst}, #{in_queue}) pid #{Process.pid}"
       apply_locks, errors = lock_nodes(nodes_to_lock, owner, reason)
 
-      # Now that we've ensured no new intervallic runs can be started,
-      # wait for any which started before we paused the daemons.
-      wait_for_chef_daemons(nodes_to_lock)
-
       unless errors.empty?
         message = "Failed to apply the proposal:\n#{errors.values.join("\n")}"
         update_proposal_status(inst, "failed", message)
         return [409, message] # 409 is 'Conflict', which makes sense for locks
       end
+
+      # Now that we've ensured no new intervallic runs can be started,
+      # wait for any which started before we paused the daemons.
+      wait_for_chef_daemons(nodes_to_lock)
     end
 
     # By this point, no intervallic runs should be running, and no

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1524,29 +1524,53 @@ class ServiceObject
 
   private
 
+  THREAD_POOL_SIZE = 20
+
   def release_chef_locks(locks)
     return if locks.empty?
 
-    locks.each_slice(20) do |lock_batch|
-      threads = []
-      lock_batch.each do |lock|
-        threads.push(Thread.new { lock.release })
+    queue = Queue.new
+    locks.each { |l| queue.push l }
+
+    workers = (1...THREAD_POOL_SIZE).map do
+      Thread.new do
+        loop do
+          begin
+            lock = queue.pop(true)
+          rescue ThreadError
+            break
+          end
+
+          lock.release
+        end
       end
-      logger.debug "Waiting for #{threads.length} unlock threads to finish..."
-      ThreadsWait.all_waits(threads)
     end
+
+    logger.debug "Waiting for #{THREAD_POOL_SIZE} unlock threads to finish..."
+    workers.map(&:join)
   end
 
   def lock_and_wait_for_chef_clients(nodes, lock_owner, lock_reason)
     locks = []
     errors = {}
+
+    return [locks, errors] if nodes.empty?
+
     locks_mutex = Mutex.new
     errors_mutex = Mutex.new
 
-    nodes.each_slice(20) do |node_batch|
-      threads = {}
-      node_batch.each do |node|
-        thread = Thread.new do
+    queue = Queue.new
+    nodes.each { |n| queue.push n }
+
+    workers = (1...THREAD_POOL_SIZE).map do
+      Thread.new do
+        loop do
+          begin
+            node = queue.pop(true)
+          rescue ThreadError
+            break
+          end
+
           begin
             lock = Crowbar::Lock::SharedNonBlocking.new(
               logger: @logger,
@@ -1555,23 +1579,20 @@ class ServiceObject
               owner: lock_owner,
               reason: lock_reason
             ).acquire
-            locks_mutex.synchronize { locks.push(lock) }
-            # Now that we've ensured no new intervallic runs can be started,
-            # wait for any which started before we paused the daemons.
-            wait_for_chef_clients(node, logger: true)
           rescue Crowbar::Error::LockingFailure => e
             errors_mutex.synchronize { errors[node] = e.message }
           end
+
+          locks_mutex.synchronize { locks.push(lock) }
+          # Now that we've ensured no new intervallic runs can be started,
+          # wait for any which started before we paused the daemons.
+          wait_for_chef_clients(node, logger: true)
         end
-        threads[thread] = node
       end
-
-      # wait for all running threads and collect the ones with a non-zero return value
-      logger.debug "Waiting for #{threads.keys.length} lock threads to finish..."
-      ThreadsWait.all_waits(threads.keys)
-
-      break unless errors.empty?
     end
+
+    logger.debug "Waiting for #{THREAD_POOL_SIZE} lock threads to finish..."
+    workers.map(&:join)
 
     [locks, errors]
   end

--- a/crowbar_framework/config/application.rb
+++ b/crowbar_framework/config/application.rb
@@ -19,6 +19,10 @@ require File.expand_path("../boot", __FILE__)
 
 module Crowbar
   class Application < Rails::Application
+    # Explicitely eager load /lib/crowbar/lock so we can use SharedNonBlocking
+    # with threading without hitting circular dependencies
+    config.eager_load_paths += Dir["#{config.root}/lib/crowbar/lock"]
+
     config.autoload_paths += %W(
       #{config.root}/lib
     )


### PR DESCRIPTION
Stolen from https://github.com/crowbar/crowbar-core/pull/896/ to rebase and improve (if needed)

crowbar: Use a thread pool when acquiring/release chef-client locks.