### PR TITLE
Add utils_systemd_service_restart LWRP

### DIFF
--- a/chef/cookbooks/apache2/metadata.rb
+++ b/chef/cookbooks/apache2/metadata.rb
@@ -4,6 +4,7 @@ license "Apache 2.0"
 description "Installs and configures all aspects of apache2 using Debian style symlinks with helper definitions"
 long_description IO.read(File.join(File.dirname(__FILE__), "README.rdoc"))
 version "0.99.3"
+depends "utils"
 recipe "apache2", "Main Apache configuration"
 recipe "apache2::mod_alias", "Apache module 'alias' with config file"
 recipe "apache2::mod_auth_basic", "Apache module 'auth_basic'"

--- a/chef/cookbooks/apache2/recipes/default.rb
+++ b/chef/cookbooks/apache2/recipes/default.rb
@@ -222,3 +222,5 @@ service "apache2" do
   action [:enable, :start]
   ignore_failure true
 end
+
+utils_systemd_service_restart "apache2"

--- a/chef/cookbooks/utils/providers/systemd_service_restart.rb
+++ b/chef/cookbooks/utils/providers/systemd_service_restart.rb
@@ -1,0 +1,81 @@
+#
+# Copyright 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+def fetch_service(new_resource)
+  service = new_resource.service
+  if new_resource.fetch_name_from_service_resource
+    begin
+      service_resource = new_resource.resources(service: service)
+      service = service_resource.service_name
+    rescue Chef::Exceptions::ResourceNotFound
+      Chef::Log.warn("Unable to find resource for service #{service}!")
+    end
+  end
+  service
+end
+
+def write_conf_snippet(new_resource, snippet_variables)
+  service = fetch_service(new_resource)
+
+  etc_dir = "/etc/systemd/system/#{service}.service.d"
+
+  systemd_reload_resource_name = "reload systemd after restart config snippet change for #{service}"
+  bash systemd_reload_resource_name do
+    code "systemctl daemon-reload"
+    action :nothing
+  end
+
+  directory_resource = directory etc_dir do
+    owner "root"
+    group "root"
+    mode 0o755
+    action :nothing
+  end
+  directory_resource.run_action(:create)
+
+  template_resource = template ::File.join(etc_dir, "crowbar-restart.conf") do
+    owner "root"
+    group "root"
+    mode 0o644
+    cookbook "utils"
+    source "systemd_service_restart.conf.erb"
+    variables snippet_variables
+    notifies :run, "bash[#{systemd_reload_resource_name}]", :immediately
+  end
+  template_resource.run_action(:create)
+
+  new_resource.updated_by_last_action(template_resource.updated_by_last_action?)
+end
+
+action :enable do
+  variables = {
+    restart: new_resource.restart || "on-failure",
+    restart_sec: new_resource.restart_sec,
+    success_exit_status: new_resource.success_exit_status,
+    restart_prevent_exit_status: new_resource.restart_prevent_exit_status,
+    restart_force_exit_status: new_resource.restart_force_exit_status
+  }
+
+  write_conf_snippet(new_resource, variables)
+end
+
+action :disable do
+  variables = {
+    restart: "no"
+  }
+
+  write_conf_snippet(new_resource, variables)
+end

--- a/chef/cookbooks/utils/resources/systemd_service_restart.rb
+++ b/chef/cookbooks/utils/resources/systemd_service_restart.rb
@@ -1,0 +1,29 @@
+#
+# Copyright 2017, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :enable, :disable
+default_action :enable
+
+attribute :service, kind_of: String, name_attribute: true
+attribute :fetch_name_from_service_resource, kind_of: [TrueClass, FalseClass], default: true
+attribute :restart,
+  kind_of: String,
+  regex: /^(no|always|on-success|on-failure|on-abnormal|on-abort|on-watchdog)$/,
+  default: "on-failure"
+attribute :restart_sec, kind_of: String
+attribute :success_exit_status, kind_of: Array
+attribute :restart_prevent_exit_status, kind_of: Array
+attribute :restart_force_exit_status, kind_of: Array

--- a/chef/cookbooks/utils/templates/default/systemd_service_restart.conf.erb
+++ b/chef/cookbooks/utils/templates/default/systemd_service_restart.conf.erb
@@ -1,0 +1,14 @@
+[Service]
+Restart=<%= @restart %>
+<% unless @restart_sec.nil? || @restart_sec.empty? -%>
+RestartSec=<%= @restart_sec %>
+<% end -%>
+<% unless @success_exit_status.nil? || @success_exit_status.empty? -%>
+SuccessExitStatus=<%= @success_exit_status.map { |x| x.to_s }.join(" ") %>
+<% end -%>
+<% unless @restart_prevent_exit_status.nil? || @restart_prevent_exit_status.empty? -%>
+RestartPreventExitStatus=<%= @restart_prevent_exit_status.map { |x| x.to_s }.join(" ") %>
+<% end -%>
+<% unless @restart_force_exit_status.nil? || @restart_force_exit_status.empty? -%>
+RestartForceExitStatus=<%= @restart_force_exit_status.map { |x| x.to_s }.join(" ") %>
+<% end -%>


### PR DESCRIPTION
This resource adds (or removes) a systemd config snippet for a service,
to change the behavior to Restart=on-failure for that service. This
means systemd will automatically restart the service on failures, which
makes a relatively good self-healing solution without pacemaker.

See systemd.service(5) for details on Restart=

Note that the fetch_name_from_service_resource attribute of this
resource enables automatically fetching the systemd service name from
the service resource, which helps remove duplication of code in the
cookbooks when the service name is being overridden in the attributes of
the service resource. For instance, this will work as expected:
```
  service "foobar" do
    service_name "notfoobar"
  end

  utils_systemd_service_restart "foobar"
```