### PR TITLE
crowbar: accept aliases in groups API

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -238,11 +238,11 @@ class NodesController < ApplicationController
 
   api :POST, "/nodes/groups/1.0/:id/:group", "Add a node to a group"
   header "Accept", "application/json", required: true
-  param :id, String, desc: "Node name", required: true
+  param :id, String, desc: "Node name or alias", required: true
   param :group, String, desc: "Group name", required: true
   error 404, "Node not found"
   def group_change
-    Node.find_by_name(params[:id]).tap do |node|
+    Node.find_node_by_name_or_alias(params[:id]).tap do |node|
       raise ActionController::RoutingError.new("Not Found") if node.nil?
 
       if params[:group].downcase.eql? "automatic"


### PR DESCRIPTION
**Why is this change necessary?**
Crowbar client didn't accept node aliases in `node group` subcommand.

**How does it address the issue?**
Added handling of node aliases in API used by `node group` crowbarctl subcommand to match (usage) documentation.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/T03pTNx0/222-check-fix-crowbarctl-node-alias-support