### PR TITLE
[4.0] Add all .log file to apache logrotate(bsc#1071317)

### DIFF
--- a/chef/cookbooks/apache2/recipes/default.rb
+++ b/chef/cookbooks/apache2/recipes/default.rb
@@ -153,6 +153,13 @@ unless node[:platform_family] == "suse"
   end
 end
 
+template "/etc/logrotate.d/apache2-all" do
+  source "apache.logrotate.erb"
+  mode 0o644
+  owner "root"
+  group "root"
+end
+
 template "#{node[:apache][:dir]}/ports.conf" do
   path "#{node[:apache][:dir]}/listen.conf" if node[:platform_family] == "suse"
   source "ports.conf.erb"

--- a/chef/cookbooks/apache2/templates/default/apache.logrotate.erb
+++ b/chef/cookbooks/apache2/templates/default/apache.logrotate.erb
@@ -1,0 +1,15 @@
+/var/log/apache2/*.log {
+    compress
+    dateext
+    maxage 365
+    rotate 99
+    size=+4096k
+    notifempty
+    missingok
+    create 644 root root
+    sharedscripts
+    postrotate
+     systemctl reload apache2.service
+     sleep 60
+    endscript
+}


### PR DESCRIPTION
Currently only the apache access and error logs are rotated by logrotate
but /var/log/apache also contains access and error logs from keystone,
ceilometer, barbican and other services which are not rotated.
This adds a file which rotates all the logs in the apache directory.

(cherry picked from commit 7df53dca5f144ac670037d1006d6977241f35cc3)