### PR TITLE
Properly pass command args to bmc_cmd

### DIFF
--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -982,8 +982,9 @@ class Node < ChefObject
   end
 
   def bmc_cmd(cmd)
+    cmd_list = cmd.split
     if bmc_address.nil? || get_bmc_user.nil? || get_bmc_password.nil? ||
-        !system("ipmitool", "-I", get_bmc_interface, "-H", bmc_address, "-U", get_bmc_user, "-P", get_bmc_password, cmd)
+        !system("ipmitool", "-I", get_bmc_interface, "-H", bmc_address, "-U", get_bmc_user, "-P", get_bmc_password, *cmd_list)
       case cmd
       when "power cycle"
         ssh_command = "/sbin/reboot -f"


### PR DESCRIPTION
Multiple string arguments mean that the system method runs the first
argument without a shell and passes subsequent arguments quoted to that
command [1].
This means that if the cmd string contains multiple substrings separated
by whitespace the whole string gets quoted into one argument and
passed to ipmitool which is incorrect.
By first splitting cmd on whitespace and then splatting the resulting
list into a list of arguments to system, all whitespace separated
substrings become separate arguments to ipmitool.

[1] https://ruby-doc.org/core-2.2.0/Kernel.html#method-i-system

(cherry picked from commit e339ca6de997df9828e05775e00777f9132da618)