### PR TITLE
[3.0] apache2: fix apache2.conf template

### DIFF
--- a/chef/cookbooks/apache2/templates/default/apache2.conf.erb
+++ b/chef/cookbooks/apache2/templates/default/apache2.conf.erb
@@ -24,7 +24,7 @@ LockFile logs/accept.lock
 PidFile /var/run/apache2.pid
 <% elsif (node[:platform] == "redhat" && node[:platform_version].to_f < 6) || node[:platform_family] == "fedora" -%>
 PidFile /var/run/httpd.pid
-<% elsif node[:platform_family] == "arch" || node[:platform_family] == "rhel -%>
+<% elsif node[:platform_family] == "arch" || node[:platform_family] == "rhel" -%>
 PidFile /var/run/httpd/httpd.pid
 <% else -%>
 PidFile logs/httpd.pid


### PR DESCRIPTION
There was a missing " in the template, leading to errors while uploading
the recipe manually to the chef server

(cherry picked from commit 4a60c80c636b7b364d929f955e5c082a16201837)