### PR TITLE
[3.0] Backport Skip unready nodes deployment backport

### DIFF
--- a/crowbar_framework/config/application.rb
+++ b/crowbar_framework/config/application.rb
@@ -57,5 +57,8 @@ module Crowbar
         Rails.logger.warn "Failed to load chef"
       end
     end
+
+    # experimental options
+    config.experimental = config_for(:experimental)
   end
 end

--- a/crowbar_framework/config/experimental.yml
+++ b/crowbar_framework/config/experimental.yml
@@ -1,0 +1,30 @@
+default: &default
+  skip_unready_nodes:
+    enabled: false
+    roles:
+     - bmc-nat-client
+     - ceilometer-agent
+     - deployer-client
+     - dns-client
+     - ipmi
+     - logging-client
+     - nova-compute-ironic
+     - nova-compute-kvm
+     - nova-compute-qemu
+     - nova-compute-vmware
+     - nova-compute-xen
+     - nova-compute-zvm
+     - ntp-client
+     - provisioner-base
+     - suse-manager-client
+     - swift-storage
+     - updater
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/crowbar_framework/lib/crowbar/deployment_queue.rb
+++ b/crowbar_framework/lib/crowbar/deployment_queue.rb
@@ -147,11 +147,11 @@ module Crowbar
 
             next unless dependencies_satisfied?(item.properties["deps"])
 
-            nodes_map = elements_to_nodes_to_roles_map(
+            nodes_map, pre_cached_nodes = elements_to_nodes_to_roles_map(
               prop["deployment"][item.barclamp]["elements"],
               prop["deployment"][item.barclamp]["element_order"]
             )
-            delay, pre_cached_nodes = elements_not_ready(nodes_map.keys)
+            delay, = elements_not_ready(nodes_map.keys, pre_cached_nodes)
             proposal_to_commit = { barclamp: item.barclamp, inst: item.name } if delay.empty?
           end
 
@@ -278,11 +278,12 @@ module Crowbar
     # should be emptied.  FIXME: looks like bc-inst: value should be a list, not
     # a hash?
     def remove_pending_elements(bc, inst, elements)
-      nodes_map = elements_to_nodes_to_roles_map(elements)
+      nodes_map, = elements_to_nodes_to_roles_map(elements)
 
       # Remove the entries from the nodes.
       new_lock("BA-LOCK").with_lock do
         nodes_map.each do |node_name, data|
+          # TODO(itxaka): Maybe we can optimize this to use the node cache safely?
           node = NodeObject.find_node_by_name(node_name)
           next if node.nil?
           unless node.crowbar["crowbar"]["pending"].nil? or node.crowbar["crowbar"]["pending"]["#{bc}-#{inst}"].nil?
@@ -296,7 +297,7 @@ module Crowbar
     # Create map with nodes and their element list
     # Transform ( {role => [nodes], role1 => [nodes]} hash to { node => [roles], node1 => [roles]},
     # accounting for clusters
-    def elements_to_nodes_to_roles_map(elements, element_order = [])
+    def elements_to_nodes_to_roles_map(elements, element_order = [], pre_cached_nodes = {})
       nodes_map = {}
       active_elements = element_order.flatten
 
@@ -311,7 +312,8 @@ module Crowbar
 
         # Add the role to node's list
         nodes.each do |node_name|
-          if NodeObject.find_node_by_name(node_name).nil?
+          pre_cached_nodes[node_name] ||= NodeObject.find_node_by_name(node_name)
+          if pre_cached_nodes[node_name].nil?
             logger.debug "elements_to_nodes_to_roles_map: skipping deleted node #{node_name}"
             next
           end
@@ -320,12 +322,14 @@ module Crowbar
         end
       end
 
-      nodes_map
+      [nodes_map, pre_cached_nodes]
     end
 
     # Get a hash of {node => [roles], node1 => [roles]}
     def add_pending_elements(bc, inst, element_order, elements, queue_me, pre_cached_nodes = {})
-      nodes_map = elements_to_nodes_to_roles_map(elements, element_order)
+      nodes_map, pre_cached_nodes = elements_to_nodes_to_roles_map(
+        elements, element_order, pre_cached_nodes
+      )
 
       # We need to be sure that we're the only ones modifying the node records at this point.
       # This will work for preventing changes from rails app, but not necessarily chef.


### PR DESCRIPTION
Adds to the experimental options the skip_unready_nodes
configs that would allow to set a list of roles for which we would not
have to wait for all nodes to be in status ready to apply the barclamps.

Backport of #1361