### PR TITLE
crowbar: explicitly require the modules to avoid circular dependencies

### DIFF
--- a/crowbar_framework/lib/crowbar/lock/shared_non_blocking.rb
+++ b/crowbar_framework/lib/crowbar/lock/shared_non_blocking.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+require "remote_node"
+
 module Crowbar
   class Lock::SharedNonBlocking < Lock
     # This class implements a shared (i.e. non-exclusive) lock, by


### PR DESCRIPTION
In order to avoid circular dependencies when using threading
we should explicitly require the appropriate modules that we
are gonna use.