### PR TITLE
Managing mandatory service restarts on chef runs

### DIFF
--- a/chef/cookbooks/utils/libraries/restart_manager.rb
+++ b/chef/cookbooks/utils/libraries/restart_manager.rb
@@ -1,0 +1,61 @@
+module ServiceRestart
+  class RestartManager
+    def initialize(cookbook_name, node, new_resource, is_pacemaker_service)
+      @cookbook_name = cookbook_name
+      @node = node
+      @service_name = new_resource.name.to_sym
+      @is_pacemaker_service = is_pacemaker_service
+    end
+
+    def cookbook
+      # if the cookbook_name is apache2, then any cookbook could have triggered it, so
+      # try to pick the value from the extra key that we set
+      if @cookbook_name == "apache2"
+        @node.run_state["apache2_restart_origin"]
+      else
+        @cookbook_name.to_s
+      end
+    end
+
+    def add_restart_management_node_attributes
+      @node.set[:crowbar_wall] = {} unless @node[:crowbar_wall]
+      @node.set[:crowbar_wall][:requires_restart] = {} \
+            unless @node[:crowbar_wall][:requires_restart]
+      @node.set[:crowbar_wall][:requires_restart][cookbook] = {} \
+            unless @node[:crowbar_wall][:requires_restart][cookbook]
+    end
+
+    def disallow_restart?
+      # if the databag or item does not exits it returns a 404
+      data_bag = data_bag_item("crowbar-config", "disallow_restart") rescue {}
+
+      data_bag[cookbook] || false
+    end
+
+    def register_restart_request
+      # Store more data about the service attempted restart
+      # use the service as the key name for the data for easy removal
+      # we have to force the attributes to be a simple hash instead of a node attribute if you want
+      # the update method to actually update. If you update the attribute directly it doesn't
+      # update but overwrites! The joys of chef!
+      add_restart_management_node_attributes
+      requires_restart_hash = @node[:crowbar_wall][:requires_restart][cookbook].to_h
+      @node.set[:crowbar_wall][:requires_restart][cookbook] = requires_restart_hash.update(
+        @service_name => {
+          pacemaker_service: @is_pacemaker_service,
+          timestamp: Time.now.getutc
+        }
+      )
+    end
+
+    def clear_restart_requests
+      @node.fetch(
+        :crowbar_wall, {}
+      ).fetch(
+        :requires_restart, {}
+      ).fetch(
+        cookbook, {}
+      ).delete(@service_name)
+    end
+  end
+end

--- a/chef/cookbooks/utils/libraries/service.rb
+++ b/chef/cookbooks/utils/libraries/service.rb
@@ -1,0 +1,51 @@
+#
+# Copyright 2017, SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# As we want to override the restart method to either call it or skip it,
+# we just monkey patch the Chef::Provider::Service to override the action_restart
+# which is the common method for all the children Service classes
+class Chef
+  class Provider
+    class Service < Chef::Provider
+      def action_restart
+        restart_manager = ServiceRestart::RestartManager.new(
+          cookbook_name,
+          node,
+          @new_resource,
+          false
+        )
+
+        if restart_manager.disallow_restart?
+          Chef::Log.info("Disallowing restart for #{@new_resource.name} due to flag")
+          restart_manager.register_restart_request
+        else
+          # from this point this is a modified version of the original method, see:
+          # https://github.com/SUSE-Cloud/chef/blob/10-stable-suse/chef/lib/chef/provider/service.rb#L113
+          converge_by("restart service #{@new_resource}") do
+            restart_service
+            Chef::Log.info("#{@new_resource} restarted")
+          end
+          # we have restarted the service so we clear pending restart requests
+          restart_manager.clear_restart_requests
+        end
+        # we still want to load the state and set the running flag to true as we dont want any side
+        # issues of the resource being into an unknown state
+        load_new_resource_state
+        @new_resource.running(true)
+      end
+    end
+  end
+end

