### PR TITLE
skip unchanged nodes from chef run

### DIFF
--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -188,4 +188,21 @@ class DnsService < ServiceObject
     instance = Crowbar::DataBagConfig.instance_from_role(old_role, role)
     Crowbar::DataBagConfig.save("core", instance, @bc_name, config)
   end
+
+  # try to know if we can skip a node from running chef-client
+  def skip_unchanged_node?(node_name, old_role, new_role)
+    # if old_role is nil, then we are applying the barclamp for the first time
+    return false if old_role.nil?
+
+    # if the node changed roles, then we need to apply
+    return false if node_changed_roles?(node_name, old_role, new_role)
+
+    # if attributes have changed, we need to run
+    return false if node_changed_attributes?(node_name, old_role, new_role)
+
+    # by this point its safe to assume that we can skip the node as nothing has changed on it
+    # same attributes, same roles so skip it
+    @logger.info("#{@bc_name} skip_batch_for_node? skipping: #{node_name}")
+    true
+  end
 end

--- a/crowbar_framework/app/models/ntp_service.rb
+++ b/crowbar_framework/app/models/ntp_service.rb
@@ -101,4 +101,21 @@ class NtpService < ServiceObject
     instance = Crowbar::DataBagConfig.instance_from_role(old_role, role)
     Crowbar::DataBagConfig.save("core", instance, @bc_name, config)
   end
+
+  # try to know if we can skip a node from running chef-client
+  def skip_unchanged_node?(node_name, old_role, new_role)
+    # if old_role is nil, then we are applying the barclamp for the first time
+    return false if old_role.nil?
+
+    # if the node changed roles, then we need to apply
+    return false if node_changed_roles?(node_name, old_role, new_role)
+
+    # if attributes have changed, we need to run
+    return false if node_changed_attributes?(node_name, old_role, new_role)
+
+    # by this point its safe to assume that we can skip the node as nothing has changed on it
+    # same attributes, same roles so skip it
+    @logger.info("#{@bc_name} skip_batch_for_node? skipping: #{node_name}")
+    true
+  end
 end

--- a/crowbar_framework/app/models/provisioner_service.rb
+++ b/crowbar_framework/app/models/provisioner_service.rb
@@ -275,4 +275,21 @@ class ProvisionerService < ServiceObject
 
     [200, ""]
   end
+
+  # try to know if we can skip a node from running chef-client
+  def skip_unchanged_node?(node_name, old_role, new_role)
+    # if old_role is nil, then we are applying the barclamp for the first time
+    return false if old_role.nil?
+
+    # if the node changed roles, then we need to apply
+    return false if node_changed_roles?(node_name, old_role, new_role)
+
+    # if attributes have changed, we need to run
+    return false if node_changed_attributes?(node_name, old_role, new_role)
+
+    # by this point its safe to assume that we can skip the node as nothing has changed on it
+    # same attributes, same roles so skip it
+    @logger.info("#{@bc_name} skip_batch_for_node? skipping: #{node_name}")
+    true
+  end
 end

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1826,4 +1826,16 @@ class ServiceObject
     logger.debug("skip_unready_nodes: exit for #{bc}:#{inst}")
     [cleaned_elements, pre_cached_nodes]
   end
+
+  # return true if the new attributes are different from the old ones
+  def node_changed_attributes?(node, old_role, new_role)
+    old_role.default_attributes[@bc_name] != new_role.default_attributes[@bc_name]
+  end
+
+  # return true if the node has changed roles
+  def node_changed_roles?(node, old_role, new_role)
+    roles_in_old = old_role.elements.keys.select { |r| old_role.elements[r].include?(node) }.sort
+    roles_in_new = new_role.elements.keys.select { |r| new_role.elements[r].include?(node) }.sort
+    roles_in_old != roles_in_new
+  end
 end


### PR DESCRIPTION
By using skip_batch_for_node? we can avoid running chef on nodes that do
not change role and if there is no attribute change for the barclamp.
    
Does not skip nodes that have changed roles, all nodes if
attributes have changed and when deploying the barclamp for the first
time.

Barclamps on witch this check will run are configured in experimental
configuration file

Requires: #1401