### PR TITLE
Avoid crashing chef on listing "installing" nodes (bsc#1050278)

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -35,7 +35,8 @@ module BarclampLibrary
       # returns a full network definition, including ranges; this doesn't
       # depend on the node being enabled for this network
       def self.get_network_definition(node, type)
-        if node[:network][:networks].nil? || !node[:network][:networks].key?(type)
+        if node[:network].nil? || node[:network][:networks].nil? ||
+            !node[:network][:networks].key?(type)
           nil
         else
           node[:network][:networks][type].to_hash
@@ -45,7 +46,7 @@ module BarclampLibrary
       def self.list_networks(node)
         answer = []
         unless node[:crowbar].nil? || node[:crowbar][:network].nil? ||
-            node[:network][:networks].nil?
+            node[:network].nil? || node[:network][:networks].nil?
           node[:crowbar][:network].each do |net, data|
             # network is not valid if we don't have the full definition
             next unless node[:network][:networks].key?(net)
@@ -57,8 +58,8 @@ module BarclampLibrary
       end
 
       def self.get_network_by_type(node, type)
-        unless node[:crowbar].nil? ||
-            node[:crowbar][:network].nil? || node[:network][:networks].nil?
+        unless node[:crowbar].nil? || node[:crowbar][:network].nil? ||
+            node[:network].nil? || node[:network][:networks].nil?
           [type, "admin"].uniq.each do |usage|
             found = node[:crowbar][:network].find do |net, data|
               # network is not valid if we don't have the full definition


### PR DESCRIPTION
Apparently there is a way to get nodes in a state without the [:network]
attribute being set. it shouldn't harm to just continue as if
nothing would have happened.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
