### PR TITLE
crowbar: Forward protocol to rails (bsc#1059733)

### DIFF
--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -371,6 +371,7 @@ include_recipe "apache2::mod_slotmem_shm"
 include_recipe "apache2::mod_socache_shmcb"
 include_recipe "apache2::mod_auth_digest"
 include_recipe "apache2::mod_ssl"
+include_recipe "apache2::mod_headers"
 
 # Verify that we have the certificate available before configuring things to use it
 if node[:crowbar][:apache][:ssl] && !node[:crowbar][:apache][:generate_certs]

--- a/chef/cookbooks/crowbar/templates/default/apache.conf.erb
+++ b/chef/cookbooks/crowbar/templates/default/apache.conf.erb
@@ -45,6 +45,9 @@
     SSLCertificateChainFile <%= @ssl_crt_chain_file %>
     <% end %>
 
+    RequestHeader set X-Forwarded-Proto 'https'
+    RequestHeader set Forwarded 'proto=https'
+
     DocumentRoot /opt/dell/crowbar_framework/public
 
     ErrorLog /var/log/apache2/crowbar-error.log


### PR DESCRIPTION
Without this patch, when crowbar is deployed with the HTTP+HTTPS option
and the user is connected with HTTPS, any redirect (such as after a
proposal is applied or when a node is deleted) will force the user back
to an HTTP connection. This is obviously insecure. This patch adds a
setting to the crowbar apache vhost to forward the request protocol to
rails so that the ssl property of the rails request object will be set
and the redirect_to method in rails will do the right thing.