### PR TITLE
[4.0] utils: Load databag item once per run

### DIFF
--- a/chef/cookbooks/utils/libraries/restart_manager.rb
+++ b/chef/cookbooks/utils/libraries/restart_manager.rb
@@ -1,5 +1,24 @@
 module ServiceRestart
   class RestartManager
+    class << self
+      def data_bag
+        # Cache the flags from the data bag item
+        # This cache needs to be invalidated for each chef-client run from
+        # chef-client daemon (which are all in the same process); so use the
+        # ohai time as a marker for that.
+        @cache ||= {}
+        ohai_time = BarclampLibrary::Barclamp::Config.node[:ohai_time]
+
+        if @cache["cache_time"] != ohai_time
+          # Invalidating cache
+          @cache["config"] = nil
+          @cache["cache_time"] = ohai_time
+        end
+
+        @cache["config"] ||= Chef::DataBagItem.load("crowbar-config", "disallow_restart") rescue {}
+      end
+    end
+
     def initialize(cookbook_name, node, new_resource, is_pacemaker_service)
       @cookbook_name = cookbook_name
       @node = node
@@ -26,10 +45,7 @@ module ServiceRestart
     end
 
     def disallow_restart?
-      # if the databag or item does not exits it returns a 404
-      data_bag = Chef::DataBagItem.load("crowbar-config", "disallow_restart") rescue {}
-
-      data_bag[cookbook] || false
+      RestartManager.data_bag[cookbook] || false
     end
 
     def register_restart_request

--- a/chef/cookbooks/utils/libraries/restart_manager.rb
+++ b/chef/cookbooks/utils/libraries/restart_manager.rb
@@ -15,7 +15,11 @@ module ServiceRestart
           @cache["cache_time"] = ohai_time
         end
 
-        @cache["config"] ||= Chef::DataBagItem.load("crowbar-config", "disallow_restart") rescue {}
+        @cache["config"] ||= begin
+          Chef::DataBagItem.load("crowbar-config", "disallow_restart")
+        rescue Net::HTTPServerException
+          {}
+        end
       end
     end
 


### PR DESCRIPTION
For checking the disallow_restart flags, we load a databag item. At the
moment, it was loaded every time we were checkign the flag for a
service.

By caching it, we get some small performance improvement, but we also
get consistency by making sure that the flag doesn't get changed in the
middle of a chef run.