### PR TITLE
bind: set transfer-source to avoid xfer failures (bsc#1036601)

### DIFF
--- a/chef/cookbooks/bind9/templates/default/named.conf.default-zones.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.default-zones.erb
@@ -9,6 +9,7 @@ zone "0.in-addr.arpa" {
 <% else -%>
         type slave;
         masters { <%= @master_ip -%>; };
+        transfer-source <%= @admin_addr -%>;
         file "/etc/bind/slave/db.0";
 <% end %>
 };
@@ -20,6 +21,7 @@ zone "255.in-addr.arpa" {
 <% else -%>
         type slave;
         masters { <%= @master_ip -%>; };
+        transfer-source <%= @admin_addr -%>;
         file "/etc/bind/slave/db.255";
 <% end %>
 };

--- a/chef/cookbooks/bind9/templates/default/zone.erb
+++ b/chef/cookbooks/bind9/templates/default/zone.erb
@@ -13,6 +13,7 @@ zone "<%= zonefile_entry -%>" {
     type slave;
     notify no;
     masters { <%= @master_ip -%>; };
+    transfer-source <%= @admin_addr -%>;
     file "/etc/bind/slave/db.<%= zonefile_entry -%>";
 };
 <%   end %>


### PR DESCRIPTION
Currently bind isn't explicitely told which IP address to
request zone transfers from, while the server is configured to
specifically only accept zone transfer requests from the specific
list of whitelisted 2ndary slave ip addresses. Without that
change it happened that bind happened to choose another IP address
from the admin network (like an unrelated VIP allocated from admin)
for transfer, failing to sync up with master.

(cherry picked from commit 6f450c3375b5437d443ec666560539e4b4de2076)

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