--- a/crowbar_framework/app/controllers/api/restart_management_controller.rb
+++ b/crowbar_framework/app/controllers/api/restart_management_controller.rb
@@ -1,0 +1,142 @@
+#
+# Copyright 2017, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Api::RestartManagementController < ApiController
+  skip_before_filter :upgrade
+
+  api :POST, "/api/restart_management/configuration", "Set the disallow restart value for cookbooks"
+  header "Accept", "application/vnd.crowbar.v2.0+json", required: true
+  param :disallow_restart, [true, false], desc: "Disallow service reboots", required: true
+  param :cookbook, String, desc: "Cookbook to apply to", required: true
+  api_version "2.0"
+
+  api :GET, "/api/restart_management/configuration", "List the disallow restart value for cookbooks"
+  header "Accept", "application/vnd.crowbar.v2.0+json", required: true
+  api_version "2.0"
+  def configuration
+    if request.post?
+      configuration_post
+    else
+      configuration_get
+    end
+  end
+
+  api :POST, "/api/restart_management/restarts", "Clean the service restart flags"
+  header "Accept", "application/vnd.crowbar.v2.0+json", required: true
+  param :node, String, desc: "Node name", required: true
+  param :service, String, desc: "Service to clean restart flag for", required: true
+  api_version "2.0"
+
+  api :GET, "/api/restart_management/restarts", "Get a list of services that need restart"
+  header "Accept", "application/vnd.crowbar.v2.0+json", required: true
+  api_version "2.0"
+  def restarts
+    if request.post?
+      restarts_post
+    else
+      restarts_get
+    end
+  end
+
+  private
+
+  # Gets a list of the cookbooks and extract the values from their nodes
+  # this ignores the roles and groups together all the nodes under a cookbook
+  # this is because we use a cookbook-level service restart checks instead of
+  # doing it service level, which is more cumbersome and requires us to know a list of services
+  # beforehand
+  def restarts_get
+    # Chef query search to find all nodes that have requires_restart attribute not empty
+    nodes_with_restarts = NodeObject.find("requires_restart:*")
+    restart_requests_per_node = {}
+    nodes_with_restarts.each do |node|
+      restart_requests_per_node[node[:fqdn]] = { alias: node.alias }
+      managed_cookbooks.each do |cookbook|
+        # skip if there is not attributes for the cookbook or the requires_restart is empty
+        requires_restart = node.crowbar_wall.fetch(
+          "requires_restart", {}
+        ).fetch(
+          cookbook.to_s, {}
+        )
+        next if requires_restart.empty?
+        restart_requests_per_node[node[:fqdn]].update(cookbook => requires_restart)
+      end
+    end
+
+    render json: restart_requests_per_node
+  end
+
+  def restarts_post
+    params.require(:node)
+    params.require(:service)
+
+    node_name = params[:node]
+    service = params[:service]
+
+    node = get_node_or_raise(node_name)
+
+    managed_cookbooks.each do |cookbook|
+      next unless node.key? :crowbar_wall
+      next unless node[:crowbar_wall].key? :requires_restart
+      next unless node[:crowbar_wall][:requires_restart].key? cookbook
+      next unless node[:crowbar_wall][:requires_restart][cookbook].key? service
+      node[:crowbar_wall][:requires_restart][cookbook].delete(service)
+    end
+
+    node.save
+
+    head :ok
+  end
+
+  def configuration_get
+    # If its a GET call, just show a list of the cookbooks disallow_flag status
+    restart_management_configuration = Crowbar::DataBagConfig.get_or_create_databag_item(
+      "crowbar-config", "disallow_restart"
+    )
+    restart_management_configuration.raw_data.delete("id")
+    render json: restart_management_configuration.raw_data
+  end
+
+  def configuration_post
+    params.require(:disallow_restart)
+    params.require(:cookbook)
+
+    disallow_restart = params[:disallow_restart] == "true" ? true : false
+    cookbook = params[:cookbook]
+
+    # validate that the cookbook exists
+    raise Crowbar::Error::NotFound unless managed_cookbooks.include? cookbook
+
+    # update new value into databag
+    item = Crowbar::DataBagConfig.get_or_create_databag_item("crowbar-config", "disallow_restart")
+    item.update(cookbook => disallow_restart)
+    item.save
+
+    head :ok
+  end
+
+  def get_node_or_raise(node_name)
+    node = NodeObject.find("name:#{node_name}").first
+    raise Crowbar::Error::NotFound if node.nil?
+    node
+  end
+
+  def managed_cookbooks
+    # right now, we only look at openstack, and the cookbook names are the same as the barclamp
+    # names, so we can use the barclamp catalog.
+    BarclampCatalog.members("openstack").keys
+  end
+end

--- a/crowbar_framework/config/application.rb
+++ b/crowbar_framework/config/application.rb
@@ -63,5 +63,7 @@ module Crowbar
         Rails.logger.warn "Failed to load chef"
       end
     end
+    # experimental options
+    config.experimental = config_for(:experimental)
   end
 end

--- a/crowbar_framework/config/experimental.yml
+++ b/crowbar_framework/config/experimental.yml
@@ -1,0 +1,12 @@
+default: &default
+  disallow_restart:
+    enabled: false
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -268,5 +268,20 @@ Rails.application.routes.draw do
         get :upgrade
       end
     end
+
+    # service restart management
+    resource :restart_management,
+      constraints: lambda { |request|
+        Rails.application.config.experimental.fetch("disallow_restart", {}).fetch("enabled", false)
+      },
+      controller: :restart_management,
+      only: [] do
+      member do
+        post :configuration
+        get :configuration
+        post :restarts
+        get :restarts
+      end
+    end
   end
 end

