### PR TITLE
crowbar_join: Add a report timing handler

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -238,6 +238,44 @@ EOF
         echo "$reboot_handler_reset_content" > /var/chef/handlers/reboot_handler_reset.rb
     fi
 
+    # create resource timing handler
+    read -d '' resource_timing_handler_content <<"EOF"
+class TimingHandler < Chef::Handler
+  def initialize(items=10)
+    super()
+    @items = items
+  end
+  def report
+    Chef::Log.info "Showing the #{@items} slowest resources"
+    all_resources.sort_by! {|r| r.elapsed_time }.reverse!
+    all_resources[0...@items].each do |r|
+      Chef::Log.info "#{full_name(r)} -> %.10f" % r.elapsed_time
+    end
+  end
+  def full_name(resource)
+    "#{resource.resource_name}[#{resource.name}]"
+  end
+end
+EOF
+    if [ -f /var/chef/handlers/resource_timing_handler.rb ] ; then
+        # only update resource_timing_handler.rb if something changed
+        local resource_timing_handler_shasum_file=$(sha256sum /var/chef/handlers/resource_timing_handler.rb | cut -d ' ' -f 1)
+        local resource_timing_handler_shasum_new=$(echo "$resource_timing_handler_content" | sha256sum | cut -d ' ' -f 1)
+
+        if [ "$resource_timing_handler_shasum_file" != "$resource_timing_handler_shasum_new" ] ; then
+            echo "$resource_timing_handler_content" > /var/chef/handlers/resource_timing_handler.rb
+        fi
+    else
+        echo "$resource_timing_handler_content" > /var/chef/handlers/resource_timing_handler.rb
+    fi
+
+    # add resource timing handler as report_handler
+    for line in 'require "/var/chef/handlers/resource_timing_handler"' \
+        'resource_timing_handler = TimingHandler.new(20)' \
+        'report_handlers << resource_timing_handler # these fire at the end of a successful run'; do
+        grep -q -e "^$line$" /etc/chef/client.rb || echo "$line" >> /etc/chef/client.rb
+    done
+
     # add reboot handler as report_handler
     for line in 'require "/var/chef/handlers/reboot_handler"' \
         'reboot_handler = RebootHandler.new' \


### PR DESCRIPTION
Adds a timing handler that runs during the report phase of
the chef-client to show the 10 slowest resources during the chef run

Ideally the handlers should be moved out of the crowbar_join.sh
file and turned into a chef resource for a decend deploy
mechanism and the ability to configure them, but as a first step
I think its ok to include them like this (for the moment, maybe a PR will come next to fix that)
