### PR TITLE
Show IPMI links earlier

### DIFF
--- a/crowbar_framework/app/helpers/nodes_helper.rb
+++ b/crowbar_framework/app/helpers/nodes_helper.rb
@@ -541,7 +541,7 @@ module NodesHelper
 
   def node_link_list(node)
     link_list = [].tap do |result|
-      if node.bmc_set?
+      if node.bmc_configured?
         path = node["crowbar_wall"]["ipmi"]["address"] rescue "none"
 
         result.push content_tag(

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -1148,11 +1148,9 @@ class Node < ChefObject
     bmc_cmd("chassis identify")
   end
 
-  def bmc_set?
-    return false if @node.nil? or @node["crowbar_wall"].nil? or @node["crowbar_wall"]["status"].nil?
-    return false if @node["crowbar_wall"]["status"]["ipmi"].nil?
-    return false if @node["crowbar_wall"]["status"]["ipmi"]["address_set"].nil?
-    @node["crowbar_wall"]["status"]["ipmi"]["address_set"]
+  def bmc_configured?
+    return false if @node.nil? || @node["crowbar_wall"].nil? || @node["crowbar_wall"]["ipmi"].nil?
+    !@node["crowbar_wall"]["ipmi"]["address"].nil?
   end
 
   def disk_owner(device)

--- a/crowbar_framework/app/views/nodes/_buttons_power.html.haml
+++ b/crowbar_framework/app/views/nodes/_buttons_power.html.haml
@@ -1,11 +1,11 @@
-- if @node.bmc_set?
+- if @node.bmc_configured?
   = link_to t(".identify"),
     hit_nodes_path(@node.handle, "identify"),
     class: "btn btn-default",
     data: { blockui_click: t(".blockui_identify") }
 
 - unless @node.admin?
-  - if @node[:platform_family] != 'windows' || @node.bmc_set?
+  - if @node[:platform_family] != 'windows' || @node.bmc_configured?
     %button.btn.btn-default.dropdown-toggle{ type: "button", data: { toggle: "dropdown" } }
       = t(".actions")
       %span.caret
@@ -23,13 +23,13 @@
             role: "menuitem",
             data: { blockui_click: t(".blockui_shutdown"), confirm: t("are_you_sure") }
         %li.divider{ role: "presentation" }
-      - if @node.bmc_set?
+      - if @node.bmc_configured?
         %li{ role: "presentation" }
           = link_to t(".poweron"),
             hit_nodes_path(@node.handle, "poweron"),
             role: "menuitem",
             data: { blockui_click: t(".blockui_poweron"), confirm: t("are_you_sure") }
-      - if @node[:platform_family] != 'windows' || @node.bmc_set?
+      - if @node[:platform_family] != 'windows' || @node.bmc_configured?
         %li{ role: "presentation" }
           = link_to t(".powercycle"),
             hit_nodes_path(@node.handle, "powercycle"),

--- a/crowbar_framework/app/views/nodes/_show.html.haml
+++ b/crowbar_framework/app/views/nodes/_show.html.haml
@@ -18,7 +18,7 @@
       = render :partial => "show_barclamps"
       = render :partial => "show_roles"
 
-  - if @node.bmc_set? or not @node.admin? && @node.state != "crowbar_upgrade"
+  - if @node.bmc_configured? or not @node.admin? && @node.state != "crowbar_upgrade"
     .panel-footer
       .btn-group.pull-right
         = render :partial => "buttons_power"


### PR DESCRIPTION
**Why is this change necessary?**
When IPMI interfaces are pre-configured and/or read-only mode is enabled discovered IPMI info was not used to display links in UI.

**How does it address the issue?**
After this change, the links will be shown as soon as there is some IPMI address discovered from the BMC.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/Gxhc3uD3/107-show-ipmi-link-in-ui-as-soon-as-the-addresses-are-available-in-crowbarwall