### PR TITLE
gem: Use rails 4.2.9

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -17,7 +17,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 4.2.2"
+gem "rails", "~> 4.2.9"
 gem "rake", "< 12.0.0"
 gem "haml-rails", "~> 0.9.0"
 gem "sass-rails", "~> 5.0.3"


### PR DESCRIPTION
SLE is updating rails to 4.2.9 so let's use and test against this release.