### PR TITLE
[4.0] crowbar: Attribute names in validation errors

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -669,7 +669,7 @@ class ServiceObject
     Rails.logger.info "validating proposal #{@bc_name}"
 
     errors = validator.validate(proposal)
-    @validation_errors = errors.map { |e| e.message }
+    @validation_errors = errors.map { |e| "#{e.path} #{e.message}" }
     handle_validation_errors
   end
 


### PR DESCRIPTION
Before this change, when validation errors happened, only error message
like "not a string" was displayed. Attribute path was added to the
message to better identify possible source of error.

(cherry picked from commit 656605aabc9575408151e15ca53c2b3cf43fd24b)

Backport of https://github.com/crowbar/crowbar-core/pull/1479