### PR TITLE
crowbar_join: Fix detection of reboot

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -510,11 +510,13 @@ if [ "$MODE" == "setup" -o "$MODE" == "start" ]; then
 
     [ $final_state == "ready" ] || EXVAL=1
 elif [ "$MODE" == "stop" ]; then
-    RUNLEVEL=$(runlevel | awk '{print $2}')
-    final_state="shutdown"
-    [ "$RUNLEVEL" == "6" ] && final_state="reboot"
+    if systemctl --no-legend --full --no-pager list-jobs reboot.target | grep -q " start "; then
+        final_state="reboot"
+    else
+        final_state="shutdown"
+    fi
 
-    echo_debug "Stopping with state=$final_state (runlevel $RUNLEVEL)"
+    echo_debug "Stopping with state=$final_state"
 
     HOSTNAME=$(hostname -f)
     post_state $HOSTNAME "$final_state"


### PR DESCRIPTION
We were using the runlevel command to find out if we're rebooting (to
set the appropriate state for the node), but that doesn't work anymore
with systemd. Instead, check if reboot.target is starting.