### PR TITLE
provisioner: Make chef splay configurable

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -211,6 +211,7 @@ end
 config_file = "/etc/sysconfig/chef-client"
 
 chef_client_runs = node[:provisioner][:chef_client_runs] || 900
+chef_splay = node[:provisioner][:chef_splay] || 20
 
 template config_file do
   owner "root"
@@ -218,6 +219,7 @@ template config_file do
   mode "0644"
   source "chef_client.erb"
   variables(
+    chef_splay: chef_splay,
     chef_client_runs: chef_client_runs
   )
   notifies :restart, "service[chef-client]", :delayed

--- a/chef/cookbooks/provisioner/templates/default/chef_client.erb
+++ b/chef/cookbooks/provisioner/templates/default/chef_client.erb
@@ -1,4 +1,4 @@
 LOGFILE=/var/log/chef/client.log
 CONFIG=/etc/chef/client.rb
 INTERVAL=<%= @chef_client_runs %>
-SPLAY=20
+SPLAY=<%= @chef_splay %>

--- a/chef/data_bags/crowbar/migrate/provisioner/201_chef_splay.rb
+++ b/chef/data_bags/crowbar/migrate/provisioner/201_chef_splay.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["chef_splay"] = ta["chef_splay"] unless a.key? "chef_splay"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("chef_splay")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-provisioner.json
+++ b/chef/data_bags/crowbar/template-provisioner.json
@@ -215,6 +215,7 @@
           "debug": "debug"
         }
       },
+      "chef_splay": 20,
       "chef_client_runs": 900
     }
   },
@@ -222,7 +223,7 @@
     "provisioner": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "provisioner-server": [ "readying", "ready", "applying" ],
         "provisioner-base": [ "hardware-installing", "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-provisioner.schema
+++ b/chef/data_bags/crowbar/template-provisioner.schema
@@ -104,6 +104,7 @@
                 }
               }
             },
+            "chef_splay": { "type": "int", "required": true },
             "chef_client_runs": { "type": "int", "required": true }
           }
         }


### PR DESCRIPTION
**Why is this change necessary?**
For large installations many concurrent chef-client runs can cause significant load on chef-server and crowbar.

**How does it address the issue?**
Exposing `splay` parameter enables users to increase it to distribute the chef-server load caused by chef-clients.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/dcIa46O8/118-change-chef-client-splay