### PR TITLE
Improve skip_unchanged_node? for dns, logging, ntp, provisioner

### DIFF
--- a/crowbar_framework/app/models/ntp_service.rb
+++ b/crowbar_framework/app/models/ntp_service.rb
@@ -107,14 +107,27 @@ class NtpService < ServiceObject
     # if old_role is nil, then we are applying the barclamp for the first time
     return false if old_role.nil?
 
+    # if the servers have changed, we need to apply
+    old_servers = Set.new(old_role.elements["ntp-server"])
+    new_servers = Set.new(new_role.elements["ntp-server"])
+    return false if old_servers != new_servers
+
     # if the node changed roles, then we need to apply
     return false if node_changed_roles?(node_name, old_role, new_role)
 
-    # if attributes have changed, we need to run
-    return false if node_changed_attributes?(node_name, old_role, new_role)
+    # if we're a server, and any attribute has changed, then we need to apply
+    if new_role.elements["ntp-server"].include?(node_name) &&
+        node_changed_attributes?(node_name, old_role, new_role)
+      return false
+    end
 
-    # by this point its safe to assume that we can skip the node as nothing has changed on it
-    # same attributes, same roles so skip it
+    # if we're only a client, and relevant attributes have changed (we list
+    # here the ones to ignore), then we need to apply
+    return false if relevant_attributes_changed_if_roles?(node_name, old_role, new_role,
+      ["external_servers"], ["ntp-client"])
+
+    # by this point its safe to assume that we can skip the node as nothing has
+    # changed on it same attributes, same roles so skip it
     @logger.info("#{@bc_name} skip_batch_for_node? skipping: #{node_name}")
     true
   end

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1852,4 +1852,50 @@ class ServiceObject
     roles_in_new = new_role.elements.keys.select { |r| new_role.elements[r].include?(node) }.sort
     roles_in_old != roles_in_new
   end
+
+  # return true if no other attribute than the ignored has changed, but only if
+  # the node has no other role than the ones listed in only_for_roles
+  def relevant_attributes_changed_if_roles?(node, old_role, new_role, ignore_attr, only_for_roles)
+    # if only_for_roles has some sole
+    unless only_for_roles.nil? || only_for_roles.empty?
+      # get roles for this node
+      roles_in_new = new_role.elements.keys.select { |r| new_role.elements[r].include?(node) }
+
+      # return false if node has other roles that ones in the list
+      # (only_for_roles) -- this test is not for us
+      return false unless Set.new(roles_in_new).subset?(Set.new(only_for_roles))
+    end
+
+    # if the ingnore_attr has some element, apply filters
+    if ignore_attr.nil? || ignore_attr.empty?
+      old_role.default_attributes[@bc_name] != new_role.default_attributes[@bc_name]
+    else
+      # prepare a clone of default attributes of old and new roles
+      old_selected_attributes = old_role.default_attributes[@bc_name].deep_dup
+      new_selected_attributes = new_role.default_attributes[@bc_name].deep_dup
+
+      # function to remove all ignored attributes from a list
+      remove_ignored = lambda do |attributes, ignored|
+        ignored.each do |path|
+          iterator = attributes
+          path = path.split(".")
+
+          while path.length > 1
+            iterator = iterator[path[0]]
+            break if iterator.nil?
+            path.slice!(0)
+          end
+
+          iterator.delete(path[0]) unless iterator.nil?
+        end
+      end
+
+      # remove ignored attributes from old and new attributes
+      remove_ignored.call(old_selected_attributes, ignore_attr)
+      remove_ignored.call(new_selected_attributes, ignore_attr)
+
+      # return true if the attributes have changed, except for the ignored ones
+      old_selected_attributes != new_selected_attributes
+    end
+  end
 end


### PR DESCRIPTION
**crowbar: Add helper for skip_unchanged_node?**
    
The new "relevant_attributes_changed_if_roles?" helper checks if no
other attribute than the ignored has changed, and only considers this if
the node has no other role than the ones whitelisted.
    
This is useful to allow skipping "client" nodes when many attributes are
relevant only to "server" nodes.

**dns/logging/ntp/provisioner: Improve skip_unchanged_node?**

Use the new helper :-) Also always apply if the server changed.