### PR TITLE
provisioner: Wait for admin server after net restart (bsc#1054191)

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -266,6 +266,9 @@ do_chef_client_after_setup() {
     # Make sure our interfaces are as up as we can get them
     echo_verbose "Ensuring that our network interfaces are up."
     log_to ifup /sbin/service network restart
+    # Wait again for the admin server. Otherwise chef-client runs fail with EHOSTUNREACH (bsc#1054191)
+    echo_verbose "Checking connectivity with administration server after network restart..."
+    wait_for_admin_server
 }
 
 do_chef_client() {


### PR DESCRIPTION
When the network is restarted, it might not come up fast enough the
the next chef-client run may fail with:

Errno::EHOSTUNREACH: No route to host - connect(2) for "192.168.76.10" port 4000

Waiting for the admin server to be reachable should fix this.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
