### PR TITLE
[4.0]  Skip chef run on nodes when applying

### DIFF
--- a/crowbar_framework/config/experimental.yml
+++ b/crowbar_framework/config/experimental.yml
@@ -21,6 +21,8 @@ default: &default
      - suse-manager-client
      - swift-storage
      - updater
+  skip_unchanged_nodes:
+    enabled: false
 
 development:
   <<: *default


### PR DESCRIPTION
Provides a method that barclamps can override to skip a node from the list of nodes in which run is gonna run.

Provides this with a default of allowing all nodes to avoid issues and only will trigger the check if the experimental option is enabled.

Kind of stolen from vuntz/crowbar-core@321c736

Backport-of: https://github.com/crowbar/crowbar-core/pull/1374