### PR TITLE
[4.0] Allow setting NVMe drive in ceph (bsc#1051298)

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -246,7 +246,7 @@ module BarclampLibrary
         def fixed
           # This needs to be kept in sync with the number_of_drives method in
           # node_object.rb in the Crowbar framework.
-          @device =~ /^([hsv]d|cciss|xvd)/ && !removable && !cinder_volume
+          @device =~ /^([hsv]d|cciss|xvd|nvme)/ && !removable && !cinder_volume
         end
 
         def <=>(other)

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -483,7 +483,8 @@ class Node < ChefObject
 
     if @node[:block_device]
       @node[:block_device].find_all do |disk, data|
-        disk =~ /^([hsv]d|cciss|xvd)/ && data[:removable] == "0" && !(data[:vendor] == "cinder" && data[:model] =~ /^volume-/)
+        disk =~ /^([hsv]d|cciss|xvd|nvme)/ && data[:removable] == "0"\
+          && !(data[:vendor] == "cinder" && data[:model] =~ /^volume-/)
       end
     else
       []


### PR DESCRIPTION
NVMe device does not match any of the conditions to be a claimed disk
hence always unclaimed. Adding the pattern to the regex makes it claimable.

(cherry picked from commit 15e207f82c2f4fd286269bc4d9c99c116109db59)
