### PR TITLE
travis: Make our travis config trusty ready

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: ruby
 sudo: false
+cache: bundler
+dist: trusty
 
-rvm: 2.1.0
+rvm: 2.1.9
 
 env: SKIP_CHECKS=yes
 


### PR DESCRIPTION
Travis started switching to the trusty image which breaks some of our
current setting. This PR fixes them.

cache: this speeds up the hound PR tests
dist: specify the dist to not mix between trusty and precise
rvm: 2.1.0 is not avalible anymore, switch to 2.1.9 which is used in SP3
(cherry picked from commit cb037a689155c94cbef709d8bcb50dd4b1390e76)