### PR TITLE
Read only ipmi

### DIFF
--- a/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
+++ b/chef/cookbooks/ipmi/recipes/ipmi-configure.rb
@@ -30,6 +30,7 @@ end
 bmc_user     = node[:ipmi][:bmc_user]
 bmc_password = node[:ipmi][:bmc_password]
 use_dhcp     = node[:ipmi][:use_dhcp]
+readonly     = !node[:ipmi][:bmc_reconfigure]
 
 bmc_network = Barclamp::Inventory.get_network_by_type(node, "bmc")
 if bmc_network.nil?
@@ -72,7 +73,7 @@ if node[:ipmi][:bmc_enable]
     end
   end
 
-  unless node[:platform_family] == "windows" || node["crowbar_wall"]["status"]["ipmi"]["address_set"]
+  unless readonly || node[:platform_family] == "windows" || node["crowbar_wall"]["status"]["ipmi"]["address_set"]
     if use_dhcp
       ### lan parameters to check and set. The loop that follows iterates over this array.
       # [0] = name in "print" output, [1] command to issue, [2] desired value.
@@ -114,7 +115,7 @@ if node[:ipmi][:bmc_enable]
     end
   end
 
-  unless node[:platform_family] == "windows" || node["crowbar_wall"]["status"]["ipmi"]["user_set"]
+  unless readonly || node[:platform_family] == "windows" || node["crowbar_wall"]["status"]["ipmi"]["user_set"]
     ipmi_user_set "#{bmc_user}" do
       password bmc_password
       action :run

--- a/chef/data_bags/crowbar/migrate/ipmi/103_bmc_reconfigure.rb
+++ b/chef/data_bags/crowbar/migrate/ipmi/103_bmc_reconfigure.rb
@@ -1,0 +1,11 @@
+def upgrade(ta, td, a, d)
+  unless a.key? "bmc_reconfigure"
+    a["bmc_reconfigure"] = ta["bmc_reconfigure"]
+  end
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete "bmc_reconfigure"
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-ipmi.json
+++ b/chef/data_bags/crowbar/template-ipmi.json
@@ -7,6 +7,7 @@
       "bmc_user": "root",
       "bmc_password": "cr0wBar!",
       "bmc_interface": "lanplus",
+      "bmc_reconfigure": true,
       "ignore_address_suggestions": false,
       "use_dhcp": false,
       "bmc_nat_enable": true,
@@ -17,7 +18,7 @@
     "ipmi": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 102,
+      "schema-revision": 103,
       "element_states": {
         "ipmi": [ "discovering", "hardware-installing", "readying" ],
         "bmc-nat-router": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-ipmi.schema
+++ b/chef/data_bags/crowbar/template-ipmi.schema
@@ -8,6 +8,7 @@
             "bmc_user": { "type": "str", "required": true },
             "bmc_password": { "type": "str", "required": true },
             "bmc_interface": { "type": "str", "required": true },
+            "bmc_reconfigure":  { "type": "bool", "required": true},
             "use_dhcp":  { "type": "bool", "required": true},
             "ignore_address_suggestions": { "type": "bool", "required": true },
             "bmc_nat_enable":  { "type": "bool", "required": true},

--- a/crowbar_framework/app/models/ipmi_service.rb
+++ b/crowbar_framework/app/models/ipmi_service.rb
@@ -78,7 +78,8 @@ class IpmiService < ServiceObject
       ns = NetworkService.new
       role = RoleObject.find_role_by_name "#{@bc_name}-config-#{inst}"
 
-      if role && !role.default_attributes["ipmi"]["use_dhcp"]
+      if role && role.default_attributes["ipmi"]["bmc_reconfigure"] &&
+          !role.default_attributes["ipmi"]["use_dhcp"]
         Rails.logger.debug("IPMI transition: Allocate bmc address for #{name}")
         node = Node.find_by_name(name)
         suggestion = if role.default_attributes["ipmi"]["ignore_address_suggestions"]

--- a/crowbar_framework/app/views/barclamp/ipmi/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/ipmi/_edit_attributes.html.haml
@@ -7,7 +7,14 @@
     = string_field :bmc_user
     = password_field :bmc_password
     = string_field :bmc_interface
-    = boolean_field :use_dhcp
-    = boolean_field :ignore_address_suggestions
+    = boolean_field :bmc_reconfigure,
+     "data-showit" => "true",
+     "data-showit-target" => "#reconfigure_container",
+     "data-showit-direct" => "true"
+    %span.help-block
+      = t(".bmc_reconfigure_hint")
+    #reconfigure_container
+      = boolean_field :use_dhcp
+      = boolean_field :ignore_address_suggestions
     = boolean_field :bmc_nat_enable
     = boolean_field :debug

--- a/crowbar_framework/config/locales/ipmi/en.yml
+++ b/crowbar_framework/config/locales/ipmi/en.yml
@@ -23,6 +23,8 @@ en:
         bmc_user: 'BMC User'
         bmc_password: 'BMC Password'
         bmc_interface: 'BMC Interface'
+        bmc_reconfigure: 'Modify BMC Settings'
+        bmc_reconfigure_hint: 'When this option is disabled, Crowar will not reconfigure BMC. All BMC network settings need to be properly pre-configured on all nodes and users/passwords need to match the ones specified above.'
         use_dhcp: 'BMC Should Use DHCP (Not explicitly assigned)'
         ignore_address_suggestions: 'Ignore Already Configured Address'
         bmc_nat_enable: 'NAT BMC Through Admin Server'


### PR DESCRIPTION
**NOTE: https://github.com/crowbar/crowbar-ha/pull/232 is needed to complete this functionality wrt STONITH**

**Why is this change necessary?**
When IPMI boards are pre-configured with static IPs/users Crowbar should not try to allocate new IPs or change passwords. Only the discovery part should be done by Crowbar to detect the settings.

**How does it address the issue?**
New option is added which disables all write operations on IPMI interface.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/Q7laJy5q/91-readonly-ipmi-use-existing-ipmi-settings-no-bmc-nat
