### PR TITLE
[4.0] utils: Fix restart flag removal

### DIFF
--- a/chef/cookbooks/utils/libraries/restart_manager.rb
+++ b/chef/cookbooks/utils/libraries/restart_manager.rb
@@ -49,13 +49,9 @@ module ServiceRestart
     end
 
     def clear_restart_requests
-      @node.fetch(
-        :crowbar_wall, {}
-      ).fetch(
-        :requires_restart, {}
-      ).fetch(
-        cookbook, {}
-      ).delete(@service_name)
+      # we need to delete from the node attribute directly, fetch wont work here as it
+      # seems to return the value but we want the full attribute to be able to delete it
+      @node[:crowbar_wall][:requires_restart][cookbook].delete(@service_name) rescue nil
     end
   end
 end


### PR DESCRIPTION
It looks like when you use fetch to fetch an attribute from the node
object we get the direct value, which if modified (deleted/updated)
doesnt get to be reflected into the node object, so when we deleted the
restart flag from a service and the node was saved, the modification we
did was not saved.

Instead, lets just ask for forgiveness when trying to delete the
attribute by using rescue to save from any issues of attributes not
existing when deleting the flags.

(cherry picked from commit 9d19923bf4dc4a3c75dcb16d4cfcd2ec4fdbbb63)

Backport-of: https://github.com/crowbar/crowbar-core/pull/1368