### PR TITLE
[4.0] network: keep ovs secure fail-mode (bsc#1063772)

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -576,6 +576,7 @@ when "suse"
 
       pre_up_script = "/etc/wicked/scripts/#{nic.name}-pre-up"
       datapath_id = get_datapath_id_for_ovsbridge nic.name
+      is_admin_nwk = if_mapping.key?("admin") && if_mapping["admin"].include?(nic.name)
 
       template pre_up_script do
         owner "root"
@@ -584,7 +585,8 @@ when "suse"
         source "ovs-pre-up.sh.erb"
         variables(
           bridgename: nic.name,
-          datapath_id: datapath_id
+          datapath_id: datapath_id,
+          is_admin_nwk: is_admin_nwk
         )
       end
     end

--- a/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
+++ b/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
@@ -2,4 +2,13 @@
 
 ovs-vsctl br-exists <%= @bridgename %> || exit 0
 ovs-vsctl set Bridge <%= @bridgename %> other-config:datapath-id=<%= @datapath_id %>
+<%
+  # remove the "secure" fail-mode for bridges that share an interface
+  # with the "admin" network, otherwise the admin network will be offline
+  # during boot and until the neutron OVS agent wakes up
+  if @is_admin_nwk
+-%>
 ovs-vsctl del-fail-mode <%= @bridgename %>
+<%
+  end
+-%>


### PR DESCRIPTION
(backport of #1366)

Update the wicked pre-up scriptlets for OVS bridges to keep the "secure" ovs fail-mode on all neutron managed bridges (br-public, br-fixed), with the exception of those that are also used to implement the "admin" network, which needs to be enabled during boot.

Previously, all neutron managed OVS bridges were configured by wicked scriptlets to be in a "standalone" fail-mode during boot, which contributed to a condition that could enable outside traffic to be unconditionally forwarded through them if:
 - the node is hard-reset (which doesn't give wicked a chance to remove the OVS bridges as it would during a graceful shutdown)
 - the neutron openvswitch agent fails during startup in such a way that leaves the br-int OVS bridge configured to forward all traffic unconditionally

Implications:
 - after a hard-reset, the interfaces attached to networks implemented using neutron managed OVS bridges will be available until (and if) the neutron openvswitch agent starts up, with the exception of the
admin network

Fixes https://bugzilla.suse.com/show_bug.cgi?id=1063772