### PR TITLE
[4.0] crowbar: Avoid crash on precached deleted nodes

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1218,6 +1218,10 @@ class ServiceObject
 
     # Cache attributes that are useful later on
     pre_cached_nodes.each do |node_name, node|
+      if node.nil?
+        Rails.logger.debug "skipping deleted node #{node_name}"
+        next
+      end
       node_attr_cache[node_name] = {
         "alias" => node.alias,
         "windows" => node[:platform_family] == "windows",


### PR DESCRIPTION
When applying a proposal with deleted nodes it crashes due to
pre_cached_nodes containing a node with nil value.

(cherry picked from commit af5b3cab4173a45c8c5a584eb9fb934600b6cfcc)

Backport of https://github.com/crowbar/crowbar-core/pull/1469