### PR TITLE
Add Cloud8/Pike repository tags

### DIFF
--- a/crowbar_framework/config/repos-cloud.yml
+++ b/crowbar_framework/config/repos-cloud.yml
@@ -303,6 +303,7 @@ suse-12.3:
       repomd:
         tag: ["obsproduct://build.suse.de/SUSE:SLE-12-SP3:Update:Products:Cloud8/suse-openstack-cloud/8/cd/aarch64",
               "obsproduct://build.suse.de/Devel:Cloud:8:Ocata/suse-openstack-cloud/8/cd/aarch64",
+              "obsproduct://build.suse.de/Devel:Cloud:8:Pike/suse-openstack-cloud/8/cd/aarch64",
               "obsproduct://build.suse.de/Devel:Cloud:8:Staging/suse-openstack-cloud/8/cd/aarch64",
               "obsproduct://build.suse.de/Devel:Cloud:8/suse-openstack-cloud/8/cd/aarch64"]
         fingerprint: []
@@ -401,6 +402,7 @@ suse-12.3:
       repomd:
         tag: ["obsproduct://build.suse.de/SUSE:SLE-12-SP3:Update:Products:Cloud8/suse-openstack-cloud/8/cd/x86_64",
               "obsproduct://build.suse.de/Devel:Cloud:8:Ocata/suse-openstack-cloud/8/cd/x86_64",
+              "obsproduct://build.suse.de/Devel:Cloud:8:Pike/suse-openstack-cloud/8/cd/x86_64",
               "obsproduct://build.suse.de/Devel:Cloud:8:Staging/suse-openstack-cloud/8/cd/x86_64",
               "obsproduct://build.suse.de/Devel:Cloud:8/suse-openstack-cloud/8/cd/x86_64"]
         fingerprint: []
@@ -498,6 +500,7 @@ suse-12.3:
       repomd:
         tag: ["obsproduct://build.suse.de/SUSE:SLE-12-SP3:Update:Products:Cloud8/suse-openstack-cloud/8/cd/s390x",
               "obsproduct://build.suse.de/Devel:Cloud:8:Ocata/suse-openstack-cloud/8/cd/s390x",
+              "obsproduct://build.suse.de/Devel:Cloud:8:Pike/suse-openstack-cloud/8/cd/s390x",
               "obsproduct://build.suse.de/Devel:Cloud:8:Staging/suse-openstack-cloud/8/cd/s390x",
               "obsproduct://build.suse.de/Devel:Cloud:8/suse-openstack-cloud/8/cd/s390x"]
         fingerprint: []


### PR DESCRIPTION
**Why is this change necessary?**
This change fixes the current pikecloud8 crowbar allocation failures
**How does it address the issue?**
Adds missing pike repository tags.
**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
