### PR TITLE
[4.0] crowbar: Fix the wait for the chef daemons

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1215,7 +1215,7 @@ class ServiceObject
 
       # Now that we've ensured no new intervallic runs can be started,
       # wait for any which started before we paused the daemons.
-      wait_for_chef_daemons(nodes_to_lock)
+      wait_for_chef_daemons(applying_nodes)
     end
 
     # By this point, no intervallic runs should be running, and no


### PR DESCRIPTION
Before the threading patch we were waiting for ALL of the nodes
being applied to finish their chef runs. After what looked like a typo
we were only looking at the nodes locked, which ignores the admin node.
So it could happen that the admin node was running the chef client
and it was ignored, not filling properly the templates for bind
thus not allowing the other dns server nodes to transfer zones,
which made the multi-dns test fail all the time randomly

(cherry picked from commit af14a7b70248e7890274282dc6816f48a27bba98)
