### PR TITLE
upgrade: fix pacemaker founder searchs

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -79,7 +79,7 @@ end
 # Find out now if we have HA setup and pass that info to the script
 use_ha = roles.include? "pacemaker-cluster-member"
 remote_node = roles.include? "pacemaker-remote"
-cluster_founder = use_ha && node["pacemaker"]["founder"]
+is_cluster_founder = use_ha && node["pacemaker"]["founder"] == node[:fqdn]
 
 template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   source "crowbar-shutdown-services-before-upgrade.sh.erb"
@@ -89,7 +89,7 @@ template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   action :create
   variables(
     use_ha: use_ha || remote_node,
-    cluster_founder: cluster_founder
+    cluster_founder: is_cluster_founder
   )
 end
 
@@ -101,7 +101,7 @@ template "/usr/sbin/crowbar-delete-cinder-services-before-upgrade.sh" do
   owner "root"
   group "root"
   action :create
-  only_if { cinder_controller && (!use_ha || cluster_founder) }
+  only_if { cinder_controller && (!use_ha || is_cluster_founder) }
 end
 
 # Find all ovs bridges that we manage to be able to reset their fail-mode

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -335,7 +335,7 @@ module Api
         when "ceph"
           ::Node.find("roles:ceph-* AND ceph_config_environment:*").any?
         when "ha"
-          ::Node.find("pacemaker_founder:true AND pacemaker_config_environment:*").any?
+          ::Node.find("pacemaker_config_environment:*").any?
         end
       end
     end

--- a/crowbar_framework/spec/fixtures/offline_chef/node_drbd.crowbar.com.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/node_drbd.crowbar.com.json
@@ -13,6 +13,7 @@
       }
     },
     "pacemaker" : {
+      "founder": "drbd.crowbar.com",
       "config": {
         "environment": "data"
       }

--- a/crowbar_framework/spec/fixtures/offline_chef/node_testing.crowbar.com.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/node_testing.crowbar.com.json
@@ -15,6 +15,7 @@
     "crowbar_wall" : {
     },
     "pacemaker" : {
+      "founder": "testing.crowbar.com",
       "config": {
         "environment": "data"
       }

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -550,14 +550,18 @@ describe Api::Upgrade do
       allow(Node).to(
         receive(:find).
         with(
-          "pacemaker_founder:true AND run_list_map:neutron-network " \
+          "run_list_map:pacemaker-cluster-member AND run_list_map:neutron-network " \
           "AND NOT run_list_map:neutron-server"
         ).and_return([])
       )
       allow(Node).to(
-        receive(:find).with("pacemaker_founder:true").
-        and_return([Node.find_by_name("drbd")])
+        receive(:find).with("run_list_map:pacemaker-cluster-member").and_return([drbd_master])
       )
+
+      allow(Node).to(
+        receive(:find_by_name).with("drbd.crowbar.com").and_return(drbd_master)
+      )
+
       allow(Node).to(
         receive(:find).
         with("pacemaker_config_environment:data "\
@@ -718,19 +722,26 @@ describe Api::Upgrade do
       allow(Node).to(
         receive(:find).
         with(
-          "pacemaker_founder:true AND run_list_map:neutron-network " \
+          "run_list_map:pacemaker-cluster-member AND run_list_map:neutron-network " \
           "AND NOT run_list_map:neutron-server"
         ).and_return([])
       )
       allow(Node).to(
-        receive(:find).with("pacemaker_founder:true").
-        and_return([Node.find_by_name("testing.crowbar.com")])
+        receive(:find).with(
+          "run_list_map:pacemaker-cluster-member"
+        ).and_return([Node.find_by_name("testing.crowbar.com")])
       )
+
+      allow(Node).to(
+        receive(:find).with("testing.crowbar.com").and_return([])
+      )
+
       allow(Node).to(
         receive(:find).with(
-          "pacemaker_founder:false AND pacemaker_config_environment:data " \
-          "AND run_list_map:pacemaker-cluster-member"
-        ).and_return([Node.find_by_name("testing.crowbar.com")])
+          "pacemaker_config_environment:data " \
+          "AND run_list_map:pacemaker-cluster-member " \
+          "AND NOT fqdn:testing.crowbar.com"
+        ).and_return([])
       )
       allow_any_instance_of(Node).to receive(:upgraded?).and_return(true)
       allow(Api::Upgrade).to receive(:upgrade_non_compute_nodes).and_return(true)


### PR DESCRIPTION
When we introduced the new syncmarks for pacemaker
the founder was changed from a boolean indicating
that the node is a founder, to the fqdn of the founder

This results in the upgrade not working as expected because
it expects to find the boolean and the value to mark if
its a founder or not, which doesnt work with the new values

This patch tries to fix that by doing searches for the founder
value, extracting the fqdn of the founder and then loading
the founder node directly