### PR TITLE
testing: use knife to check syntax of cookbooks

### DIFF
--- a/.knife-test.rb
+++ b/.knife-test.rb
@@ -1,0 +1,5 @@
+# knife config file for travis-ci jobs that require knife
+# set a dir for the cache in the HOME dir or it will try to write to /var/chef
+cache_type "BasicFile"
+cache_options(:path => "#{ENV['HOME']}/.chef/checksums")
+cookbook_path "chef/cookbooks/"

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,10 @@ matrix:
     - gemfile: chef/cookbooks/barclamp/Gemfile
       script:
        - cd chef/cookbooks/barclamp && bundle exec rake
+    - gemfile: crowbar_framework/Gemfile
+      script:
+       - crowbar_framework/bin/bundle exec knife cookbook test -c .knife-test.rb -a
+
 
 addons:
   apt:


### PR DESCRIPTION
Use the installed knife command to check for cookbook
syntax. This will catch ruby issues on the cookbooks and also
template issues that we are not checking right now.

