### PR TITLE
crowbar: Don't store invalid locks (bsc#1055669)

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1663,7 +1663,8 @@ class ServiceObject
             errors_mutex.synchronize { errors[node] = e.message }
           end
 
-          locks_mutex.synchronize { locks.push(lock) }
+          locks.push(lock) if lock
+          locks_mutex.synchronize { locks }
         end
       end
     end


### PR DESCRIPTION
Currently, if a locking failure occurs, the lock variable will be unset
and an empty lock will be added to the lock queue. This is a problem
when it comes time to release locks, where the error "undefined method
`release' for nil:NilClass" will occur and cause a proposal failure.
This patch ensures that only successfully acquired locks make it into
the lock queue.

(cherry picked from commit 4b1784ac1f685babbfd89f9567c1fc385d461ed8)

Backport of https://github.com/crowbar/crowbar-core/pull/1311