### PR TITLE
bind: set transfer-source to avoid xfer failures (bsc#1036601)

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -130,6 +130,8 @@ def make_zone(zone)
     master_ip = node[:dns][:master_ip]
   end
 
+  admin_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+
   Chef::Log.debug "Creating zone file for zones: #{zonefile_entries.inspect}"
   template "/etc/bind/zone.#{zone[:domain]}" do
     source "zone.erb"
@@ -138,7 +140,8 @@ def make_zone(zone)
     group "root"
     notifies :reload, "service[bind9]"
     variables(zonefile_entries: zonefile_entries,
-              master_ip: master_ip)
+              master_ip: master_ip,
+              admin_addr: admin_addr)
   end
   node.set[:dns][:zone_files] << "/etc/bind/zone.#{zone[:domain]}"
 
@@ -285,6 +288,9 @@ when "suse"
   end
 end
 
+# We would like to bind service only to ip address from admin network
+admin_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+
 # Load up our default zones.  These never change.
 if node[:dns][:master]
   files=%w{db.0 db.255 named.conf.default-zones}
@@ -299,7 +305,8 @@ files.each do |file|
     mode 0644
     owner "root"
     group bindgroup
-    variables(master_ip: master_ip)
+    variables(master_ip: master_ip,
+              admin_addr: admin_addr)
     notifies :reload, "service[bind9]"
   end
 end
@@ -347,9 +354,6 @@ if node[:dns][:master]
 else
   allow_transfer = []
 end
-
-# We would like to bind service only to ip address from admin network
-admin_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
 
 # When we're restoring the admin node from backup or upgrade data,
 # reject incoming DNS traffic to avoid sending wrong results to running

--- a/chef/cookbooks/bind9/templates/default/named.conf.default-zones.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.default-zones.erb
@@ -9,6 +9,7 @@ zone "0.in-addr.arpa" {
 <% else -%>
         type slave;
         masters { <%= @master_ip -%>; };
+        transfer-source <%= @admin_addr -%>;
         file "/etc/bind/slave/db.0";
 <% end %>
 };
@@ -20,6 +21,7 @@ zone "255.in-addr.arpa" {
 <% else -%>
         type slave;
         masters { <%= @master_ip -%>; };
+        transfer-source <%= @admin_addr -%>;
         file "/etc/bind/slave/db.255";
 <% end %>
 };

--- a/chef/cookbooks/bind9/templates/default/zone.erb
+++ b/chef/cookbooks/bind9/templates/default/zone.erb
@@ -13,6 +13,7 @@ zone "<%= zonefile_entry -%>" {
     type slave;
     notify no;
     masters { <%= @master_ip -%>; };
+    transfer-source <%= @admin_addr -%>;
     file "/etc/bind/slave/db.<%= zonefile_entry -%>";
 };
 <%   end %>


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=1036601

Currently bind isn't explicitely told which IP address to
request zone transfers from, while the server is configured to
specifically only accept zone transfer requests from the specific
list of whitelisted 2ndary slave ip addresses. Without that
change it happened that bind happened to choose another IP address
from the admin network (like an unrelated VIP allocated from admin)
for transfer, failing to sync up with master.

Cherry-picked from commit 6f450c3375b5437d443ec666560539
