### PR TITLE
Bootdisk detection: Skip cciss, prefer wwn's

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -339,7 +339,6 @@ module BarclampLibrary
                 candidates.find { |b| b =~ /^scsi-[^1]/ } ||
                 candidates.find { |b| b =~ /^scsi-/ } ||
                 candidates.find { |b| b =~ /^ata-/ } ||
-                candidates.find { |b| b =~ /^cciss-/ } ||
                 candidates.first
 
               unless match.empty?

--- a/chef/cookbooks/provisioner/recipes/bootdisk.rb
+++ b/chef/cookbooks/provisioner/recipes/bootdisk.rb
@@ -88,11 +88,11 @@ ruby_block "Find the fallback boot device" do
         # reusable than the normal links.
         # Note: this find construct should match the code in
         # barclamp/libraries/barclamp_library.rb (from deployer)
-        bootdisk = bootdisks.find{ |b|b =~ /^wwn-/ } ||
-          bootdisks.find{ |b|b =~ /^scsi-[a-zA-Z]/ } ||
-          bootdisks.find{ |b|b =~ /^scsi-[^1]/ } ||
-          bootdisks.find{ |b|b =~ /^scsi-/ } ||
-          bootdisks.find{ |b|b =~ /^ata-/ } ||
+        bootdisk = bootdisks.find { |b| b =~ /^wwn-/ } ||
+          bootdisks.find { |b| b =~ /^scsi-[a-zA-Z]/ } ||
+          bootdisks.find { |b| b =~ /^scsi-[^1]/ } ||
+          bootdisks.find { |b| b =~ /^scsi-/ } ||
+          bootdisks.find { |b| b =~ /^ata-/ } ||
           bootdisks.first
         dev = "disk/by-id/#{bootdisk}"
       end

--- a/chef/cookbooks/provisioner/recipes/bootdisk.rb
+++ b/chef/cookbooks/provisioner/recipes/bootdisk.rb
@@ -88,11 +88,11 @@ ruby_block "Find the fallback boot device" do
         # reusable than the normal links.
         # Note: this find construct should match the code in
         # barclamp/libraries/barclamp_library.rb (from deployer)
-        bootdisk = bootdisks.find{ |b|b =~ /^scsi-[a-zA-Z]/ } ||
+        bootdisk = bootdisks.find{ |b|b =~ /^wwn-/ } ||
+          bootdisks.find{ |b|b =~ /^scsi-[a-zA-Z]/ } ||
           bootdisks.find{ |b|b =~ /^scsi-[^1]/ } ||
           bootdisks.find{ |b|b =~ /^scsi-/ } ||
           bootdisks.find{ |b|b =~ /^ata-/ } ||
-          bootdisks.find{ |b|b =~ /^cciss-/ } ||
           bootdisks.first
         dev = "disk/by-id/#{bootdisk}"
       end


### PR DESCRIPTION
On Systems with HP Smart Array Controllers, the discovery image
detects cciss udev links but those don't actually exist during
installation because for unknown reasons the installation system
doesn't actually load the cciss module. So skip them and prefer
wwn's, those are hopefully unique enough.

Funny side story: In at least one case, the cciss- link was based on the
controller's serial number (which is the same for both devices that
were attached). you just had one job..

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
