### PR TITLE
Add json version of /clusters endpoint

### DIFF
--- a/crowbar_framework/app/controllers/dashboard_controller.rb
+++ b/crowbar_framework/app/controllers/dashboard_controller.rb
@@ -3,6 +3,10 @@ class DashboardController < ApplicationController
 
   def clusters
     @clusters = ServiceObject.available_clusters
+    respond_to do |format|
+      format.html
+      format.json { render json: @clusters }
+    end
   end
 
   def active_roles


### PR DESCRIPTION
**Why is this change necessary?**
/clusters rendered the HTML view of clusters but didn't provide json version for use in crowbar-client (needed for filtering of deployment lists).

**How does it address the issue?**
Handler was added to properly render json view of clusters data.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/zxBV0sly/89-remove-deleted-nodes-from-proposals-using-the-cli