### PR TITLE
dns: Run dns-client role only in readying/ready/applying states

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -130,6 +130,8 @@ def make_zone(zone)
     master_ip = node[:dns][:master_ip]
   end
 
+  admin_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+
   Chef::Log.debug "Creating zone file for zones: #{zonefile_entries.inspect}"
   template "/etc/bind/zone.#{zone[:domain]}" do
     source "zone.erb"
@@ -138,7 +140,8 @@ def make_zone(zone)
     group "root"
     notifies :reload, "service[bind9]"
     variables(zonefile_entries: zonefile_entries,
-              master_ip: master_ip)
+              master_ip: master_ip,
+              admin_addr: admin_addr)
   end
   node.set[:dns][:zone_files] << "/etc/bind/zone.#{zone[:domain]}"
 
@@ -285,6 +288,9 @@ when "suse"
   end
 end
 
+# We would like to bind service only to ip address from admin network
+admin_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
+
 # Load up our default zones.  These never change.
 if node[:dns][:master]
   files=%w{db.0 db.255 named.conf.default-zones}
@@ -299,7 +305,8 @@ files.each do |file|
     mode 0644
     owner "root"
     group bindgroup
-    variables(master_ip: master_ip)
+    variables(master_ip: master_ip,
+              admin_addr: admin_addr)
     notifies :reload, "service[bind9]"
   end
 end
@@ -347,9 +354,6 @@ if node[:dns][:master]
 else
   allow_transfer = []
 end
-
-# We would like to bind service only to ip address from admin network
-admin_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").address
 
 # When we're restoring the admin node from backup or upgrade data,
 # reject incoming DNS traffic to avoid sending wrong results to running

--- a/chef/cookbooks/bind9/templates/default/named.conf.default-zones.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.default-zones.erb
@@ -9,6 +9,7 @@ zone "0.in-addr.arpa" {
 <% else -%>
         type slave;
         masters { <%= @master_ip -%>; };
+        transfer-source <%= @admin_addr -%>;
         file "/etc/bind/slave/db.0";
 <% end %>
 };
@@ -20,6 +21,7 @@ zone "255.in-addr.arpa" {
 <% else -%>
         type slave;
         masters { <%= @master_ip -%>; };
+        transfer-source <%= @admin_addr -%>;
         file "/etc/bind/slave/db.255";
 <% end %>
 };

--- a/chef/cookbooks/bind9/templates/default/zone.erb
+++ b/chef/cookbooks/bind9/templates/default/zone.erb
@@ -13,6 +13,7 @@ zone "<%= zonefile_entry -%>" {
     type slave;
     notify no;
     masters { <%= @master_ip -%>; };
+    transfer-source <%= @admin_addr -%>;
     file "/etc/bind/slave/db.<%= zonefile_entry -%>";
 };
 <%   end %>

--- a/chef/cookbooks/resolver/recipes/default.rb
+++ b/chef/cookbooks/resolver/recipes/default.rb
@@ -38,35 +38,33 @@ search_domains.unshift(node[:dns][:domain])
 search_domains.uniq!
 
 unless node[:platform_family] == "windows"
-  unless CrowbarHelper.in_sledgehammer?(node)
-    package "dnsmasq"
+  package "dnsmasq"
 
-    template "/etc/dnsmasq.conf" do
-      source "dnsmasq.conf.erb"
-      owner "root"
-      group "root"
-      mode 0644
-      # do a dup, because we'll insert 127.0.0.1 later on
-      variables(nameservers: dns_list.dup)
-    end
-
-    file "/etc/resolv-forwarders.conf" do
-      action :delete
-    end
-
-    service "dnsmasq" do
-      supports status: true, start: true, stop: true, restart: true
-      action [:enable, :start]
-      subscribes :restart, "template[/etc/dnsmasq.conf]"
-      if node["roles"].include?("dns-server")
-        # invalidate dnsmasq cache if local zone changes
-        subscribes :reload, "template[/etc/bind/db.#{node[:dns][:domain]}]"
-      end
-      not_if { node["crowbar"]["admin_node"] && ::File.exist?("/var/lib/crowbar/install/disable_dns") }
-    end
-
-    dns_list = dns_list.insert(0, "127.0.0.1").take(3)
+  template "/etc/dnsmasq.conf" do
+    source "dnsmasq.conf.erb"
+    owner "root"
+    group "root"
+    mode 0644
+    # do a dup, because we'll insert 127.0.0.1 later on
+    variables(nameservers: dns_list.dup)
   end
+
+  file "/etc/resolv-forwarders.conf" do
+    action :delete
+  end
+
+  service "dnsmasq" do
+    supports status: true, start: true, stop: true, restart: true
+    action [:enable, :start]
+    subscribes :restart, "template[/etc/dnsmasq.conf]"
+    if node["roles"].include?("dns-server")
+      # invalidate dnsmasq cache if local zone changes
+      subscribes :reload, "template[/etc/bind/db.#{node[:dns][:domain]}]"
+    end
+    not_if { node["crowbar"]["admin_node"] && ::File.exist?("/var/lib/crowbar/install/disable_dns") }
+  end
+
+  dns_list = dns_list.insert(0, "127.0.0.1").take(3)
 
   template "/etc/resolv.conf" do
     source "resolv.conf.erb"

--- a/chef/data_bags/crowbar/migrate/dns/012_dns_client_states.rb
+++ b/chef/data_bags/crowbar/migrate/dns/012_dns_client_states.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  return a, d
+end
+
+def downgrade(ta, td, a, d)
+  d["element_states"] = td["element_states"]
+  return a, d
+end

--- a/chef/data_bags/crowbar/template-dns.json
+++ b/chef/data_bags/crowbar/template-dns.json
@@ -16,10 +16,10 @@
     "dns": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 11,
+      "schema-revision": 12,
       "element_states": {
         "dns-server": [ "readying", "ready", "applying" ],
-        "dns-client": [ "all" ]
+        "dns-client": [ "readying", "ready", "applying" ]
       },
       "elements": {},
       "element_order": [


### PR DESCRIPTION
This is like nearly all other roles.

The change only really impacts the discovery image, but it turns out
that with the discovery image, we use DHCP, so we get the DNS info from
DHCP in that case.

(cherry picked from commit 8e980e6f5d02f78b54113b7d92a16009812c2ca7)

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
