### PR TITLE
crowbar: Fill pre_cached_nodes with one search

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1305,6 +1305,13 @@ class ServiceObject
         node_attr_cache[node_name]["windows"]
       end
 
+      # refill pre_cached_nodes in one call instead of allowing
+      # #remote_chef_client_threads to load node by node, thus speeding it up?
+      nodes_to_run.each_slice(50) do |partial_nodes|
+        search = (partial_nodes.map { |n| "name:#{n}" }).join(" OR ")
+        NodeObject.find(search).map { |n| pre_cached_nodes[n.name] = n }
+      end
+
       threads = remote_chef_client_threads(nodes_to_run, pre_cached_nodes,
                                            roles)
 


### PR DESCRIPTION
As we reset the pre_cached_nodes before calling
remote_chef_client_threads the caceh will be empty and the nodes will
have to be loaded one by one, which in a higher number of nodes
translates to a higher number of chef api calls.

Instead, pre-fill the pre_cached_nodes by doing just one search to
include all the nodes that we are gonna modify. This should help with
performance when we have a high number of nodes to run chef onto.
