### PR TITLE
Upgrade services tweaks

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -24,7 +24,7 @@ set -x
 <% if @cluster_founder %>
 log "Stopping pacemaker resources..."
 
-exclude="postgresql|vip|rabbitmq|keystone|neutron|haproxy|remote"
+exclude="postgresql|vip|rabbitmq|keystone|neutron|haproxy|remote|galera|apache"
 
 for type in clone ms primitive; do
     for resource in $(crm configure show | grep ^$type | grep -Ev $exclude | cut -d " " -f2);

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1147,7 +1147,6 @@ module Api
           )
         else
           node_api.upgrade
-          node_api.reboot_and_wait
           node_api.post_upgrade
           node_api.join_and_chef
         end


### PR DESCRIPTION
Do not stop galera and apache:
In the services step, we want to keep database and keystone running.