### PR TITLE
network: run ifdown for vlan interface cleanup

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -151,6 +151,7 @@ def kill_nic(nic)
 
   Chef::Log.info("Interface #{nic.name} is no longer being used, deconfiguring it.")
   nic.destroy
+  ::Kernel.system("wicked ifdown #{nic.name}")
 
   kill_nic_files(nic)
 end


### PR DESCRIPTION
When cleaning up vlan interfaces, simply running 'vconfig rem' doesn't have any effect for interfaces that are already managed by wicked. Only running 'wicked ifdown' or the more general 'ifdown' properly cleans up these interfaces.

Fixes [bsc#1063535](https://bugzilla.suse.com/show_bug.cgi?id=1063535)
Also see: https://trello.com/c/tkxpXh9w