### PR TITLE
Remove unready nodes from deployment

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -248,9 +248,9 @@ class ServiceObject
 #   process_queue - see what we can execute
 #
 
-  def queue_proposal(inst, element_order, elements, deps, bc = @bc_name)
+  def queue_proposal(inst, element_order, elements, deps, bc = @bc_name, pre_cached_nodes = {})
     Crowbar::DeploymentQueue.new(logger: Rails.logger).queue_proposal(
-      bc, inst, elements, element_order, deps
+      bc, inst, elements, element_order, deps, pre_cached_nodes
     )
   end
 
@@ -945,6 +945,11 @@ class ServiceObject
     # Cache some node attributes to avoid useless node reloads
     node_attr_cache = {}
 
+    # experimental option
+    skip_unready_nodes_enabled = Rails.application.config.experimental.fetch(
+      "skip_unready_nodes", {}
+    ).fetch("enabled", false)
+
     # Part I: Looking up data & checks
     #
     # we look up the role in the database (if there is one), the new one is
@@ -970,50 +975,6 @@ class ServiceObject
     new_elements = new_deployment["elements"]
     element_order = new_deployment["element_order"]
 
-    # When bootstrapping, we don't run chef, so there's no need for queuing
-    if bootstrap
-      pre_cached_nodes = {}
-      # do not try to process the queue in any case
-      in_queue = true
-    else
-      # Attempt to queue the proposal.  If delay is empty, then run it.
-      deps = proposal_dependencies(role)
-      delay, pre_cached_nodes = queue_proposal(inst, element_order, new_elements, deps)
-      unless delay.empty?
-        # force not processing the queue further
-        in_queue = true
-        # FIXME: this breaks the convention that we return a string; but really,
-        # we should return a hash everywhere, to avoid this...
-        return [202, delay]
-      end
-
-      Rails.logger.debug "delay empty - running proposal"
-    end
-
-    # expand items in elements that are not nodes
-    expanded_new_elements = {}
-    new_deployment["elements"].each do |role_name, nodes|
-      expanded_new_elements[role_name], failures = expand_nodes_for_all(nodes)
-      unless failures.nil? || failures.empty?
-        Rails.logger.fatal(
-          "apply_role: Failed to expand items #{failures.inspect} for role \"#{role_name}\""
-        )
-        message = "Failed to apply the proposal: cannot expand list of nodes for role \"#{role_name}\", following items do not exist: #{failures.join(", ")}"
-        Rails.logger.progress("Failed to apply role #{role.name}")
-        update_proposal_status(inst, "failed", message)
-        return [405, message]
-      end
-    end
-    new_elements = expanded_new_elements
-
-    # save list of expanded elements, as this is needed when we look at the old
-    # role. See below the comments for old_elements.
-    if new_elements != new_deployment["elements"]
-      new_deployment["elements_expanded"] = new_elements
-    else
-      new_deployment.delete("elements_expanded")
-    end
-
     # Build a list of old elements.
     # elements_expanded on the old role is guaranteed to exists, as we already
     # ran through apply_role with the old_role.  Cache is used for the case
@@ -1027,6 +988,64 @@ class ServiceObject
         old_elements = old_deployment["elements"]
       end
     end
+
+    # When bootstrapping, we don't run chef, so there's no need for queuing
+    if bootstrap
+      pre_cached_nodes = {}
+      # do not try to process the queue in any case
+      in_queue = true
+    else
+      # Attempt to queue the proposal.  If delay is empty, then run it.
+      deps = proposal_dependencies(role)
+      if skip_unready_nodes_enabled
+        elements_without_unready, pre_cached_nodes = skip_unready_nodes(
+          @bc_name, inst, new_elements, old_elements
+        )
+        delay, pre_cached_nodes = queue_proposal(
+          inst, element_order, elements_without_unready, deps, @bc_name, pre_cached_nodes
+        )
+      else
+        delay, pre_cached_nodes = queue_proposal(inst, element_order, new_elements, deps)
+      end
+
+      unless delay.empty?
+        # force not processing the queue further
+        in_queue = true
+        # FIXME: this breaks the convention that we return a string; but really,
+        # we should return a hash everywhere, to avoid this...
+        return [202, delay]
+      end
+
+      Rails.logger.debug "delay empty - running proposal"
+    end
+
+    new_elements, failures, msg = expand_items_in_elements(new_deployment["elements"])
+    unless failures.nil?
+      Rails.logger.progress("apply_role: Failed to apply role #{role.name}")
+      update_proposal_status(inst, "failed", msg)
+      return [405, msg]
+    end
+
+    # save list of expanded elements, as this is needed when we look at the old
+    # role. See below the comments for old_elements.
+    if new_elements != new_deployment["elements"]
+      new_deployment["elements_expanded"] = new_elements
+    else
+      new_deployment.delete("elements_expanded")
+    end
+
+    if skip_unready_nodes_enabled
+      # if we have removed nodes from the list, make sure to expand them and overwrite the
+      # new_elements var so we dont try to run chef-client on those not-ready nodes
+      new_elements, failures, msg = expand_items_in_elements(elements_without_unready)
+      unless failures.nil?
+        Rails.logger.progress("apply_role: Failed to apply role #{role.name}")
+        update_proposal_status(inst, "failed", msg)
+        return [405, msg]
+      end
+    end
+
+    # use the same order as in the old deployment if the element order is not filled yet
     element_order = old_deployment["element_order"] if (!old_deployment.nil? and element_order.nil?)
 
     Rails.logger.debug "old_deployment #{old_deployment.pretty_inspect}"
