### PR TITLE
clean up UI display of recent Chef logs on failure

### DIFF
--- a/crowbar_framework/app/assets/stylesheets/content/alert.scss
+++ b/crowbar_framework/app/assets/stylesheets/content/alert.scss
@@ -7,4 +7,14 @@
   p:last-child {
     margin-bottom: 0
   }
+
+  pre {
+    background-color: $state-danger-pre-bg;
+    max-height: 20em;
+    overflow: scroll;
+
+    br {
+      display: none;
+    }
+  }
 }

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1816,21 +1816,21 @@ class ServiceObject
 
   def get_log_lines(node)
     begin
-      l_counter = 1
-      find_counter = 0
+      line_count = 0
+      last_delimiter_line = 0
       f = File.open("/var/log/crowbar/chef-client/#{node}.log")
       f.each do |line|
-        if line == "="*80
-           find_counter = l_counter
+        if line == "=" * 80
+          last_delimiter_line = line_count
         end
-        l_counter += 1
+        line_count += 1
       end
       f.seek(0, IO::SEEK_SET)
       logged_lines =
-        if (find_counter > 0) && (l_counter - find_counter) < 50
-          f.readlines[find_counter -3..l_counter]
+        if (last_delimiter_line > 0) && (line_count - last_delimiter_line) < 50
+          f.readlines[last_delimiter_line -3..line_count]
         else
-          f.readlines[l_counter-50..l_counter]
+          f.readlines[line_count-50..line_count]
         end
       "Most recent logged lines from the Chef run: \n\n<pre>" +
         logged_lines.join + "</pre>"

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1814,11 +1814,11 @@ class ServiceObject
     end
   end
 
-  def get_log_lines(pid)
+  def get_log_lines(node)
     begin
       l_counter = 1
       find_counter = 0
-      f = File.open("/var/log/crowbar/chef-client/#{pid}.log")
+      f = File.open("/var/log/crowbar/chef-client/#{node}.log")
       f.each do |line|
         if line == "="*80
            find_counter = l_counter

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1832,8 +1832,8 @@ class ServiceObject
         else
           f.readlines[l_counter-50..l_counter]
         end
-      "Most recent logged lines from the Chef run: \n\n" +
-        logged_lines.join(" ")
+      "Most recent logged lines from the Chef run: \n\n<pre>" +
+        logged_lines.join + "</pre>"
     rescue
       Rails.logger.error("Error reporting: Couldn't open /var/log/crowbar/chef-client/#{pid}.log ")
       raise "Error reporting: Couldn't open  /var/log/crowbar/chef-client/#{pid}.log"

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1826,12 +1826,15 @@ class ServiceObject
         line_count += 1
       end
       f.seek(0, IO::SEEK_SET)
-      logged_lines =
+      starting_line =
+        # If we found a delimiter in the last (say) 10 lines, we don't need
+        # to show all of the last 50.
         if (last_delimiter_line > 0) && (line_count - last_delimiter_line) < 50
-          f.readlines[last_delimiter_line -3..line_count]
+          last_delimiter_line - 3
         else
-          f.readlines[line_count-50..line_count]
+          line_count - 50
         end
+      logged_lines = f.readlines[starting_line..line_count]
       "Most recent logged lines from the Chef run: \n\n<pre>" +
         logged_lines.join + "</pre>"
     rescue

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1826,11 +1826,14 @@ class ServiceObject
         l_counter += 1
       end
       f.seek(0, IO::SEEK_SET)
-      if (find_counter > 0) && (l_counter - find_counter) < 50
-        "Most recent logged lines from the Chef run: \n\n" + f.readlines[find_counter -3..l_counter].join(" ")
-      else
-        "Most recent logged lines from the Chef run: \n\n" + f.readlines[l_counter-50..l_counter].join(" ")
-      end
+      logged_lines =
+        if (find_counter > 0) && (l_counter - find_counter) < 50
+          f.readlines[find_counter -3..l_counter]
+        else
+          f.readlines[l_counter-50..l_counter]
+        end
+      "Most recent logged lines from the Chef run: \n\n" +
+        logged_lines.join(" ")
     rescue
       Rails.logger.error("Error reporting: Couldn't open /var/log/crowbar/chef-client/#{pid}.log ")
       raise "Error reporting: Couldn't open  /var/log/crowbar/chef-client/#{pid}.log"

--- a/crowbar_framework/vendor/assets/stylesheets/bootstrap/_variables.scss
+++ b/crowbar_framework/vendor/assets/stylesheets/bootstrap/_variables.scss
@@ -516,6 +516,7 @@ $state-warning-border:           darken(adjust-hue($state-warning-bg, -10), 5%) 
 
 $state-danger-text:              #a94442 !default;
 $state-danger-bg:                #f2dede !default;
+$state-danger-pre-bg:            lighten($state-danger-bg, 5%);
 $state-danger-border:            darken(adjust-hue($state-danger-bg, -10), 5%) !default;
 
 


### PR DESCRIPTION
When `chef-client` fails, the most recent lines of the Chef logs are surfaced in the Crowbar proposal UI.  However they are not wrapped in anything, so the line breaks gets ignored, creating an unholy mess.  Not sure how this was tolerated for so long, but let's fix it.

Also a couple of refactorings to clean up the relevant method.