### PR TITLE
Increase inotify max user instances

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -92,6 +92,13 @@ execute "enable netfilter for bridges" do
   subscribes :run, resources(cookbook_file: "modprobe-bridge.conf"), :delayed
 end
 
+# Increase inotify max user instances
+# https://bugs.launchpad.net/charms/+bug/1593041
+execute "increasing inotify max user instances" do
+  command "echo 1024 > /proc/sys/fs/inotify/max_user_instances"
+  action :nothing
+end
+
 conduit_map = Barclamp::Inventory.build_node_map(node)
 Chef::Log.debug("Conduit mapping for this node:  #{conduit_map.inspect}")
 route_pref = 10000


### PR DESCRIPTION
It has been found that during heavy network creation by Neutron (>1K
networks) dnsmasq is unable to complete due to lack of inotify user
instances.

The system default is 128 instances which doesn't cover this situation.
By (short) experimentation 1024 has been found to be a comprehensive
value.

Reference: https://bugs.launchpad.net/charms/+bug/1593041

Found while investigating: https://trello.com/c/M0umdQTM