### PR TITLE
provisioner: Install crowbarctl

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -413,3 +413,21 @@ template "/etc/sh.shrc.local" do
   group "root"
   mode "0644"
 end
+
+crowbar_node = node_search_with_cache("roles:crowbar").first
+address = crowbar_node["crowbar"]["network"]["admin"]["address"]
+protocol = crowbar_node["crowbar"]["apache"]["ssl"] ? "https" : "http"
+server = "#{protocol}://#{address}"
+password = crowbar_node["crowbar"]["users"]["crowbar"]["password"]
+verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
+template "/etc/crowbarrc" do
+  source "crowbarrc.erb"
+  variables(
+    server: server,
+    password: password,
+    verify_ssl: verify_ssl
+  )
+  owner "root"
+  group "root"
+  mode "0o600"
+end

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -341,6 +341,7 @@ sync
 <% end -%>
       <package>netcat</package>
       <package>ruby2.1-rubygem-chef</package>
+      <package>ruby2.1-rubygem-crowbar-client</package>
 <% if @is_ses -%>
       <package>ses-release</package>
 <% else -%>

--- a/chef/cookbooks/provisioner/templates/default/crowbarrc.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbarrc.erb
@@ -1,0 +1,7 @@
+[default]
+server = <%= @server %>
+username = crowbar
+password = <%= @password %>
+<% unless @verify_ssl %>
+verify_ssl = 0
+<% end %>

--- a/chef/data_bags/crowbar/migrate/crowbar/200_add_insecure_attribute.rb
+++ b/chef/data_bags/crowbar/migrate/crowbar/200_add_insecure_attribute.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["apache"]["insecure"] = ta["apache"]["insecure"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a["apache"].delete("insecure")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-crowbar.json
+++ b/chef/data_bags/crowbar/template-crowbar.json
@@ -30,6 +30,7 @@
       },
       "apache": {
         "ssl": false,
+        "insecure": false,
         "generate_certs": false,
         "ssl_crt_file": "/etc/apache2/ssl.crt/crowbar-server.crt",
         "ssl_key_file": "/etc/apache2/ssl.key/crowbar-server.key",
@@ -41,7 +42,7 @@
     "crowbar": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 103,
+      "schema-revision": 200,
       "element_states": {
         "crowbar": [ "all" ],
         "crowbar-upgrade": [ "readying", "ready", "applying", "crowbar_upgrade" ]

--- a/chef/data_bags/crowbar/template-crowbar.schema
+++ b/chef/data_bags/crowbar/template-crowbar.schema
@@ -43,6 +43,7 @@
               "required" : true,
               "mapping": {
                 "ssl": { "type": "bool", "required": true },
+                "insecure": { "type": "bool", "required": true },
                 "generate_certs": { "type": "bool", "required": true },
                 "ssl_crt_file": { "type": "str" },
                 "ssl_key_file": { "type": "str" },

--- a/crowbar_framework/app/views/barclamp/crowbar/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/crowbar/_edit_attributes.html.haml
@@ -17,6 +17,7 @@
 
       #apache_container
         = boolean_field %w(apache generate_certs)
+        = boolean_field %w(apache insecure)
         = string_field %w(apache ssl_crt_file)
         = string_field %w(apache ssl_key_file)
         = string_field %w(apache ssl_crt_chain_file)

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -201,7 +201,8 @@ en:
         ssl_header: 'SSL Support'
         apache:
           ssl: 'Protocol'
-          generate_certs: 'Generate (self-signed) certificates'
+          generate_certs: 'Generate (self-signed) certificates (implies insecure)'
+          insecure: 'SSL Certificate is insecure (for instance, self-signed)'
           ssl_crt_file: 'SSL Certificate File'
           ssl_key_file: 'SSL (Private) Key File'
           ssl_crt_chain_file: 'SSL Certificate Chain File'

--- a/crowbar_framework/spec/fixtures/data_bags/template-crowbar.json
+++ b/crowbar_framework/spec/fixtures/data_bags/template-crowbar.json
@@ -32,6 +32,7 @@
       },
       "apache": {
         "ssl": false,
+        "insecure": false,
         "generate_certs": false
       }
     }


### PR DESCRIPTION
Update autoyast.xml.erb to install crowbarctl in each node.  This
is the first step to replace `curl` raw calls to the crowbar API,
and use `crowbarctl` instead.

This replacement will fix some issues in relation with `curl`,
https, redirections and BasicAuth passwords.