### PR TITLE
[3.0] utils: Add systemd override LWRP

### DIFF
--- a/chef/cookbooks/utils/providers/systemd_override_limits.rb
+++ b/chef/cookbooks/utils/providers/systemd_override_limits.rb
@@ -1,0 +1,99 @@
+#
+# Copyright 2017 SUSE Linux GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Support whyrun
+def whyrun_supported?
+  true
+end
+
+action :create do
+  current_resource = @current_resource
+  converge_by("Create #{@new_resource}") do
+    execute "systemctl daemon-reload" do
+      action :nothing
+    end
+
+    directory _get_override_directory do
+      owner "root"
+      group "root"
+      mode "0755"
+    end
+
+    service_resource_name = _get_service_resource_name
+    template _get_override_file_path do
+      source "systemd_override_limits.conf.erb"
+      owner "root"
+      group "root"
+      mode "0644"
+      cookbook "utils"
+      variables(
+        limits: current_resource.limits
+      )
+      notifies :run, resources(execute: "systemctl daemon-reload"), :delayed
+      notifies :restart, resources(service: service_resource_name), :delayed
+    end
+    Chef::Log.info "#{@new_resource} created / updated"
+  end
+end
+
+action :delete do
+  if @current_resource.exists
+    converge_by("Delete #{@new_resource}") do
+      execute "systemctl daemon-reload" do
+        action :nothing
+      end
+
+      override_file_path = _get_override_file_path
+      service_resource_name = _get_service_resource_name
+      file override_file_path do
+        action :delete
+        only_if { ::File.exist?(override_file_path) }
+        notifies :run, resources(execute: "systemctl daemon-reload"), :delayed
+        notifies :restart, resources(service: service_resource_name), :delayed
+      end
+      Chef::Log.info "#{@new_resource} deleted"
+    end
+  else
+    Chef::Log.info "#{@current_resource} doesn't exist - can't delete."
+  end
+end
+
+def load_current_resource
+  @current_resource = Chef::Resource::UtilsSystemdOverrideLimits.new(@new_resource.name)
+  @current_resource.service_name(@new_resource.service_name)
+  @current_resource.limits(@new_resource.limits)
+  @current_resource.exists = true if ::File.exist?(_get_override_file_path)
+  @current_resource
+end
+
+private
+
+# For openstack services the service name is prefixed with openstack-
+# but the name of the chef resource is not
+def _get_service_resource_name
+  current_resource.service_name.sub(/^openstack-/, "")
+end
+
+def _get_unit_name
+  "#{@new_resource.service_name}.service"
+end
+
+def _get_override_directory
+  "/etc/systemd/system/#{_get_unit_name}.d"
+end
+
+def _get_override_file_path
+  "#{_get_override_directory}/60-limits.conf"
+end

--- a/chef/cookbooks/utils/resources/systemd_override_limits.rb
+++ b/chef/cookbooks/utils/resources/systemd_override_limits.rb
@@ -1,0 +1,7 @@
+actions :create, :delete
+default_action :create
+
+attribute :service_name
+attribute :limits
+
+attr_accessor :exists

--- a/chef/cookbooks/utils/templates/default/systemd_override_limits.conf.erb
+++ b/chef/cookbooks/utils/templates/default/systemd_override_limits.conf.erb
@@ -1,0 +1,4 @@
+[Service]
+<% @limits.each do |name, value| -%>
+<%= name %>=<%= value %>
+<% end -%>


### PR DESCRIPTION
Some services require modifications to the system resource limits, such
as the maximum number of open files, that we cannot necessarily predict
a reasonable default for. Without this patch, there is no way to control
those limits from crowbar and they must be changed manually. This patch
adds a LWRP to allow setting resource limits.

Currently only the LimitNOFILE (systemd's name for the maximum
number of open files) limit is supported.

Traditionally this was managed by editing limits for service users
installed by packages in /etc/security/limits.conf. This is no longer
effective under systemd, though the documentation of this reality is
poor and the best reference I can find for this is a comment in a bug
report[1].

Since limits.conf is no longer effective, this patch manages limits by
creating a systemd unit file under /etc/systemd/system for the service
in question. Systemd appends these override unit files to the unit file
installed by the package plus the unit file created by pacemaker if
applicable. Open file limits aren't directly configurable in pacemaker,
as the contents of the unit file are hardcoded[2].

[1] https://bugzilla.redhat.com/show_bug.cgi?id=754285#c1
[2] https://github.com/ClusterLabs/pacemaker/blob/Pacemaker-1.1.17-rc1/lib/services/systemd.c#L603-L625

Co-authored-by: Colleen Murphy <colleen.murphy@suse.com>
(cherry picked from commit 86e2b6c7cca6a8a92906e43ff9ec8e37eed0c541)