### PR TITLE
upgrade: Services are no longer located under /etc/init.d

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -37,9 +37,9 @@ done
 <% end %>
 
 # stop cinder-volume at all nodes so the service could be removed from the database later
-if test -e /etc/init.d/openstack-cinder-volume; then
+if test -e /usr/sbin/rcopenstack-cinder-volume; then
     log "Stopping cinder-volume service"
-    /etc/init.d/openstack-cinder-volume stop
+    /usr/sbin/rcopenstack-cinder-volume stop
 fi
 
 <% else %>
@@ -48,11 +48,10 @@ fi
 # Note that for HA setup, they should be stopped by pacemaker.
 log "Stopping OpenStack services..."
 
-for i in /etc/init.d/openstack-* \
-         /etc/init.d/apache2 \
-         /etc/init.d/rabbitmq-server \
-         /etc/init.d/ovs-usurp-config-* \
-         /etc/init.d/hawk;
+for i in /usr/sbin/rcopenstack-* \
+         /usr/sbin/rcapache2 \
+         /usr/sbin/rcrabbitmq-server \
+         /usr/sbin/rchawk;
 do
     if test -e $i; then
         log "Stopping service $i"


### PR DESCRIPTION
These are the services we initentionally stop before the OpenStack upgrade.

**Why is this change necessary?**

During the disruptive upgrade, we're explicitly stopping OpenStack (and some related) services at before we go to next step of upgrading the packages. 

The locations have changed for SLES12SP3.

**Note**

It's possible we might rework the whole step or upgrade process. But for now, I'm only focusing on keeping the same functionality of the 6-7 upgrade