### PR TITLE
crowbar: Avoid nil crash on applying errored nodes

### DIFF
--- a/chef/cookbooks/utils/libraries/role_recipe.rb
+++ b/chef/cookbooks/utils/libraries/role_recipe.rb
@@ -20,7 +20,8 @@ module CrowbarRoleRecipe
     # If we're applying the nova-ha-compute batch, skip other roles to avoid
     # chef-client drift between nodes (since sync marks are only reset before
     # the first batch) - https://bugzilla.suse.com/show_bug.cgi?id=1004758
-    if node["crowbar"]["applying_for"].key?("nova") &&
+    if node.key?("crowbar") && node["crowbar"].key?("applying_for") &&
+        node["crowbar"]["applying_for"].key?("nova") &&
         node["crowbar"]["applying_for"]["nova"].include?("nova-ha-compute") &&
         role != "nova-ha-compute"
       return "not required in nova-ha-compute batch"


### PR DESCRIPTION
When a node is in error state, it seems the chef apply fails
with

[2017-11-03T00:42:02-04:00] FATAL: NoMethodError: undefined method `key?' for nil:NilClass

This is due to "applying_for" not being set.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
