### PR TITLE
Add chef_splay to allowed time without update

### DIFF
--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -313,6 +313,7 @@ class Node < ChefObject
     if self.crowbar["state"] === "ready" and @node["ohai_time"]
       since_last = Time.now.to_i-@node["ohai_time"].to_i
       max_last = @node.default_attrs["provisioner"]["chef_client_runs"] || 900
+      max_last += @node.default_attrs["provisioner"]["chef_splay"] || 20
       max_last += 300 # time + 5 min buffer time
       return "noupdate" if since_last > max_last
     end


### PR DESCRIPTION
**Why is this change necessary?**
After chef_splay was added, node state can change to "unknown" because interval between chef-client runs can be longer.

**How does it address the issue?**
This change adds chef_splay to calculation to get upper limit for chef-client run properly.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/WXL2ZVg6/148-crowbar-consider-splay-when-calculating-node-status