### PR TITLE
provisioner: Fix wwn usage for persistent disk names

### DIFF
--- a/chef/cookbooks/provisioner/recipes/bootdisk.rb
+++ b/chef/cookbooks/provisioner/recipes/bootdisk.rb
@@ -88,7 +88,8 @@ ruby_block "Find the fallback boot device" do
         # reusable than the normal links.
         # Note: this find construct should match the code in
         # barclamp/libraries/barclamp_library.rb (from deployer)
-        bootdisk = bootdisks.find{ |b|b =~ /^scsi-[a-zA-Z]/ } ||
+        bootdisk = bootdisks.find{ |b|b =~ /^wwn-/ } ||
+          bootdisks.find{ |b|b =~ /^scsi-[a-zA-Z]/ } ||
           bootdisks.find{ |b|b =~ /^scsi-[^1]/ } ||
           bootdisks.find{ |b|b =~ /^scsi-/ } ||
           bootdisks.find{ |b|b =~ /^ata-/ } ||


### PR DESCRIPTION
Commit 5697817479c0a switched to use wwn if possible but forgot to change
one place which is now fixed with this commit.

Co-Authored-By: Dirk Mueller <dmueller@suse.com>

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
