### PR TITLE
network: Ensure default route exists

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -638,6 +638,14 @@ when "suse"
     code "wicked ifup all"
     only_if { run_wicked_ifup }
   end
+  # Sometimes wicked deletes the default route upon bringing up a new interface,
+  # make sure it gets put back
+  unless ::Kernel.system("ip route |grep -q default")
+    nic = default_route[:nic]
+    gw = default_route[:gateway]
+    Chef::Log.info("Adding default route via #{gw} to #{nic}")
+    ::Kernel.system("ip route add default via #{gw} dev #{nic}")
+  end
 
   # Avoid running the wicked related thing on SLE11 nodes
   unless node[:platform] == "suse" && node[:platform_version].to_f < 12.0


### PR DESCRIPTION
Sometimes when bringing up a new interface, wicked deletes the default
interface. We've seen this before[1] but we don't have a root cause.
This workaround ensures that after wicked ifup is called, the default
route is reapplied.

[1] https://bugzilla.suse.com/show_bug.cgi?id=1031077