### PR TITLE
schema_migration: Provide a hook into ServiceObject (bsc#1058876)

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1412,6 +1412,15 @@ class ServiceObject
     # noop by default.
   end
 
+  # This callback provides a hook into the schema migration procedure.
+  # It is called from lib/schema_migration.rb after the schema migrations
+  # for a proposal (and its role, if present) have been executed. Parameters
+  # are the migrated proposal an role objects. The default implementation is
+  # a noop. (To be overwritten in sub classes)
+  def post_schema_migration_callback(proposal, role)
+    # noop by default
+  end
+
   #
   # Inputs: role = RoleObject of proposal being applied/queued.
   # Returns: List of hashs { "barclamp" => bcname, "inst" => instname }

--- a/crowbar_framework/lib/schema_migration.rb
+++ b/crowbar_framework/lib/schema_migration.rb
@@ -59,6 +59,9 @@ module SchemaMigration
       unless role.nil?
         migrate_role(bc_name, template, all_scripts, role)
       end
+
+      service = ServiceObject.get_service(bc_name).new
+      service.post_schema_migration_callback(prop, role)
     end
   end
 


### PR DESCRIPTION
This allows to execute barclamp specific maintenance code after a
schema migration ran for a proposal and its role. Subclasses, e.g.
DatabaseService can overwrite the default implementation (which is
a no-op).

This is a PR is laying the groundwork in order to fix:
https://bugzilla.suse.com/show_bug.cgi?id=1058876