### PR TITLE
provisioner: Update grub.efi location for aarch64

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -133,7 +133,8 @@ discovery_arches.each do |arch|
     package "shim"
     shim_code = "cp /usr/lib64/efi/shim.efi boot#{short_arch}.efi; cp /usr/lib64/efi/grub.efi grub.efi"
   else
-    shim_code = "cp /usr/lib64/efi/grub.efi boot#{short_arch}.efi"
+    # aarch64
+    shim_code = "cp /usr/lib/efi/grub.efi boot#{short_arch}.efi"
   end
 
   directory "#{uefi_dir}/default/boot" do

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -506,7 +506,7 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
     if arch == "aarch64"
       grub2arch = "arm64"
       short_arch = "aa64"
-      shim_code = "cp /usr/lib64/efi/grub.efi boot/boot#{short_arch}.efi"
+      shim_code = "cp /usr/lib/efi/grub.efi boot/boot#{short_arch}.efi"
     end
 
     bash "Copy UEFI shim loader with grub2 for #{mnode[:fqdn]} (#{new_group})" do


### PR DESCRIPTION
SP2+ are installing the grub2 efi compat symlink under /usr/lib/grub2
not /usr/lib64/grub2 like on x86_64. adjust paths accordingly

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

