### PR TITLE
[3.0] Find and use permanent addresses of interfaces for dhcp config 

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -137,7 +137,7 @@ def get_permanent_address(interface)
 
   # unpack the uint64 we get to bytes, and then only take the size as
   # specified in the reply, to build the MAC address
-  mac_bytes = [rv.value].pack("Q").each_byte.map { |b| b.to_s(16) }
+  mac_bytes = [rv.value].pack("Q").each_byte.map { |b| format("%02X", b) }
   mac_bytes.slice(0, rv.size).join(":")
 rescue StandardError => e
   puts "Failed to get ioctl for permanent address: #{e.message}"

--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -120,7 +120,7 @@ def get_supported_speeds(interface)
   speeds
 rescue StandardError => e
   puts "Failed to get ioctl for speed: #{e.message}"
-  speeds = ["1g", "0g"]
+  ["1g", "0g"]
 end
 
 def get_permanent_address(interface)

--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -28,8 +28,8 @@ MAX_ADDR_LEN = 32
 SIOCETHTOOL = 0x8946
 
 # From: "/usr/include/linux/ethtool.h"
-ETHTOOL_GSET = 1
-ETHTOOL_GLINK = 10
+ETHTOOL_GSET = 0x01
+ETHTOOL_GLINK = 0x0a
 ETHTOOL_GPERMADDR = 0x20
 
 # From: "/usr/include/linux/ethtool.h"

--- a/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/crowbar.rb
@@ -99,30 +99,28 @@ class EthtoolValue < CStruct
 end
 
 def get_supported_speeds(interface)
-  begin
-    ecmd = EthtoolCmd.new
-    ecmd.cmd = ETHTOOL_GSET
+  ecmd = EthtoolCmd.new
+  ecmd.cmd = ETHTOOL_GSET
 
-    ifreq = [interface, ecmd.data].pack("a16p")
-    sock = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
-    sock.ioctl(SIOCETHTOOL, ifreq)
+  ifreq = [interface, ecmd.data].pack("a16p")
+  sock = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
+  sock.ioctl(SIOCETHTOOL, ifreq)
 
-    rv = ecmd.class.new
-    rv.data = ifreq.unpack("a16p")[1]
+  rv = ecmd.class.new
+  rv.data = ifreq.unpack("a16p")[1]
 
-    speeds = []
-    speeds << "10m"  if (rv.supported & ((1 <<  0) | (1 <<  1))) != 0
-    speeds << "100m" if (rv.supported & ((1 <<  2) | (1 <<  3))) != 0
-    speeds << "1g"   if (rv.supported & ((1 <<  4) | (1 <<  5) | (1 << 17))) != 0
-    speeds << "10g"  if (rv.supported & ((1 << 12) | (1 << 18) | (1 << 19) | (1 << 20))) != 0
-    speeds << "20g"  if (rv.supported & ((1 << 21) | (1 << 22))) != 0
-    speeds << "40g"  if (rv.supported & ((1 << 23) | (1 << 24) | (1 << 25) | (1 << 26))) != 0
-    speeds << "56g"  if (rv.supported & ((1 << 27) | (1 << 28) | (1 << 29) | (1 << 30))) != 0
-    speeds
-  rescue Exception => e
-    puts "Failed to get ioctl for speed: #{e.message}"
-    speeds = ["1g", "0g"]
-  end
+  speeds = []
+  speeds << "10m"  if (rv.supported & ((1 <<  0) | (1 <<  1))) != 0
+  speeds << "100m" if (rv.supported & ((1 <<  2) | (1 <<  3))) != 0
+  speeds << "1g"   if (rv.supported & ((1 <<  4) | (1 <<  5) | (1 << 17))) != 0
+  speeds << "10g"  if (rv.supported & ((1 << 12) | (1 << 18) | (1 << 19) | (1 << 20))) != 0
+  speeds << "20g"  if (rv.supported & ((1 << 21) | (1 << 22))) != 0
+  speeds << "40g"  if (rv.supported & ((1 << 23) | (1 << 24) | (1 << 25) | (1 << 26))) != 0
+  speeds << "56g"  if (rv.supported & ((1 << 27) | (1 << 28) | (1 << 29) | (1 << 30))) != 0
+  speeds
+rescue StandardError => e
+  puts "Failed to get ioctl for speed: #{e.message}"
+  speeds = ["1g", "0g"]
 end
 
 def get_permanent_address(interface)
