### PR TITLE
crowbar: Attribute names in validation errors

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -669,7 +669,7 @@ class ServiceObject
     Rails.logger.info "validating proposal #{@bc_name}"
 
     errors = validator.validate(proposal)
-    @validation_errors = errors.map { |e| e.message }
+    @validation_errors = errors.map { |e| "#{e.path} #{e.message}" }
     handle_validation_errors
   end
 


### PR DESCRIPTION
**Why is this change necessary?**
When validation errors happened, only error message like "not a string" was displayed.

**How does it address the issue?**
Attribute path was added to the message to better identify possible source of error.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