--- a/crowbar_framework/spec/controllers/api/restart_management_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/restart_management_controller_spec.rb
@@ -1,0 +1,234 @@
+#
+# Copyright 2017, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+require "json"
+
+describe Api::RestartManagementController, type: :request, focus: true do
+  let(:headers) { { ACCEPT: "application/vnd.crowbar.v2.0+json" } }
+
+  context "Feature enabled" do
+
+    before(:each) do
+      @catalog = {
+        "neutron" => 10,
+        "nova" => 20,
+        "cinder" => 30
+      }
+      allow_any_instance_of(BarclampCatalog).to receive(:members).and_return(@catalog)
+      @nova_proposal = Proposal.where(barclamp: "nova", name: "default").create(
+        barclamp: "nova",
+        name: "default"
+      )
+      @cinder_proposal = Proposal.where(barclamp: "cinder", name: "default").create(
+        barclamp: "cinder",
+        name: "default"
+      )
+      @testing_node = NodeObject.find_by_name("testing.crowbar.com")
+      @admin_node = NodeObject.find_by_name("admin.crowbar.com")
+      @nova_proposal.raw_data["deployment"]["nova"]["elements"] = {
+        "openstack-nova-api" => ["testing.crowbar.com"]
+      }
+
+      @cinder_proposal.raw_data["deployment"]["cinder"]["elements"] = {
+        "openstack-cinder-api" => ["testing.crowbar.com"]
+      }
+      allow(Proposal).to receive(:where).with(barclamp: "neutron").and_return([])
+      allow(Proposal).to receive(:where).with(barclamp: "nova").and_return([@nova_proposal])
+      allow(Proposal).to receive(:where).with(barclamp: "cinder").and_return([@cinder_proposal])
+      allow(NodeObject).to receive(:find_by_name).with("testing.crowbar.com").and_return(
+        @testing_node
+      )
+      @databag_item = ::Chef::DataBagItem.load("crowbar-config", "disallow_restart")
+
+      # mock experimental config to test the controller
+      allow(
+        Rails.application.config.experimental
+      ).to receive(:fetch).with("disallow_restart", {}).and_return("enabled" => true)
+    end
+
+    context "GET configuration" do
+      it "lists the cookbooks and their disallowed_restart status" do
+
+        get "/api/restart_management/configuration", {}, headers
+        expect(response).to have_http_status(:ok)
+        expect(ActiveSupport::JSON.decode(response.body)).to eq("nova" => true, "cinder" => false)
+      end
+    end
+
+    context "POST configuration" do
+      it "enabling changes the cookbook disallow_restart status to true" do
+        allow(::Chef::DataBagItem).to receive(:load).with(
+          "crowbar-config", "disallow_restart"
+        ).and_return(@databag_item)
+
+        # check that we are saving the databag with the proper items
+        expect(@databag_item).to receive(:update).with("nova" => true)
+        expect(@databag_item).to receive(:save)
+        post "/api/restart_management/configuration", {
+          disallow_restart: true, cookbook: "nova"
+        }, headers
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "disabling changes the cookbook disallow_restart status to false" do
+        allow(::Chef::DataBagItem).to receive(:load).with(
+          "crowbar-config", "disallow_restart"
+        ).and_return(@databag_item)
+
+        # check that we are saving the databag with the proper items
+        expect(@databag_item).to receive(:update).with("nova" => false)
+        expect(@databag_item).to receive(:save)
+
+        post "/api/restart_management/configuration", {
+          disallow_restart: false, cookbook: "nova"
+        }, headers
+        expect(response).to have_http_status(:ok)
+      end
+
+      it "returns a 404 error if we pass a non-existant cookbook" do
+        post "/api/restart_management/configuration", {
+          disallow_restart: true, cookbook: "parrot"
+        }, headers
+        expect(response).to have_http_status(:not_found)
+      end
+    end
+
+    context "GET restarts" do
+      it "lists the nodes and the services that require service restarts" do
+        time = Time.now.getutc.to_s
+        @admin_node.set["crowbar_wall"]["requires_restart"]["nova"] = {
+          "openstack-nova-api" => {
+            "pacemaker_service" => false,
+            "timestamp" => time
+          }
+        }
+
+        @admin_node.set["crowbar_wall"]["requires_restart"]["neutron"] = {
+          "openstack-neutron" => {
+            "pacemaker_service" => false,
+            "timestamp" => time
+          }
+        }
+
+        @testing_node.set["crowbar_wall"]["requires_restart"]["cinder"] = {
+          "cinder-volume" => {
+            "pacemaker_service" => false,
+            "timestamp" => time
+          }
+        }
+        allow(NodeObject).to receive(:find).with("requires_restart:*").and_return(
+          [@admin_node, @testing_node]
+        )
+        get "/api/restart_management/restarts", {}, headers
+        expect(response).to have_http_status(:ok)
+        expect(ActiveSupport::JSON.decode(response.body)).to eq(
+          "admin.crowbar.com" => {
+            "alias" => "admin",
+            "neutron" => {
+              "openstack-neutron" => {
+                "pacemaker_service" => false,
+                "timestamp" => time
+              }
+            },
+            "nova" => {
+              "openstack-nova-api" => {
+                "pacemaker_service" => false,
+                "timestamp" => time
+              }
+            }
+          },
+          "testing.crowbar.com" => {
+            "alias" => "testing",
+            "cinder" => {
+              "cinder-volume" => {
+                "pacemaker_service" => false,
+                "timestamp" => time
+              }
+            }
+          }
+        )
+      end
+    end
+
+    context "POST restarts" do
+      it "cleans the restart flag for a service" do
+        @admin_node.set["crowbar_wall"]["requires_restart"]["nova"] = {
+          "openstack-nova-api" => {}
+        }
+        allow(NodeObject).to receive(:find).with(
+          "name:admin.crowbar.com"
+        ).and_return([@admin_node])
+
+        # check that the key is in ther first
+        expect(
+          @admin_node["crowbar_wall"]["requires_restart"]["nova"]
+        ).to include("openstack-nova-api")
+        post "/api/restart_management/restarts", {
+          node: "admin.crowbar.com",
+          service: "openstack-nova-api"
+        }, headers
+
+        expect(response).to have_http_status(:ok)
+        # it should be now removed from the node attributes
+        expect(
+          @admin_node["crowbar_wall"]["requires_restart"]["nova"]
+        ).to_not include("openstack-nova-api")
+      end
+
+      it "returns a 404 if the node could not be found" do
+        post "/api/restart_management/restarts", { node: "partyparrot", service: "_" }, headers
+        expect(response).to have_http_status(:not_found)
+      end
+
+    end
+  end
+
+  context "Feature disabled" do
+
+    context "GET configuration" do
+      it "should fail to reach the route" do
+        expect do
+          get "/api/restart_management/configuration", {}, headers
+        end.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context "POST configuration" do
+      it "should fail to reach the route" do
+        expect do
+          post "/api/restart_management/configuration", {}, headers
+        end.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context "GET restarts" do
+      it "should fail to reach the route" do
+        expect do
+          get "/api/restart_management/restarts", {}, headers
+        end.to raise_error(ActionController::RoutingError)
+      end
+    end
+
+    context "POST restarts" do
+      it "should fail to reach the route" do
+        expect do
+          post "/api/restart_management/restarts", {}, headers
+        end.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end

