### PR TITLE
[4.0] crowbar_framework: fix skip_unchanged_nodes

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1788,8 +1788,8 @@ class ServiceObject
 
   def skip_unchanged_nodes(elements, old_role, role)
     cleaned_elements = {}
-    elements.each do |r|
-      cleaned_elements[r] ||= {}
+    elements.each_key do |r|
+      cleaned_elements[r] ||= []
       elements[r].each do |node_name|
         cleaned_elements[r] << node_name unless skip_unchanged_node?(node_name, old_role, role)
       end


### PR DESCRIPTION
There was 2 mistakes on the original method. The first, we were
iterating over the elements but only using one value instead of k,v so
it led to the value of r being the whole k+v which broke the hash
lookup. The second is that the initialization of the cleaned_elements
was a hash but a hash doesn't have the << method

For the first, the correct way of iterating over a hash and extracting
the k,v is now used

For the second, we initialize the attribute to an array as expected

(cherry picked from commit 70ab89e)
Backport-of: https://github.com/crowbar/crowbar-core/pull/1395