### PR TITLE
[4.0] crowbar: Add CSS rule for form-group in heading

### DIFF
--- a/crowbar_framework/vendor/assets/stylesheets/bootstrap/_forms.scss
+++ b/crowbar_framework/vendor/assets/stylesheets/bootstrap/_forms.scss
@@ -210,6 +210,10 @@ input[type="search"] {
   margin-bottom: $form-group-margin-bottom;
 }
 
+.list-group-item-heading .form-group {
+  margin-top: $heading-form-group-margin-top;
+}
+
 
 // Checkboxes and radios
 //

--- a/crowbar_framework/vendor/assets/stylesheets/bootstrap/_variables.scss
+++ b/crowbar_framework/vendor/assets/stylesheets/bootstrap/_variables.scss
@@ -219,6 +219,7 @@ $input-height-small:             (floor($font-size-small * $line-height-small) +
 
 //** `.form-group` margin
 $form-group-margin-bottom:       15px !default;
+$heading-form-group-margin-top:  -5px !default;
 
 $legend-color:                   $gray-dark !default;
 $legend-border-color:            #e5e5e5 !default;


### PR DESCRIPTION
This is required for some visual tweak in crowbar-ha, where a button is
put inside a heading of a list group. Without it, the button doesn't
look correctly aligned vertically.

(cherry picked from commit 5a6223e6cc54a373aa310c530a165cda1387b794)

Backport from https://github.com/crowbar/crowbar-core/pull/1429