### PR TITLE
[4.0] crowbar: Avoid nil crash on applying errored nodes

### DIFF
--- a/chef/cookbooks/utils/libraries/role_recipe.rb
+++ b/chef/cookbooks/utils/libraries/role_recipe.rb
@@ -20,7 +20,8 @@ module CrowbarRoleRecipe
     # If we're applying the nova-ha-compute batch, skip other roles to avoid
     # chef-client drift between nodes (since sync marks are only reset before
     # the first batch) - https://bugzilla.suse.com/show_bug.cgi?id=1004758
-    if node["crowbar"]["applying_for"].key?("nova") &&
+    if node.key?("crowbar") && node["crowbar"].key?("applying_for") &&
+        node["crowbar"]["applying_for"].key?("nova") &&
         node["crowbar"]["applying_for"]["nova"].include?("nova-ha-compute") &&
         role != "nova-ha-compute"
       return "not required in nova-ha-compute batch"


### PR DESCRIPTION
When a node is in error state, it seems the chef apply fails
with

[2017-11-03T00:42:02-04:00] FATAL: NoMethodError: undefined method `key?' for nil:NilClass

This is due to "applying_for" not being set.

(cherry picked from commit 96cb9b6f24b2ceeb1cc806b33eb23fdde6b02d46)

Backport of https://github.com/crowbar/crowbar-core/pull/1412