### PR TITLE
chef: add names to cookbook metadata

### DIFF
--- a/chef/cookbooks/bmc-nat/metadata.rb
+++ b/chef/cookbooks/bmc-nat/metadata.rb
@@ -1,0 +1,1 @@
+name "bmc-nat"

--- a/chef/cookbooks/build-essential/metadata.rb
+++ b/chef/cookbooks/build-essential/metadata.rb
@@ -1,3 +1,4 @@
+name "build-essential"
 maintainer "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license "Apache 2.0"

--- a/chef/cookbooks/crowbar-hacks/metadata.rb
+++ b/chef/cookbooks/crowbar-hacks/metadata.rb
@@ -1,0 +1,1 @@
+name "crowbar-hacks"

--- a/chef/cookbooks/deployer/metadata.rb
+++ b/chef/cookbooks/deployer/metadata.rb
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+name "deployer"
 maintainer "Crowbar Project"
 maintainer_email "crowbar@googlegroups.com"
 license "Apache 2.0"

--- a/chef/cookbooks/dns/metadata.rb
+++ b/chef/cookbooks/dns/metadata.rb
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+name "dns"
 maintainer "Crowbar Project"
 maintainer_email "crowbar@googlegroups.com"
 license "Apache 2.0"

--- a/chef/cookbooks/ipmi/metadata.rb
+++ b/chef/cookbooks/ipmi/metadata.rb
@@ -15,6 +15,7 @@
 #
 # Author: andi abes
 #
+name "ipmi"
 maintainer "Dell, Inc."
 maintainer_email "crowbar@dell.com"
 license "Apache 2.0"

--- a/chef/cookbooks/kernel-panic/metadata.rb
+++ b/chef/cookbooks/kernel-panic/metadata.rb
@@ -1,3 +1,4 @@
+name "kernel-panic"
 maintainer "Dell Crowbar Team"
 maintainer_email "openstack@dell.com"
 license "Apache 2"

--- a/chef/cookbooks/nfs-client/metadata.rb
+++ b/chef/cookbooks/nfs-client/metadata.rb
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+name "nfs-client"
 maintainer "Crowbar Project"
 maintainer_email "crowbar@dell.com"
 license "Apache 2.0"

--- a/chef/cookbooks/nfs-server/metadata.json
+++ b/chef/cookbooks/nfs-server/metadata.json
@@ -28,7 +28,7 @@
       "nfs": "Installs nfs"
     },
     "maintainer_email": "crowbar@dell.com",
-    "name": "nfs",
+    "name": "nfs-server",
     "conflicting": {
     },
     "description": "Installs nfs",

--- a/chef/cookbooks/ohai/metadata.rb
+++ b/chef/cookbooks/ohai/metadata.rb
@@ -1,3 +1,4 @@
+name "ohai"
 maintainer "Opscode, Inc"
 maintainer_email "cookbooks@opscode.com"
 license "Apache 2.0"

--- a/chef/cookbooks/openssl/metadata.rb
+++ b/chef/cookbooks/openssl/metadata.rb
@@ -1,3 +1,4 @@
+name "openssl"
 maintainer "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license "Apache 2.0"

--- a/chef/cookbooks/provisioner/metadata.rb
+++ b/chef/cookbooks/provisioner/metadata.rb
@@ -1,3 +1,4 @@
+name "provisioner"
 maintainer "Dell Crowbar Team"
 maintainer_email "openstack@dell.com"
 license "Apache 2.0"

--- a/chef/cookbooks/repos/metadata.rb
+++ b/chef/cookbooks/repos/metadata.rb
@@ -1,3 +1,4 @@
+name "repos"
 maintainer "Crowbar Project"
 maintainer_email "crowbar@dell.com"
 license "Apache 2.0"

--- a/chef/cookbooks/resolver/metadata.rb
+++ b/chef/cookbooks/resolver/metadata.rb
@@ -1,3 +1,4 @@
+name "resolver"
 maintainer "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license "Apache 2.0"

--- a/chef/cookbooks/runit/metadata.rb
+++ b/chef/cookbooks/runit/metadata.rb
@@ -1,3 +1,4 @@
+name "runit"
 maintainer "Opscode, Inc."
 maintainer_email "cookbooks@opscode.com"
 license "Apache 2.0"

--- a/chef/cookbooks/suse-manager-client/metadata.rb
+++ b/chef/cookbooks/suse-manager-client/metadata.rb
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+name "suse-manager-client"
 maintainer "Crowbar Project"
 maintainer_email "crowbar@dell.com"
 license "Apache 2.0"

--- a/chef/cookbooks/updater/metadata.rb
+++ b/chef/cookbooks/updater/metadata.rb
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
+name "updater"
 maintainer "Crowbar Project"
 maintainer_email "crowbar@dell.com"
 license "Apache 2.0"


### PR DESCRIPTION
There is no reason to not have the name in all the cookbooks metadata
and it collides when using tools as some tools use the metadata name for
identification instead of just resorting to the directory name.

Plus it makes all cookbooks have the similar base metadata