### PR TITLE
ipmi: Option to disable BMC NAT

### DIFF
--- a/chef/data_bags/crowbar/migrate/ipmi/102_bmc_nat_enable.rb
+++ b/chef/data_bags/crowbar/migrate/ipmi/102_bmc_nat_enable.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "bmc_nat_enable"
+    a["bmc_nat_enable"] = ta["bmc_nat_enable"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete "bmc_nat_enable"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ipmi.json
+++ b/chef/data_bags/crowbar/template-ipmi.json
@@ -9,6 +9,7 @@
       "bmc_interface": "lanplus",
       "ignore_address_suggestions": false,
       "use_dhcp": false,
+      "bmc_nat_enable": true,
       "debug": false
     }
   },
@@ -16,7 +17,7 @@
     "ipmi": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 102,
       "element_states": {
         "ipmi": [ "discovering", "hardware-installing", "readying" ],
         "bmc-nat-router": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-ipmi.schema
+++ b/chef/data_bags/crowbar/template-ipmi.schema
@@ -10,6 +10,7 @@
             "bmc_interface": { "type": "str", "required": true },
             "use_dhcp":  { "type": "bool", "required": true},
             "ignore_address_suggestions": { "type": "bool", "required": true },
+            "bmc_nat_enable":  { "type": "bool", "required": true},
             "debug":  { "type": "bool", "required": true}
           }
         }

--- a/crowbar_framework/app/views/barclamp/ipmi/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/ipmi/_edit_attributes.html.haml
@@ -9,4 +9,5 @@
     = string_field :bmc_interface
     = boolean_field :use_dhcp
     = boolean_field :ignore_address_suggestions
+    = boolean_field :bmc_nat_enable
     = boolean_field :debug

--- a/crowbar_framework/config/locales/ipmi/en.yml
+++ b/crowbar_framework/config/locales/ipmi/en.yml
@@ -25,4 +25,5 @@ en:
         bmc_interface: 'BMC Interface'
         use_dhcp: 'BMC Should Use DHCP (Not explicitly assigned)'
         ignore_address_suggestions: 'Ignore Already Configured Address'
+        bmc_nat_enable: 'NAT BMC Through Admin Server'
         debug: 'Enable Barclamp Debug'


### PR DESCRIPTION
**Why is this change necessary?**
NATing IPMI access through Admin Server is not ideal in some cases.
STONITH based on this can trigger fencing if Admin Server is (temporarily) not accessible.

**How does it address the issue?**
This change adds option to disable BMC NAT feature.
Access from nodes to IPMI plane needs to be configured externally for this to work properly.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/Q7laJy5q/91-readonly-ipmi-use-existing-ipmi-settings-no-bmc-nat