### PR TITLE
[4.0] provisioner: Make chef splay configurable

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -211,6 +211,7 @@ end
 config_file = "/etc/sysconfig/chef-client"
 
 chef_client_runs = node[:provisioner][:chef_client_runs] || 900
+chef_splay = node[:provisioner][:chef_splay] || 20
 
 template config_file do
   owner "root"
@@ -218,6 +219,7 @@ template config_file do
   mode "0644"
   source "chef_client.erb"
   variables(
+    chef_splay: chef_splay,
     chef_client_runs: chef_client_runs
   )
   notifies :restart, "service[chef-client]", :delayed

--- a/chef/cookbooks/provisioner/templates/default/chef_client.erb
+++ b/chef/cookbooks/provisioner/templates/default/chef_client.erb
@@ -1,4 +1,4 @@
 LOGFILE=/var/log/chef/client.log
 CONFIG=/etc/chef/client.rb
 INTERVAL=<%= @chef_client_runs %>
-SPLAY=20
+SPLAY=<%= @chef_splay %>

--- a/chef/data_bags/crowbar/migrate/provisioner/103_chef_splay.rb
+++ b/chef/data_bags/crowbar/migrate/provisioner/103_chef_splay.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["chef_splay"] = ta["chef_splay"] unless a.key? "chef_splay"
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("chef_splay")
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-provisioner.json
+++ b/chef/data_bags/crowbar/template-provisioner.json
@@ -193,6 +193,7 @@
           "debug": "debug"
         }
       },
+      "chef_splay": 20,
       "chef_client_runs": 900
     }
   },
@@ -200,7 +201,7 @@
     "provisioner": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 102,
+      "schema-revision": 103,
       "element_states": {
         "provisioner-server": [ "readying", "ready", "applying" ],
         "provisioner-base": [ "hardware-installing", "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-provisioner.schema
+++ b/chef/data_bags/crowbar/template-provisioner.schema
@@ -104,6 +104,7 @@
                 }
               }
             },
+            "chef_splay": { "type": "int", "required": true },
             "chef_client_runs": { "type": "int", "required": true }
           }
         }


### PR DESCRIPTION
backport of #1334 

NOTE: I'm not sure if migration is backported properly (i.e. should the number be moved to Cloud7 range?)