### PR TITLE
nfs-server: Revert systemd Restart= bits for nfs services

### DIFF
--- a/chef/cookbooks/nfs-server/metadata.json
+++ b/chef/cookbooks/nfs-server/metadata.json
@@ -6,7 +6,6 @@
     "replacing": {
     },
     "dependencies": {
-      "utils": []
     },
     "groupings": {
     },

--- a/chef/cookbooks/nfs-server/recipes/default.rb
+++ b/chef/cookbooks/nfs-server/recipes/default.rb
@@ -55,7 +55,6 @@ package rpc_service
 service rpc_service do
   action [:enable, :start]
 end
-utils_systemd_service_restart rpc_service
 
 ["/var/log/crowbar/sledgehammer", "/updates"].each do |nfs_dir|
   directory nfs_dir do
@@ -71,7 +70,6 @@ service "nfs-kernel-server" do
   supports restart: true, status: true, reload: true
   action [:enable, :start]
 end
-utils_systemd_service_restart "nfs-kernel-server"
 
 execute "nfs-export" do
   command "exportfs -a"


### PR DESCRIPTION
This breaks in some mkcloud scenarios:
  nfsserver.service: Service has Restart= setting other than no, which isn't allowed for Type=oneshot services. Refusing.