### PR TITLE
apache2: fix apache2.conf template

### DIFF
--- a/chef/cookbooks/apache2/templates/default/apache2.conf.erb
+++ b/chef/cookbooks/apache2/templates/default/apache2.conf.erb
@@ -24,7 +24,7 @@ LockFile logs/accept.lock
 PidFile /var/run/apache2.pid
 <% elsif (node[:platform] == "redhat" && node[:platform_version].to_f < 6) || node[:platform_family] == "fedora" -%>
 PidFile /var/run/httpd.pid
-<% elsif node[:platform_family] == "arch" || node[:platform_family] == "rhel -%>
+<% elsif node[:platform_family] == "arch" || node[:platform_family] == "rhel" -%>
 PidFile /var/run/httpd/httpd.pid
 <% else -%>
 PidFile logs/httpd.pid


### PR DESCRIPTION
There was a missing " in the template, leading to errors while uploading
the recipe manually to the chef server

Cant believe this was there for over 2 years and everything worked! Did nobody uploaded the apache2 recipe manually in those 2 years :rofl: 