### PR TITLE
Revert "Disable upgrade API in Cloud8"

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -15,20 +15,6 @@
 #
 
 class Api::UpgradeController < ApiController
-  # disable upgrade API until upgrade to next version is implemented
-  before_action do
-    # skip filter if we're in the middle of upgrade from previos version
-    unless File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-running")
-      render json: {
-        errors: {
-          unexpected_error: {
-            data: "Upgrade not yet supported in this version"
-          }
-        }
-      }, status: :unprocessable_entity
-    end
-  end
-
   skip_before_filter :upgrade
 
   api :GET, "/api/upgrade", "Show the Upgrade progress"

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -29,14 +29,6 @@ describe Api::UpgradeController, type: :request do
     end
     let(:tarball) { Rails.root.join("spec", "fixtures", "crowbar_backup.tar.gz") }
 
-    before do
-      # pretend we're in the middle of upgrade to not hit the filters
-      allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with(
-        "/var/lib/crowbar/upgrade/7-to-8-upgrade-running"
-      ).and_return(true)
-    end
-
     it "shows the upgrade status object" do
       allow(Api::Upgrade).to receive(:network_checks).and_return([])
       allow(Crowbar::Sanity).to receive(:check).and_return([])


### PR DESCRIPTION
This reverts commit 614c4e2f21a2a13ef9d74d09e8639cf7c6332e46.

Without reverting previous commit, we cannot test 7-8 upgrade