### PR TITLE
crowbar: require crowbar instead of eager load

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -22,6 +22,7 @@ require "hash_only_merge"
 require "securerandom"
 require "timeout"
 require "thwait"
+require "crowbar"
 
 class ServiceObject
   include CrowbarPacemakerProxy

--- a/crowbar_framework/config/application.rb
+++ b/crowbar_framework/config/application.rb
@@ -19,9 +19,6 @@ require File.expand_path("../boot", __FILE__)
 
 module Crowbar
   class Application < Rails::Application
-    # Explicitely eager load /lib/crowbar/lock so we can use SharedNonBlocking
-    # with threading without hitting circular dependencies
-    config.eager_load_paths += Dir["#{config.root}/lib/crowbar/lock"]
 
     config.autoload_paths += %W(
       #{config.root}/lib


### PR DESCRIPTION
There seems to be some issue with using eager load
where some required parameters that should be filled when
deploying a barclamp are empty.

This could be a side issue of using eager load to load some
classes on application start. Lets use the simpler require
instead.

