### PR TITLE
provisioner: Fix UEFI based discovery for SP3+

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -122,6 +122,7 @@ discovery_arches.each do |arch|
   # we use grub2; steps taken from
   # https://github.com/openSUSE/kiwi/wiki/Setup-PXE-boot-with-EFI-using-grub2
   grub2arch = arch
+  grubcfgfile = "#{uefi_dir}/default/boot/grub.cfg"
   if arch == "aarch64"
     grub2arch = "arm64"
   end
@@ -145,7 +146,7 @@ discovery_arches.each do |arch|
     action :create
   end
 
-  template "#{uefi_dir}/default/grub.cfg" do
+  template "#{grubcfgfile}" do
     mode 0o644
     owner "root"
     group "root"
@@ -158,11 +159,12 @@ discovery_arches.each do |arch|
               kernel: "discovery/#{arch}/vmlinuz0")
   end
 
+  # Secure Boot Shim
   bash "Copy UEFI shim loader with grub2" do
     cwd "#{uefi_dir}/default/boot"
     code shim_code
     action :nothing
-    subscribes :run, resources("template[#{uefi_dir}/default/grub.cfg]"), :immediately
+    subscribes :run, resources("template[#{grubcfgfile}]"), :immediately
   end
 end
 

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -131,7 +131,7 @@ node_search_with_cache("*:*").each do |mnode|
       pxefile = "#{discovery_dir}/#{arch}/#{pxecfg_subdir}/#{boot_ip_hex}"
       uefi_dir = "#{discovery_dir}/#{arch}/#{uefi_subdir}"
       grubdir = "#{uefi_dir}/#{boot_ip_hex}"
-      grubcfgfile = "#{grubdir}/grub.cfg"
+      grubcfgfile = "#{grubdir}/boot/grub.cfg"
       grubfile = "#{uefi_dir}/#{boot_ip_hex}.efi"
       windows_tftp_file = "#{tftproot}/windows-common/tftp/#{boot_ip_hex}"
     else


### PR DESCRIPTION
The grub behavior in SP3 appears to have changed, it is looking
for grub.cfg in the same directory like the grub.efi resides, not
in the parent directory like before.
