### PR TITLE
crowbar: Avoid crash on precached deleted nodes

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1218,6 +1218,10 @@ class ServiceObject
 
     # Cache attributes that are useful later on
     pre_cached_nodes.each do |node_name, node|
+      if node.nil?
+        Rails.logger.debug "skipping deleted node #{node_name}"
+        next
+      end
       node_attr_cache[node_name] = {
         "alias" => node.alias,
         "windows" => node[:platform_family] == "windows",


### PR DESCRIPTION
When applying a proposal with deleted nodes it crashes due to
pre_cached_nodes containing a node with nil value.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
