### PR TITLE
Allow to discover IPMI settings for deployed nodes

### DIFF
--- a/chef/cookbooks/ipmi/recipes/role_ipmi.rb
+++ b/chef/cookbooks/ipmi/recipes/role_ipmi.rb
@@ -15,7 +15,7 @@
 #
 
 if CrowbarRoleRecipe.node_state_valid_for_role?(node, "ipmi", "ipmi")
-  if ["discovering", "hardware-installing", "readying"].include? node[:state]
+  if ["discovering", "hardware-installing", "readying", "ready"].include? node[:state]
     include_recipe "ipmi::ipmi-discover"
   end
 


### PR DESCRIPTION
**Why is this change necessary?**
https://bugzilla.suse.com/show_bug.cgi?id=885890
When IPMI was enabled after nodes were already deployed, it could not be used for STONITH.

**How does it address the issue?**
We also include the ipmi-discover recipe in 'ready' state

**Is there additional information worth sharing?**
The discover code will not run by default, only when a user does
`crowbarctl proposal edit ipmi default`
to add `ready` under
```
  "deployment": {
    "ipmi": {
      "element_states": {
        "ipmi":
```