### PR TITLE
Fix network_validator (bsc#1025642)

### DIFF
--- a/crowbar_framework/lib/crowbar/validator/network_validator.rb
+++ b/crowbar_framework/lib/crowbar/validator/network_validator.rb
@@ -4,7 +4,7 @@ module Crowbar
       def validate_network
         `#{Rails.root.join("..", "bin/network-json-validator").to_s} \
           --admin-ip \
-          #{Socket.ip_address_list.detect(&:ipv4_private?).ip_address} \
+          #{IPSocket.getaddress(Socket.gethostname)} \
           #{network_json.to_s}`
       end
 


### PR DESCRIPTION
The previous network validator take the first private IP from the
system and expect that this is the admin IP.  This work OK in case
that eth0 is listed before eth1, but this is something that do not
happends always.

This change use the FQDN information to deduce the admin IP, as
install-suse-cloud is doing.

(cherry picked from commit c907a905767638282d7375ede271d9b5dc689b6b)
