### PR TITLE
dhcp fix for UEFI (bsc#961536)

### DIFF
--- a/chef/cookbooks/dhcp/templates/default/dhcpd.conf.erb
+++ b/chef/cookbooks/dhcp/templates/default/dhcpd.conf.erb
@@ -18,6 +18,9 @@ option path-prefix code 210 = text;
 # have to hack syslog.conf to complete the redirection).
 log-facility local7;
 
+# Fix for https://bugzilla.opensuse.org/show_bug.cgi?id=961536
+always-reply-rfc1048 true;
+
 include "/etc/dhcp3/groups.d/group_list.conf";
 include "/etc/dhcp3/subnets.d/subnet_list.conf";
 include "/etc/dhcp3/hosts.d/host_list.conf";


### PR DESCRIPTION
Without the specific dhcp option:

always-reply-rfc1048 true;

Some machines fail to boot (DL160) and print something like this on the
console:

```
Loading Linux ...
error: time out opening `suse-...../loader/linux`
Loading initial ramdisk ...
error: you need to load the kernel first.

Press any key to...
```

(cherry picked from commit 7652fd8c1edbb24c7137bdb2e42328701e9bc47e)

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