@@ -151,22 +149,20 @@ end
 # false for down
 #
 def get_link_status(interface)
-  begin
-    ecmd = EthtoolValue.new
-    ecmd.cmd = ETHTOOL_GLINK
+  ecmd = EthtoolValue.new
+  ecmd.cmd = ETHTOOL_GLINK
 
-    ifreq = [interface, ecmd.data].pack("a16p")
-    sock = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
-    sock.ioctl(SIOCETHTOOL, ifreq)
+  ifreq = [interface, ecmd.data].pack("a16p")
+  sock = Socket.new(Socket::AF_INET, Socket::SOCK_DGRAM, 0)
+  sock.ioctl(SIOCETHTOOL, ifreq)
 
-    rv = ecmd.class.new
-    rv.data = ifreq.unpack("a16p")[1]
+  rv = ecmd.class.new
+  rv.data = ifreq.unpack("a16p")[1]
 
-    rv.value != 0
-  rescue Exception => e
-    puts "Failed to get ioctl for link status: #{e.message}"
-    false
-  end
+  rv.value != 0
+rescue StandardError => e
+  puts "Failed to get ioctl for link status: #{e.message}"
+  false
 end
 
 crowbar_ohai Mash.new

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -44,6 +44,9 @@ def find_node_boot_mac_addresses(node, admin_data_net)
       next if addr_data["family"] != "lladdr"
       result << addr unless result.include? addr
     end
+    # add permanent hardware addresses, that may be hidden for slave interfaces of a bond
+    permanent_addr = node["crowbar_ohai"]["detected"]["network"][interface]["addr"] rescue nil
+    result << permanent_addr unless permanent_addr.nil? || result.include?(permanent_addr)
   end
   result
 end
@@ -89,9 +92,18 @@ if not nodes.nil? and not nodes.empty?
           end
         end
       end
-      mac_list.sort!
     end
-    Chef::Log.warn("#{mnode[:fqdn]}: no MAC address found; DHCP will not work for that node!") if mac_list.empty?
+    # add permanent hardware addresses, that may be hidden for slave interfaces of a bond
+    unless mnode.fetch("crowbar_ohai", {}).fetch("detected", {}).fetch("network", nil).nil?
+      mnode["crowbar_ohai"]["detected"]["network"].each_value do |net_data|
+        permanent_addr = net_data["addr"]
+        mac_list << permanent_addr unless permanent_addr.nil? || mac_list.include?(permanent_addr)
+      end
+    end
+    mac_list.sort!
+    if mac_list.empty?
+      Chef::Log.warn("#{mnode[:fqdn]}: no MAC address found; DHCP will not work for that node!")
+    end
 
     # delete dhcp hosts that we will not overwrite/delete (ie, index is too
     # high); this happens if there were more mac addresses at some point in the


### PR DESCRIPTION
[Below is the description of the original PR; I leave it here open whether you really want to have it for SOC6.]

When using bonds, all slave interfaces adopt the same mac address, and
therefore their permanent mac address is "hidden". This results in the
DHCP config not being fully complete since some MAC addresses are not
known, and therefore we cannot configure anything for them.

This may lead to nodes rebooting and reinstalling because there's no
DHCP config telling the node to not boot from that interface, or to boot
from disk, and therefore this falls back to the discovery image, which
will trigger some automatic reinstall (since the node is known).

Backport of #1399 