### PR TITLE
[4.0] Filter out empty elements in crowbar lists

### DIFF
--- a/crowbar_framework/vendor/assets/javascripts/jquery/dynamicTable.js
+++ b/crowbar_framework/vendor/assets/javascripts/jquery/dynamicTable.js
@@ -437,7 +437,7 @@
         value = this.splitValue(value);
 
         for (i in value) {
-          value[i] = value[i].toLowerCase() == 'true'
+          value[i] = value[i].toLowerCase() == 'true';
         }
 
         return value;
@@ -464,7 +464,11 @@
   };
 
   DynamicTable.prototype.splitValue = function(value) {
-    return value.replace(/ /g, ',').replace(/,+/g, ',').split(',');
+    // note(jhesketh): filters out empty elements
+    return $.map(
+      value.replace(/ /g, ',').replace(/,+/g, ',').split(','),
+      $.trim
+    ).filter(Boolean);
   };
 
   $.fn.dynamicTable = function(options) {

--- a/crowbar_framework/vendor/assets/javascripts/jquery/jsonAttribute.js
+++ b/crowbar_framework/vendor/assets/javascripts/jquery/jsonAttribute.js
@@ -196,10 +196,11 @@
   };
 
   JsonAttribute.prototype.splitString = function(value) {
+    // note(jhesketh): filters out empty elements
     return $.map(
       value.replace(/,+/g, ',').split(','),
       $.trim
-    );
+    ).filter(Boolean);
   };
 
   $.fn.readJsonAttribute = function(key, value, type) {


### PR DESCRIPTION
When supplying a list (eg of hostnames: "host1, host2, , host3" etc)
an empty element "" would be set in the array. This change removes any
empty elements.

This change also stops empty strings from being converted to arrays
such as [""] (ie one empty element).

(bsc#1065903)

(cherry picked from commit 247f621)

Backport of https://github.com/crowbar/crowbar-core/pull/1453