### PR TITLE
change systemd dependency from crowbar to apache to Wants

### DIFF
--- a/configs/crowbar.service
+++ b/configs/crowbar.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Crowbar
 After=network.target syslog.target remote-fs.target chef-server.service
-Requires=apache2.service
+Wants=apache2.service
 Wants=postgresql.service
 Before=crowbar-jobs.service
 


### PR DESCRIPTION
Due to this change
https://github.com/crowbar/crowbar-core/commit/6edc8727442d3054bf22df7d4d579e1fdc8ab519#diff-0191694d58feeb77cc86bffcc5a68a83R30
Apache2 is "restarted" instead of "reloaded" during installation (as well as during restore).

Due to the dependency type "Requires" in
https://github.com/crowbar/crowbar-core/blob/stable/4.0/configs/crowbar.service#L4
Puma is also restarted when Apache2 is.

Due to Puma restarting during a crowbar restore the background thread is killed which performs the restore. Thus the restore never finishes.

This PR fixes this issue by changing the dependency from Puma to Apache2 to "Wants". With this starting Puma also starts Apache2. But Puma will not be shut down if Apache2 fails, stops or restarts.

See also:
https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Wants=


Tracked also here:
https://trello.com/c/AaVN1HLE/172-cloud-mkcloud7-job-backup-restore-x8664

I will also open a PR for this change for crowbar-init to make both unit files consistent in this regard.
