### PR TITLE
crowbar : priorize provisioner barclamp execution

### DIFF
--- a/crowbar_framework/config/catalog.yml
+++ b/crowbar_framework/config/catalog.yml
@@ -40,8 +40,8 @@ barclamps:
     display: "Provisioner"
     description: "The roles and recipes to set up the provisioning server and a base environment for all nodes"
     order: 10
-    chef_order: 1060
-    run_order: 1060
+    chef_order: 10
+    run_order: 10
   ipmi:
     user_managed: true
     display: "IPMI"


### PR DESCRIPTION
After restart a node, Keystone requires the fernet keys and
they have to be imported from the founder node. To do that
is necessary to do a rsync, and to do that the ssh keys are
required. However in the current barclamp sort, the provisioner
is executed at the end of the list. So, In order to have the
ssh keys from the beginning this fix prioritize the provisioner
barclamp to be executed from the beginning.