### PR TITLE
utils: extend systemd_service_restart

### DIFF
--- a/chef/cookbooks/utils/providers/systemd_service_restart.rb
+++ b/chef/cookbooks/utils/providers/systemd_service_restart.rb
@@ -79,3 +79,10 @@ action :disable do
 
   write_conf_snippet(new_resource, variables)
 end
+
+action :override_config do
+  variables = {
+    extra_config: new_resource.extra_config
+  }
+  write_conf_snippet(new_resource, variables)
+end

--- a/chef/cookbooks/utils/resources/systemd_service_restart.rb
+++ b/chef/cookbooks/utils/resources/systemd_service_restart.rb
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-actions :enable, :disable
+actions :enable, :disable, :override_config
 default_action :enable
 
 attribute :service, kind_of: String, name_attribute: true
@@ -27,3 +27,4 @@ attribute :restart_sec, kind_of: String
 attribute :success_exit_status, kind_of: Array
 attribute :restart_prevent_exit_status, kind_of: Array
 attribute :restart_force_exit_status, kind_of: Array
+attribute :extra_config, kind_of: Hash, default: {}

--- a/chef/cookbooks/utils/templates/default/systemd_service_restart.conf.erb
+++ b/chef/cookbooks/utils/templates/default/systemd_service_restart.conf.erb
@@ -1,5 +1,7 @@
 [Service]
+<% unless @restart.nil? || @restart.empty? -%>
 Restart=<%= @restart %>
+<% end -%>
 <% unless @restart_sec.nil? || @restart_sec.empty? -%>
 RestartSec=<%= @restart_sec %>
 <% end -%>
@@ -11,4 +13,11 @@ RestartPreventExitStatus=<%= @restart_prevent_exit_status.map { |x| x.to_s }.joi
 <% end -%>
 <% unless @restart_force_exit_status.nil? || @restart_force_exit_status.empty? -%>
 RestartForceExitStatus=<%= @restart_force_exit_status.map { |x| x.to_s }.join(" ") %>
+<% end -%>
+<% unless @extra_config.nil? -%>
+  <% @extra_config.each do |key,value| -%>
+    <% unless value.nil? -%>
+<%= key %>=<%= value %>
+    <% end -%>
+  <% end -%>
 <% end -%>


### PR DESCRIPTION
Extend the systemd_service_restart helper to allow for just
writing+reloading the systemd configuration, allowing us to pass extra
parameters to add to a service in a generic way and reusing all the
existing code.

For example:

```
utils_systemd_service_restart "pacemaker" do
  extra_config {"TasksMax": 1024, "LimitNPROC": "800:1000"}
  action :override_config
end
```

would generate a
`/etc/systemd/system/pacemaker.service.d/crowbar-restart.conf` with the
following values:

```
[Service]
TasksMax=1024
LimitNPROC=800:1000
```

