### PR TITLE
ohai: Do not fail dealing with UEFI config with invalid CurrentBoot

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/linux/uefi.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/linux/uefi.rb
@@ -41,7 +41,7 @@ if File.exists? "/sys/firmware/efi"
 
     boot_entry = result[:entries][result[:boot][:current]]
 
-    if boot_entry[:device] =~ /[\/)]MAC\(/i
+    if !boot_entry.nil? && boot_entry[:device] =~ /[\/)]MAC\(/i
       mac = boot_entry[:device].match(/[\/)]MAC\(([0-9a-f]+)/i)[1]
 
       result[:boot][:last_mac] = [].tap do |tmp|


### PR DESCRIPTION
It seems it's possible to configure UEFI to have CurrentBoot pointing to
a non-existing entry. Let's deal with that.

(cherry picked from commit 8bfcdbf0deaf9cbffa53adbe4f666ce0e74b8af5)

Backport of https://github.com/crowbar/crowbar-core/pull/1392