### PR TITLE
[4.0] Deployer : Skip batches when nothing has changed

### DIFF
--- a/crowbar_framework/app/models/deployer_service.rb
+++ b/crowbar_framework/app/models/deployer_service.rb
@@ -138,4 +138,21 @@ class DeployerService < ServiceObject
     Rails.logger.debug("Deployer transition: exiting: #{name} for #{state}")
     return [200, { name: name }]
   end
+
+  # try to know if we can skip a node from running chef-client
+  def skip_unchanged_node?(node_name, old_role, new_role)
+    # if old_role is nil, then we are applying the barclamp for the first time
+    return false if old_role.nil?
+
+    # if the node changed roles, then we need to apply
+    return false if node_changed_roles?(node_name, old_role, new_role)
+
+    # no need to check if attributes changed because they are not used in
+    # cookbooks, just in the rails application
+
+    # by this point its safe to assume that we can skip the node as nothing has changed on it
+    # same attributes, same roles so skip it
+    @logger.info("#{@bc_name} skip_batch_for_node? skipping: #{node_name}")
+    true
+  end
 end


### PR DESCRIPTION
By using skip_batch_for_node? we can avoid running chef on nodes that do
not change role.

Does not skip nodes that have changed roles, all nodes when deploying
the barclamp for the first time.

(cherry picked from commit f921aad8e86aab375ff6ce740c2f0565d4dac24b)

Backport of https://github.com/crowbar/crowbar-core/pull/1416