### PR TITLE
Increase default chef_splay

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -213,7 +213,7 @@ utils_systemd_service_restart "chef-client"
 config_file = "/etc/sysconfig/chef-client"
 
 chef_client_runs = node[:provisioner][:chef_client_runs] || 900
-chef_splay = node[:provisioner][:chef_splay] || 20
+chef_splay = node[:provisioner][:chef_splay] || 900
 
 template config_file do
   owner "root"

--- a/chef/data_bags/crowbar/template-provisioner.json
+++ b/chef/data_bags/crowbar/template-provisioner.json
@@ -215,7 +215,7 @@
           "debug": "debug"
         }
       },
-      "chef_splay": 20,
+      "chef_splay": 900,
       "chef_client_runs": 900
     }
   },

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -313,7 +313,7 @@ class Node < ChefObject
     if self.crowbar["state"] === "ready" and @node["ohai_time"]
       since_last = Time.now.to_i-@node["ohai_time"].to_i
       max_last = @node.default_attrs["provisioner"]["chef_client_runs"] || 900
-      max_last += @node.default_attrs["provisioner"]["chef_splay"] || 20
+      max_last += @node.default_attrs["provisioner"]["chef_splay"] || 900
       max_last += 300 # time + 5 min buffer time
       return "noupdate" if since_last > max_last
     end


### PR DESCRIPTION
**Why is this change necessary?**
In large clouds multipe chef-clients connecting to chef-server at the same time can increase load on the admin server.

**How does it address the issue?**
Chef's SPLAY parameter controls random factor to chef-client interval.
This gives better load distribution for large clouds by avoiding multiple chef-clients connect to chef-server at the same time.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/YyJWDjew/159-chef-splay-default-settings-documentation