### PR TITLE
batch: properly fail on invalid yaml

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -112,6 +112,7 @@ def import_or_build(do_commit)
 
   data = YAML.load(input_data)
   abort "input is empty" unless data
+  abort "yaml input is not a Hash" unless data.is_a? Hash
 
   global_options = data["global_options"] || {}
 


### PR DESCRIPTION
e.g. when forgetting the 'proposal:' key

**Why is this change necessary?**
`crowbar batch build invalid.yaml`
was failing with a cryptic error:
```
/opt/dell/bin/barclamp_lib.rb:532:in `eval': no implicit conversion of String into Integer (TypeError)
        from /opt/dell/bin/crowbar_batch:116:in `import_or_build'
        from /opt/dell/bin/crowbar_batch:90:in `build'
        from (eval):1:in `run_sub_command'
        from /opt/dell/bin/barclamp_lib.rb:532:in `eval'
        from /opt/dell/bin/barclamp_lib.rb:532:in `run_sub_command'
        from /opt/dell/bin/barclamp_lib.rb:536:in `run_command'
        from /opt/dell/bin/crowbar_batch:580:in `main'
        from /opt/dell/bin/crowbar_batch:583:in `<main>'
```
**How does it address the issue?**
We make sure the data we got is structured as a hash
