### PR TITLE
all: Make systemd restart services on failures

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -391,6 +391,7 @@ service "bind9" do
   supports restart: true, status: true, reload: true
   action [:enable, :start]
 end
+utils_systemd_service_restart "bind9"
 
 execute "reload nscd after dns config change" do
   command "nscd -i hosts"

--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -301,6 +301,13 @@ template "/etc/chef/solr.rb" do
   notifies :restart, "service[chef-solr]", :delayed
 end
 
+# Make systemd restart chef services (and their deps) on failure
+utils_systemd_service_restart "rabbitmq-server"
+utils_systemd_service_restart "couchdb"
+utils_systemd_service_restart "chef-solr"
+utils_systemd_service_restart "chef-expander"
+utils_systemd_service_restart "chef-server"
+
 if node[:platform_family] == "suse"
   cookbook_file "/etc/tmpfiles.d/crowbar.conf" do
     owner "root"
@@ -319,6 +326,7 @@ if node[:platform_family] == "suse"
   service "crowbar" do
     action :enable
   end
+  # No need for utils_systemd_service_restart: Restart= is already in the .service file
 else
   %w(chef-server-api chef-server-webui chef-solr rabbitmq-server).each do |f|
     file "/etc/logrotate.d/#{f}" do

--- a/chef/cookbooks/dhcp/metadata.json
+++ b/chef/cookbooks/dhcp/metadata.json
@@ -51,6 +51,7 @@
   "replacing": {
   },
   "dependencies": {
+    "utils": []
   },
   "groupings": {
   },

--- a/chef/cookbooks/dhcp/recipes/default.rb
+++ b/chef/cookbooks/dhcp/recipes/default.rb
@@ -180,4 +180,4 @@ service "dhcp3-server" do
   supports restart: true, status: true, reload: true
   action node[:provisioner][:enable_pxe] ? "enable" : ["disable", "stop"]
 end
-
+utils_systemd_service_restart "dhcp3-server"

--- a/chef/cookbooks/logging/recipes/common.rb
+++ b/chef/cookbooks/logging/recipes/common.rb
@@ -40,3 +40,4 @@ service "rsyslog" do
   supports restart: true, status: true, reload: true
   action [:enable, :start]
 end
+utils_systemd_service_restart "rsyslog"

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -43,6 +43,7 @@ if node[:network][:needs_openvswitch]
   end
   s.run_action :enable
   s.run_action :start
+  utils_systemd_service_restart node[:network][:ovs_service]
 
   # Cleanup on SLE12. Disable (NOT stop) old sysvinit service for ovs to avoid
   # issues (https://bugzilla.suse.com/show_bug.cgi?id=935912). We use the

--- a/chef/cookbooks/nfs-server/metadata.json
+++ b/chef/cookbooks/nfs-server/metadata.json
@@ -6,6 +6,7 @@
     "replacing": {
     },
     "dependencies": {
+      "utils": []
     },
     "groupings": {
     },

--- a/chef/cookbooks/nfs-server/recipes/default.rb
+++ b/chef/cookbooks/nfs-server/recipes/default.rb
@@ -55,6 +55,7 @@ package rpc_service
 service rpc_service do
   action [:enable, :start]
 end
+utils_systemd_service_restart rpc_service
 
 ["/var/log/crowbar/sledgehammer", "/updates"].each do |nfs_dir|
   directory nfs_dir do
@@ -70,6 +71,7 @@ service "nfs-kernel-server" do
   supports restart: true, status: true, reload: true
   action [:enable, :start]
 end
+utils_systemd_service_restart "nfs-kernel-server"
 
 execute "nfs-export" do
   command "exportfs -a"

--- a/chef/cookbooks/ntp/recipes/default.rb
+++ b/chef/cookbooks/ntp/recipes/default.rb
@@ -93,5 +93,6 @@ else
     supports restart: true, status: true, reload: true
     action [:enable, :start]
   end
+  utils_systemd_service_restart "ntp"
 end
 

--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -207,6 +207,8 @@ service "chef-client" do
   supports status: true, restart: true
   action :nothing
 end
+# Make systemd restart chef services (and their deps) on failure
+utils_systemd_service_restart "chef-client"
 
 config_file = "/etc/sysconfig/chef-client"
 

--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -308,6 +308,7 @@ if node[:platform_family] == "suse"
         action ["disable", "stop"]
       end
     end
+    # No need for utils_systemd_service_restart: it's handled in the template already
 
     bash "reload systemd after tftp.service update" do
       code "systemctl daemon-reload"

--- a/chef/cookbooks/provisioner/templates/default/tftp.service.erb
+++ b/chef/cookbooks/provisioner/templates/default/tftp.service.erb
@@ -4,3 +4,4 @@ Description=Tftp Server
 [Service]
 Type=simple
 ExecStart=/usr/sbin/in.tftpd -u tftp -s <%= @tftproot %> -m /etc/tftpd.conf -L -a <%= @admin_ip %> -B 1024 -v
+Restart=on-failure

--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -51,6 +51,9 @@ unless node[:platform_family] == "windows"
     end
     not_if { node["crowbar"]["admin_node"] && File.exist?("/var/lib/crowbar/install/disable_dns") }
   end
+  utils_systemd_service_restart "dnsmasq" do
+    not_if { node["crowbar"]["admin_node"] && File.exist?("/var/lib/crowbar/install/disable_dns") }
+  end
 
   # do a dup because we modify the content
   dns_list_with_local = dns_list.dup.insert(0, "127.0.0.1").take(3)


### PR DESCRIPTION
This offers some automatic recovery, which is nice. It turns out it's
also recommended by systemd documentation, in case a service is
long-running, which is the case here.

It's worth mentioning that in the past, the periodic chef-client has
been providing this, to some extent. But this means the recovery could
take up to 15 minutes. It was actually not working in the case of the
chef server infrastructure (chef-server, chef-solr, couchdb, etc.), and
systemd can really help here.

This is of course disabled when a service is managed by Pacemaker, as we
do not want to have systemd interfere with Pacemaker in that case. Note
that this commit doesn't touch any service managed by Pacemaker, though.