### PR TITLE
crowbar: Ensure epmd.socket is configured correctly

### DIFF
--- a/chef/cookbooks/crowbar/metadata.json
+++ b/chef/cookbooks/crowbar/metadata.json
@@ -7,6 +7,7 @@
     },
     "dependencies": {
       "apache2": [],
+      "barclamp": [],
       "bluepill": [],
       "utils": []
     },

--- a/chef/cookbooks/crowbar/templates/suse/epmd.socket-port.conf.erb
+++ b/chef/cookbooks/crowbar/templates/suse/epmd.socket-port.conf.erb
@@ -1,0 +1,3 @@
+[Socket]
+ListenStream=<%= @listen_address %>:4369
+FreeBind=true


### PR DESCRIPTION
With new erlang and rabbitmq-server packages, rabbitmq now depends on
the system-wide epmd service, which will only listen on IP addresses
defined for epmd.socket.

We need epmd to listen on the admin IP address (the one that resolves
the FQDN), so configure things accordingly.

While install-suse-cloud will already do this setup correctly, we also
change the crowbar cookbook to ensure the config stays up-to-date.