### PR TITLE
crowbar: Fix skip_unready_nodes' for unready nodes

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1830,7 +1830,7 @@ class ServiceObject
         node = pre_cached_nodes[n]
         next if node.nil?
         # skip if nodes are on ready or crowbar_upgrade state, we dont need to do anything
-        next if ["ready", "crowbar_upgrade"].include?(node.crowbar["state"])
+        next if ["ready", "crowbar_upgrade"].include?(node.state)
         logger.warn(
           "Node #{n} is skipped until next chef run for #{bc}:#{inst} with role #{role}"
         )


### PR DESCRIPTION
We also need to take into account the heartbeat as nodes that were not
probably shut down will still have the state "ready".Therefore we should
not look at the raw state attribute, but we should use the method that
interprets that raw state attribute.