### PR TITLE
[4.0] utils: fix data bag loading on RestartManager

### DIFF
--- a/chef/cookbooks/utils/libraries/restart_manager.rb
+++ b/chef/cookbooks/utils/libraries/restart_manager.rb
@@ -27,7 +27,7 @@ module ServiceRestart
 
     def disallow_restart?
       # if the databag or item does not exits it returns a 404
-      data_bag = data_bag_item("crowbar-config", "disallow_restart") rescue {}
+      data_bag = Chef::DataBagItem.load("crowbar-config", "disallow_restart") rescue {}
 
       data_bag[cookbook] || false
     end


### PR DESCRIPTION
This used to work as it was part of the chef DSL which provides the
handy helper data_bag_item but it stopped working as soon as we moved it
from there into an external file, as we no longer have access to that
helper method and need to use the full path to the class to load a
databag item

(cherry picked from commit c610bb53c4075a5cef59829dd7c530204bba3f3a)

Backport of: https://github.com/crowbar/crowbar-core/pull/1363