### PR TITLE
Fix chef node attribute lookup

### DIFF
--- a/chef/cookbooks/ipmi/recipes/ipmi-discover.rb
+++ b/chef/cookbooks/ipmi/recipes/ipmi-discover.rb
@@ -35,10 +35,10 @@ unsupported = [
   "Unknown (Not Detected)"
 ]
 
-node.set["crowbar_wall"] = {} unless node["crowbar_wall"]
-node.set["crowbar_wall"]["ipmi"] = {} unless node["crowbar_wall"]["ipmi"]
-node.set["crowbar_wall"]["status"] = {} unless node["crowbar_wall"]["status"]
-node.set["crowbar_wall"]["status"]["ipmi"] = {} unless node["crowbar_wall"]["status"]["ipmi"]
+node.set["crowbar_wall"] ||= Mash.new
+node.set["crowbar_wall"]["ipmi"] ||= Mash.new
+node.set["crowbar_wall"]["status"] ||= Mash.new
+node.set["crowbar_wall"]["status"]["ipmi"] ||= Mash.new
 node.save
 
 if node[:platform_family] == "windows"

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -262,7 +262,7 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
       os = node[:provisioner][:default_os]
     end
 
-    boot_device = mnode.fetch(:crowbar_wall, {})[:boot_device]
+    boot_device = mnode.fetch("crowbar_wall", {})[:boot_device]
 
     append << node[:provisioner][:available_oses][os][arch][:append_line]
 

--- a/chef/cookbooks/utils/libraries/helpers.rb
+++ b/chef/cookbooks/utils/libraries/helpers.rb
@@ -70,7 +70,7 @@ module CrowbarHelper
 
   def self.in_sledgehammer?(node)
     states = ["ready", "readying", "recovering", "applying"]
-    !node.fetch(:crowbar_wall, {})[:registering] && !states.include?(node[:state])
+    !node.fetch("crowbar_wall", {})[:registering] && !states.include?(node[:state])
   end
 
   def self.get_proposal_instance(node, barclamp, fallback = nil)


### PR DESCRIPTION
it seems .fetch on symbols doesn't work for Chef attributes, and the
behavior is subtle different for "def []" instead. so with other words:

  node.fetch(:crowbar_wall) -> IndexError: Key crowbar_wall does not
  exist

  node[:crowbar_wall] -> works
  node["crowbar_wall] -> works
  node.fetch("crowbar_wall") -> works

This seemingly harmless HoundCI fix entirely broke the boot device
and dns export logic of Cloud 7+.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