--- a/crowbar_framework/spec/fixtures/offline_chef/data_bag_item_crowbar-config-disallow_restart.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/data_bag_item_crowbar-config-disallow_restart.json
@@ -1,0 +1,5 @@
+{
+  "id": "disallow_restart",
+  "cinder": false,
+  "nova": true
+}

--- a/crowbar_framework/spec/fixtures/offline_chef/data_bag_item_crowbar-config.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/data_bag_item_crowbar-config.json
@@ -1,0 +1,1 @@
+{"id": "crowbar-config"}

--- a/crowbar_framework/spec/requests/api_versioning_spec.rb
+++ b/crowbar_framework/spec/requests/api_versioning_spec.rb
@@ -22,6 +22,8 @@ describe "API versioning", type: :request do
 
     it "checks the content type response for an api version" do
       routes.each do |route|
+        # there is no generic page for restart_management, only subpages
+        next if route == "api/restart_management"
         # for some reason backups doesn't contain /crowbar/ namespace
         route.gsub!("api", "api/crowbar") if route == "api/backups"
 


### PR DESCRIPTION
Allow end users to set a barclamp as "no service reboots allowed" to avoid automatic service restarts by chef .

There is several parts to this:

 - A new experimental config file to enable/disable experimental features like this one.
   - Found at crowbar_framework/config/experimental.yml
   - Gets loaded into the rails config at crowbar start, available at `Rails.application.config.experimental`


 - A chef dsl service resource monkey-patching
   - allows us to skip the service restart in case that a flag is set on the `crowbar-config -> disallow_restarts` databag
   - allows us to set the flag `node[cookbook_name][:requires_restart]` if a restart was skipped due to the `disallow_restart` flag with the barclamp, service name that requires restart, timestamp, and identification if this is a pacemaker service.


 - Several new routes on chef framework:
   - /restart_management/configuration
     - GET: List the barclamps and if service reboots are disallowed for them
     - POST(params: disallow_restarts, barclamp): Sets the disallow_restart flag for a barclamp
    - /restart_management/restarts
      - GET: Lists all of the services needing restarts
      - POST(params: node, service): Cleans the restart flag for the given service in the given node