### PR TITLE
s390x: recognize DASD drives

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -246,7 +246,7 @@ module BarclampLibrary
         def fixed
           # This needs to be kept in sync with the number_of_drives method in
           # node_object.rb in the Crowbar framework.
-          @device =~ /^([hsv]d|cciss|xvd|nvme)/ && !removable && !cinder_volume
+          @device =~ /^([hsv]d|dasd|cciss|xvd|nvme)/ && !removable && !cinder_volume
         end
 
         def <=>(other)

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -478,7 +478,7 @@ class Node < ChefObject
 
     if @node[:block_device]
       @node[:block_device].find_all do |disk, data|
-        disk =~ /^([hsv]d|cciss|xvd|nvme)/ && data[:removable] == "0"\
+        disk =~ /^([hsv]d|dasd|cciss|xvd|nvme)/ && data[:removable] == "0"\
           && !(data[:vendor] == "cinder" && data[:model] =~ /^volume-/)
       end
     else


### PR DESCRIPTION
DASD drives in s390x use a different name schema than other devices, like sda or hda. Change the regular expression to recognize them.

Indirectly this fix a bug in crowbar, where the nodes appears without hard disk information. Also is required for the Cinder barclamp, in order to create the partition and assign it to the cinder-volume group.

Tested in the Dallas system