### PR TITLE
ohai: don't up interfaces

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -198,8 +198,9 @@ Dir.foreach("/sys/class/net") do |entry|
   tcpdump_out = tcpdump_file(logical_name)
   Ohai::Log.debug("tcpdump to: #{tcpdump_out}")
 
-  if ! File.exists? tcpdump_out
-    cmd = "ifconfig #{logical_name} up ; timeout 45 tcpdump -c 1 -lv -v -i #{logical_name} -a -e -s 1514 ether proto 0x88cc > #{tcpdump_out} &"
+  if !File.exist?(tcpdump_out) && get_link_status(logical_name)
+    cmd = "timeout 45 tcpdump -c 1 -lv -v -i #{logical_name} " \
+      "-a -e -s 1514 ether proto 0x88cc > #{tcpdump_out} &"
     Ohai::Log.debug("cmd: #{cmd}")
     system cmd
     wait=true


### PR DESCRIPTION
The ohai plugin that forcefully up'ed all physical interfaces
can cause harm on a configuration where multiple physical interfaces
are connected to the same switch/native vlan. in that case
the ARP lookup seemingly randomly flips between the mac addresses
of both causing hard to debug hangs on the cloud due to ip/arp
mismatch.

In our case, eth1 was not configured to be used by crowbar and thus had a MTU of 1500, while traffic leaving eth0 was assuming that replies with 9000 bytes could be received.



Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

in the error case /var/log/chef/client.log had
```
[2017-10-23T11:37:11+00:00] INFO: *** Chef 10.32.2 ***
[2017-10-23T11:47:13+00:00] ERROR: Timeout connecting to 192.168.80.10:4000 for 
/nodes/d8c-dc-d4-af-91-c0.ecp1.cloud.suse.de, retry 1/5
[2017-10-23T11:52:18+00:00] INFO: HTTP Request Returned 401 Unauthorized: Failed
 to authenticate. Please synchronize the clock on your client
[2017-10-23T11:52:18+00:00] ERROR: Net::HTTPServerException: 401 "Unauthorized"
[2017-10-23T11:52:18+00:00] FATAL: Stacktrace dumped to /var/chef/cache/chef-sta
cktrace.out
[2017-10-23T11:52:18+00:00] ERROR: Sleeping for 900 seconds before trying again
```