### PR TITLE
crowbar-hacks: Skip activation of HPE UEFI entries

### DIFF
--- a/chef/cookbooks/crowbar-hacks/recipes/uefi.rb
+++ b/chef/cookbooks/crowbar-hacks/recipes/uefi.rb
@@ -14,12 +14,32 @@
 # limitations under the License.
 #
 
+# List of UEFI boot entries excluded from activation loop.
+# Some HP hardware re-creates these entries as disabled when they are activated
+# expanding the list of boot entries on every reboot.
+ignored_boot_entries = [
+  "Embedded UEFI Shell",
+  "Diagnose Error",
+  "System Utilities",
+  "Intelligent Provisioning",
+  "Boot Menu",
+  "Network Boot",
+  "Embedded Diagnostics",
+  "View Integrated Management Log"
+]
+
 ruby_block "uefi_boot_order_config" do
   block do
     if node["uefi"] && File.exist?("/sys/firmware/efi")
       node["uefi"]["boot"]["order"].each do |order|
         entry = node["uefi"]["entries"][order]
         next if entry[:active]
+
+        if ignored_boot_entries.include? entry[:title]
+          Chef::Log.info("Skipping activation of UEFI boot entry:"\
+                         " #{entry["title"]}")
+          next
+        end
 
         Chef::Log.info("Activating UEFI boot entry "\
                        "#{sprintf("%x", order)}: #{entry["title"]}")


### PR DESCRIPTION
**Why is this change necessary?**
HPE servers have some standard UEFI boot entries which are disabled
by default. After crowbar activates them, they are re-created by the
firmware with disabled state. Crowbar activates these duplicates and
the whole cycle repeats after each reboot. This can lead to very long
lists of boot entries which can even cause the machine to fail booting.

**How does it address the issue?**
The workaround for this problem is a list of entry names which are
skipped during the activation loop. Currently the list includes only
the HPE specific entries but can be extended in the future if needed.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://trello.com/c/Tx6hp73H/239-uefi-boot-entry-numbers-increase-with-every-hardware-installation