### PR TITLE
[POC] skip unready nodes on barclamp deployment

### DIFF
--- a/crowbar_framework/config/application.rb
+++ b/crowbar_framework/config/application.rb
@@ -63,5 +63,7 @@ module Crowbar
         Rails.logger.warn "Failed to load chef"
       end
     end
+    # experimental options
+    config.experimental = config_for(:experimental)
   end
 end

--- a/crowbar_framework/config/experimental.yml
+++ b/crowbar_framework/config/experimental.yml
@@ -1,0 +1,14 @@
+default: &default
+  skip_unready_nodes:
+    enabled: false
+    roles:
+     - dns-client
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default


### PR DESCRIPTION
Background:

When changing the DNS forwarder in the DNS barclamp all nodes of the cloud must be ready and accessible to apply the change, although the change does not affect all nodes.

There must be a way to only target affected or a selected sub-set of nodes:

-  just ignore not ready/not accessible nodes (they will be automatically updated on their next local chef-client run)