@@ -1421,6 +1440,22 @@ class ServiceObject
     []
   end
 
+  def expand_items_in_elements(elements)
+    # expand items in elements that are not nodes
+    expanded_new_elements = {}
+    elements.each do |role_name, nodes|
+      expanded_new_elements[role_name], failures = expand_nodes_for_all(nodes)
+      next if failures.nil? || failures.empty?
+      Rails.logger.fatal(
+        "apply_role: Failed to expand items #{failures.inspect} for role \"#{role_name}\""
+      )
+      msg = "Failed to apply the proposal: cannot expand list of nodes " \
+        "for role \"#{role_name}\", following items do not exist: #{failures.join(", ")}"
+      return [nil, failures, msg]
+    end
+    [expanded_new_elements, nil, nil]
+  end
+
   def add_role_to_instance_and_node(barclamp, instance, name, prop, role, newrole)
     node = Node.find_by_name(name)
     if node.nil?
@@ -1724,5 +1759,35 @@ class ServiceObject
       Rails.logger.error(([e2.message] + e2.backtrace).join("\n"))
       [400, e2.message]
     end
+  end
+
+  def skip_unready_nodes(bc, inst, new_elements, old_elements)
+    logger.debug("skip_unready_nodes: enter for #{bc}:#{inst}")
+    skip_unready_nodes_roles = Rails.application.config.experimental.fetch(
+      "skip_unready_nodes", {}
+    ).fetch("roles", [])
+    pre_cached_nodes = {}
+    cleaned_elements = new_elements.deep_dup
+    skip_unready_nodes_roles.each do |role|
+      # only do something if we have the same role on both old and new
+      next unless new_elements.key?(role) && old_elements.key?(role)
+      # we only can skip nodes that are on both old and new, as we know that those old nodes had
+      # the roles applied and will eventually become consistent with the deployment due to the
+      # periodic chef run
+      shared_elements = new_elements[role] & old_elements[role]
+      shared_elements.each do |n|
+        pre_cached_nodes[n] ||= Node.find_by_name(n)
+        node = pre_cached_nodes[n]
+        next if node.nil?
+        # skip if nodes are on ready or crowbar_upgrade state, we dont need to do anything
+        next if ["ready", "crowbar_upgrade"].include?(node.crowbar["state"])
+        logger.warn(
+          "Node #{n} is skipped until next chef run for #{bc}:#{inst} with role #{role}"
+        )
+        cleaned_elements[role].delete(n)
+      end
+    end
+    logger.debug("skip_unready_nodes: exit for #{bc}:#{inst}")
+    [cleaned_elements, pre_cached_nodes]
   end
 end

--- a/crowbar_framework/config/experimental.yml
+++ b/crowbar_framework/config/experimental.yml
@@ -1,6 +1,26 @@
 default: &default
   disallow_restart:
     enabled: false
+  skip_unready_nodes:
+    enabled: false
+    roles:
+     - bmc-nat-client
+     - ceilometer-agent
+     - deployer-client
+     - dns-client
+     - ipmi
+     - logging-client
+     - nova-compute-ironic
+     - nova-compute-kvm
+     - nova-compute-qemu
+     - nova-compute-vmware
+     - nova-compute-xen
+     - nova-compute-zvm
+     - ntp-client
+     - provisioner-base
+     - suse-manager-client
+     - swift-storage
+     - updater
 
 development:
   <<: *default

--- a/crowbar_framework/lib/crowbar/deployment_queue.rb
+++ b/crowbar_framework/lib/crowbar/deployment_queue.rb
@@ -26,10 +26,9 @@ module Crowbar
     # Receives proposal info (name, barclamp), list of nodes (elements), on which the proposal
     # should be applied, and list of dependencies - a list of {barclamp, name/inst} hashes.
     # It adds them to the queue, if possible.
-    def queue_proposal(bc, inst, elements, element_order, deps)
+    def queue_proposal(bc, inst, elements, element_order, deps, pre_cached_nodes)
       logger.debug("queue proposal: enter for #{bc}:#{inst}")
       delay = []
-      pre_cached_nodes = {}
       begin
         lock = acquire_lock("queue")
 
@@ -41,7 +40,9 @@ module Crowbar
 
         # Delay is a list of nodes that are not in ready state. pre_cached_nodes
         # is an uninteresting optimization.
