### PR TITLE
Fix dependency status updates in deployment_queue

### DIFF
--- a/crowbar_framework/app/views/deploy_queue/_dependencies.html.haml
+++ b/crowbar_framework/app/views/deploy_queue/_dependencies.html.haml
@@ -11,7 +11,7 @@
           = dep["inst"]
       - else
         - status = proposal_dep.real_status(@active)
-        - led_update_path = status_proposal_path(:id => barclamp_instance, :barclamp => proposal_dep.barclamp, :name => proposal_dep.name)
+        - led_update_path = status_proposal_path(:controller => 'barclamp', :id => barclamp_instance, :barclamp => proposal_dep.barclamp, :name => proposal_dep.name)
         = display_led_for(status, barclamp_instance, led_update_path)
         %span
           = proposal_dep.barclamp


### PR DESCRIPTION
**Why is this change necessary?**
Proposal status for dependencies of queued proposal in deployment_queue was not updated correctly. It referred to 'proposal_status' action in DeployQueueController which was not implemented.

**How does it address the issue?**
The correct place to query for proposal status is BarclampController.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/SduJSFvx/216-error-when-fetching-proposal-status-on-deployment-queue-page