### PR TITLE
Create event hook infrastructure

### DIFF
--- a/crowbar_framework/lib/crowbar/event_dispatcher.rb
+++ b/crowbar_framework/lib/crowbar/event_dispatcher.rb
@@ -1,0 +1,51 @@
+#
+# Copyright 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  class EventDispatcher
+    class << self
+      def trigger_hooks(event, details)
+        BarclampCatalog.barclamps.keys.each do |barclamp|
+          begin
+            cls = ServiceObject.get_service(barclamp)
+          rescue NameError
+            # catalog may contain barclamps which don't have services
+            next
+          end
+
+          next unless cls.method_defined?(:event_hook)
+
+          service = cls.new(Rails.logger)
+
+          proposals = Proposal.where(barclamp: barclamp)
+          proposals.each do |proposal|
+            next if proposal.role.nil?
+            begin
+              service.event_hook(proposal, event, details)
+            rescue StandardError => e
+              Rails.logger.error(
+                "Error while executing event_hook for barclamp '#{barclamp}', " \
+                "proposal '#{proposal.name}', and event '#{event}'. " \
+                "Error message is '#{e.message}'."
+              )
+            end
+          end
+        end
+      end
+      handle_asynchronously :trigger_hooks
+    end
+  end
+end


### PR DESCRIPTION
Rebase of PR #952 but only including the new infrastructure class

For usage examples, see:
https://github.com/crowbar/crowbar-core/pull/952
https://github.com/crowbar/crowbar-ha/pull/171
https://github.com/crowbar/crowbar-openstack/pull/717

There are several cases where we have events that should trigger some
activity in some other part of Crowbar. For instance:

 - when the public name of a node is saved, it may impact the endpoint
   of an OpenStack service
 - when the public name of the VIP of haproxy is changed, it impacts the
   endpoint of OpenStack services
 - when the keystone proposal is applied, we may want to reapply all
   proposals that depend on keystone

What we need for this is the ability to notify about the events in the
rails application and then dispatch the notifications to hooks which
listen for them and decide if some action should be triggered.

The main reason we didn't have this in the past is that we likely don't
want to do that in the foreground of the rails application. But now that
we have delayed_job, we can send the notifications and run the hooks in
the background.

In this commit, we add the simple infrastructure about notifications and
hooks:

 - the events are defined with a name and a hash that contains the
   details of the event. The structure of the hash depends on the event.

 - a simple dispatcher exists that simply connects the hooks to the
   events.

 - the hooks only exist for service objects for the time being; a
   service object simply needs to have a event_hook method to register
   the hook, and will need to filter for the events it cares about. The
   signature of event_hook is as follows:
     def event_hook(role, event, details)

It could be argued that the hooks should be registered for some specific
events (hence moving the filter to the event dispatcher), but it's not
worth the complexity for now.