### PR TITLE
updater: deal with cluster nodes when updating (bsc#983617, bsc#1061834)

### DIFF
--- a/chef/cookbooks/updater/metadata.rb
+++ b/chef/cookbooks/updater/metadata.rb
@@ -22,5 +22,6 @@ long_description ""
 version "0.0.1"
 
 depends "utils"
+depends "crowbar-pacemaker"
 
 recipe "updater", "System Package Updater"


### PR DESCRIPTION
Make the update barclamp aware of HA nodes and deal with them properly.
When HA packages need to be updated, stop the HA services before the update
and start them again after the package have been updated.
When normal packages are updated, set the node in maintenance mode as mentioned
on the HA guide.
Also do not stop or set maintenance mode if the node is a remote_node.

Updates on normal nodes should not be affected by this changes.
