### PR TITLE
properly pass command args to bmc_cmd

### DIFF
--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -983,8 +983,9 @@ class Node < ChefObject
   end
 
   def bmc_cmd(cmd)
+    cmd_list = cmd.split
     if bmc_address.nil? || get_bmc_user.nil? || get_bmc_password.nil? ||
-        !system("ipmitool", "-I", get_bmc_interface, "-H", bmc_address, "-U", get_bmc_user, "-P", get_bmc_password, cmd)
+        !system("ipmitool", "-I", get_bmc_interface, "-H", bmc_address, "-U", get_bmc_user, "-P", get_bmc_password, *cmd_list)
       case cmd
       when "power cycle"
         ssh_command = "/sbin/reboot -f"


### PR DESCRIPTION
ruby's system method requires all args passed to the shell as single string
(no whitespace separated multi strings in one variable)

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**
none of the ipmi commands work, otherwise

**How does it address the issue?**
it splits the given command into multiple values for the system function

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
