### PR TITLE
Set up Danger for commit linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ env: SKIP_CHECKS=yes
 
 matrix:
   include:
+    - gemfile: Gemfile
+      script:
+      - bundle exec danger
     - gemfile: crowbar_framework/Gemfile
       script:
        - cd crowbar_framework

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,7 @@
+# Check basic commit message formatting
+commit_lint.check warn: :all
+
+# Ensure a clean commit history
+if git.commits.any? { |c| c.message =~ /^Merge branch/ }
+  warn('Please rebase to get rid of the merge commits in this PR')
+end

--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development do
   gem "sprockets-standalone", "~> 1.2.1"
   gem "sprockets", "~> 2.11.0"
   gem "rspec", "~> 3.1.0"
+  gem "danger-commit_lint"
 end
 
 unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"


### PR DESCRIPTION
Currently, we have no automated way of enforcing or encouraging good patch proposal practices, and it is therefore left up to the reviewer to notice and request changes for improper commit formatting and pull request structure. This is a problem because we have not actually formally agreed to rules around pull request structure, and the importance of enforcing it is subjective to each reviewer. This patch sets up a basic commit linter using Danger[1]. For now, the checks it performs are limited to the default commit formatting checks from the commit-lint plugin[2] as well as a check for the existence of merge commits in a pull request. For now, the checks are set to "warn" and will post comments but will not fail a build.

The bot will use the github account susecloudcommitpolice. Using this gem in TravisCI requires the bot to have an API token set as an environment variable in the TravisCI settings for the repository. The token (which in most workflows is a secret akin to a password) will be exposed in the TravisCI logs, which is required to enable the bot to post comments on pull requests. The bot will not be part of any SUSE-related organizations and does not have permission to do anything beyond posting comments on public repositories, so the only venue for abuse is by spamming, and if that occurs we can disable the bot.

[1] http://danger.systems/ruby/
[2] http://danger.systems/plugins/commit_lint.html