### PR TITLE
dns: fail on empty server list

### DIFF
--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -26,6 +26,11 @@ if dns_list.empty? && \
   dns_list = (node[:dns][:forwarders] + node[:dns][:nameservers]).flatten.compact
 end
 
+if dns_list.empty?
+  # better fail than leave the node with a broken DNS config
+  raise "List of DNS servers is empty"
+end
+
 unless node[:platform_family] == "windows"
   package "dnsmasq"
 


### PR DESCRIPTION
**Why is this change necessary?**
Discovered when working on http://bugzilla.novell.com/show_bug.cgi?id=1058017
Nodes that are not 'ready' are not considered available to serve as DNS server, but this can lead to situations were nodes drop all entries from /etc/resolv.conf and dnsmasq.conf and cannot resolve any DNS anymore.

**How does it address the issue?**
we detect that case and raise a (fatal) exception
to not screw up existing resolv.conf and dnsmasq.conf
which would make it hard to leave this state,
because rabbitmq (and possibly others (especially with SSL)) needs DNS to work.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
There is probably more to that bug, such as nodes losing roles, not just config flags under certain conditions.