### PR TITLE
network: Partly revert 3d24a0f4cb - do not add Restart= for ovs

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -43,7 +43,6 @@ if node[:network][:needs_openvswitch]
   end
   s.run_action :enable
   s.run_action :start
-  utils_systemd_service_restart node[:network][:ovs_service]
 
   # Cleanup on SLE12. Disable (NOT stop) old sysvinit service for ovs to avoid
   # issues (https://bugzilla.suse.com/show_bug.cgi?id=935912). We use the


### PR DESCRIPTION
the openvswitch .service file is of Type=oneshot which is not
compatible with Restart=on-failure .
