### PR TITLE
crowbar_join: Avoid repeated lines in chef config (bsc#1060692)

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -239,23 +239,23 @@ EOF
     for line in 'require "/var/chef/handlers/reboot_handler"' \
         'reboot_handler = RebootHandler.new' \
         'report_handlers << reboot_handler # these fire at the end of a successful run'; do
-        grep -q -e "^$line$" /etc/chef/client.rb || echo "$line" >> /etc/chef/client.rb
+        grep -qxF -e "$line" /etc/chef/client.rb || echo "$line" >> /etc/chef/client.rb
     done
 
     # add reboot handler reset as start_handler
     for line in 'require "/var/chef/handlers/reboot_handler_reset"' \
         'reboot_handler_reset = RebootHandlerReset.new' \
         'start_handlers << reboot_handler_reset # these fire at the start of a run'; do
-        grep -q -e "^$line$" /etc/chef/client.rb || echo "$line" >> /etc/chef/client.rb
+        grep -qxF -e "$line" /etc/chef/client.rb || echo "$line" >> /etc/chef/client.rb
     done
 
     # work around: https://tickets.opscode.com/browse/CHEF-3304
     line='Encoding.default_external = Encoding::UTF_8 if RUBY_VERSION > "1.9"'
-    grep -q -e "^$line$" /etc/chef/client.rb || echo "$line" >> /etc/chef/client.rb
+    grep -qxF -e "$line" /etc/chef/client.rb || echo "$line" >> /etc/chef/client.rb
 
     # work around: avoid excessively large node attributes due to large number of accounts
     line='Ohai::Config[:disabled_plugins] << "passwd"'
-    grep -q -e "^$line$" /etc/chef/client.rb || echo "$line" >> /etc/chef/client.rb
+    grep -qxF -e "$line" /etc/chef/client.rb || echo "$line" >> /etc/chef/client.rb
 }
 
 do_chef_client_after_setup() {


### PR DESCRIPTION
The default mode for grep(1) is matching the expression as
regular expression, which means that special characters like "[" are
not handled literally. By using -x (match whole line) and -F (plain
text search) we can avoid that escaping hell.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