-        delay, pre_cached_nodes = add_pending_elements(bc, inst, element_order, elements, queue_me)
+        delay, pre_cached_nodes = add_pending_elements(
+          bc, inst, element_order, elements, queue_me, pre_cached_nodes
+        )
 
         # We have all nodes ready.
         if delay.empty?
@@ -333,7 +334,6 @@ module Crowbar
 
       # Delay is the list of nodes that are not ready and are needed for this deploy to run
       delay = []
-      pre_cached_nodes = {}
       begin
         # Check for delays and build up cache
         # FIXME: why?
@@ -374,10 +374,9 @@ module Crowbar
       # Check to see if we should delay our commit until nodes are ready.
       delay = []
       nodes.each do |n|
-        node = Node.find_by_name(n)
+        pre_cached_nodes[n] ||= Node.find_by_name(n)
+        node = pre_cached_nodes[n]
         next if node.nil?
-
-        pre_cached_nodes[n] = node
         # allow commiting proposal for nodes in the crowbar_upgrade state
         state = node.crowbar["state"]
         delay << n if (state != "ready" && state != "crowbar_upgrade") && !delay.include?(n)

--- a/crowbar_framework/lib/crowbar/deployment_queue.rb
+++ b/crowbar_framework/lib/crowbar/deployment_queue.rb
@@ -147,11 +147,11 @@ module Crowbar
 
             next unless dependencies_satisfied?(item.properties["deps"])
 
-            nodes_map = elements_to_nodes_to_roles_map(
+            nodes_map, pre_cached_nodes = elements_to_nodes_to_roles_map(
               prop["deployment"][item.barclamp]["elements"],
               prop["deployment"][item.barclamp]["element_order"]
             )
-            delay, pre_cached_nodes = elements_not_ready(nodes_map.keys)
+            delay, = elements_not_ready(nodes_map.keys, pre_cached_nodes)
             proposal_to_commit = { barclamp: item.barclamp, inst: item.name } if delay.empty?
           end
 
@@ -278,11 +278,12 @@ module Crowbar
     # should be emptied.  FIXME: looks like bc-inst: value should be a list, not
     # a hash?
     def remove_pending_elements(bc, inst, elements)
-      nodes_map = elements_to_nodes_to_roles_map(elements)
+      nodes_map, = elements_to_nodes_to_roles_map(elements)
 
       # Remove the entries from the nodes.
       new_lock("BA-LOCK").with_lock do
         nodes_map.each do |node_name, data|
+          # TODO(itxaka): Maybe we can optimize this to use the node cache safely?
           node = Node.find_by_name(node_name)
           next if node.nil?
           unless node.crowbar["crowbar"]["pending"].nil? or node.crowbar["crowbar"]["pending"]["#{bc}-#{inst}"].nil?
@@ -296,7 +297,7 @@ module Crowbar
     # Create map with nodes and their element list
     # Transform ( {role => [nodes], role1 => [nodes]} hash to { node => [roles], node1 => [roles]},
     # accounting for clusters
-    def elements_to_nodes_to_roles_map(elements, element_order = [])
+    def elements_to_nodes_to_roles_map(elements, element_order = [], pre_cached_nodes = {})
       nodes_map = {}
       active_elements = element_order.flatten
 
@@ -311,7 +312,8 @@ module Crowbar
 
         # Add the role to node's list
         nodes.each do |node_name|
-          if Node.find_by_name(node_name).nil?
+          pre_cached_nodes[node_name] ||= Node.find_by_name(node_name)
+          if pre_cached_nodes[node_name].nil?
             logger.debug "elements_to_nodes_to_roles_map: skipping deleted node #{node_name}"
             next
           end
@@ -320,12 +322,14 @@ module Crowbar
         end
       end
 
-      nodes_map
+      [nodes_map, pre_cached_nodes]
     end
 
     # Get a hash of {node => [roles], node1 => [roles]}
     def add_pending_elements(bc, inst, element_order, elements, queue_me, pre_cached_nodes = {})
-      nodes_map = elements_to_nodes_to_roles_map(elements, element_order)
+      nodes_map, pre_cached_nodes = elements_to_nodes_to_roles_map(
+        elements, element_order, pre_cached_nodes
+      )
 
       # We need to be sure that we're the only ones modifying the node records at this point.
       # This will work for preventing changes from rails app, but not necessarily chef.


### PR DESCRIPTION
If we set the experimental skip_unready_nodes config to true and provide
a list of roles, we try to skip nodes that are not ready from the
deployment of the barclamp so we dont need all nodes to be ready to
deploy a barclamp.
    
This is useful when dealing with a high number of nodes (i.e.
nova-compute) and we dont need all those other nodes to be ready to add
a new node to a role

Background: 

When changing the DNS forwarder in the DNS barclamp all nodes of the cloud must be ready and accessible to apply the change, although the change does not affect all nodes.

There must be a way to only target affected or a selected sub-set of nodes:

just ignore not ready/not accessible nodes (they will be automatically updated on their next local chef-client run)