### PR TITLE
ohai: don't up interfaces

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -225,8 +225,9 @@ Dir.foreach("/sys/class/net") do |entry|
   tcpdump_out = tcpdump_file(logical_name)
   Ohai::Log.debug("tcpdump to: #{tcpdump_out}")
 
-  if ! File.exists? tcpdump_out
-    cmd = "ifconfig #{logical_name} up ; timeout 45 tcpdump -c 1 -lv -v -i #{logical_name} -a -e -s 1514 ether proto 0x88cc > #{tcpdump_out} &"
+  if !File.exist?(tcpdump_out) && get_link_status(logical_name)
+    cmd = "timeout 45 tcpdump -c 1 -lv -v -i #{logical_name} " \
+      "-a -e -s 1514 ether proto 0x88cc > #{tcpdump_out} &"
     Ohai::Log.debug("cmd: #{cmd}")
     system cmd
     wait=true


### PR DESCRIPTION
The ohai plugin that forcefully up'ed all physical interfaces
can cause harm on a configuration where multiple physical interfaces
are connected to the same switch/native vlan. in that case
the ARP lookup seemingly randomly flips between the mac addresses
of both causing hard to debug hangs on the cloud due to ip/arp
mismatch.

(cherry picked from commit 81a9df08ba3c6c70d40b053dda8999c81baa7b2b)

Backport of https://github.com/crowbar/crowbar-core/pull/1385