### PR TITLE
[4.0] provisioner: Fixes related to PXE-booting in UEFI case

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -290,7 +290,14 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
     end
 
     if mnode["uefi"] && mnode["uefi"]["boot"]["last_mac"]
-      append << "BOOTIF=01-#{mnode["uefi"]["boot"]["last_mac"].tr(":", "-")}"
+      # We know we configured dhcpd correctly to boot from the required
+      # interface and grub has this nice $net_default_mac variable that we can
+      # use here.
+      # We don't use the last_mac attribute as it may be wrong: the boot
+      # interface on discovery is not necessarily the one that will be used for
+      # the admin server. However what matters is that we last booted from a
+      # network interface (last_mac tells us that).
+      append << "BOOTIF=01-$net_default_mac"
     end
 
     case os

--- a/chef/cookbooks/provisioner/templates/default/grub.conf.erb
+++ b/chef/cookbooks/provisioner/templates/default/grub.conf.erb
@@ -12,8 +12,6 @@ menuentry '<%= @install_name %>' --class os {
      # dhcp, tftp server in my network
      set net_default_server=<%= @admin_ip %>
 
-     net_bootp
-
      echo 'Network status: '
      net_ls_cards
      net_ls_addr


### PR DESCRIPTION
Backport of https://github.com/crowbar/crowbar-core/pull/1487

**Don't use net_bootp for PXE-booted EFI-enabled grub**

net_bootp would configure all network interfaces with DHCP (which is
more than what we want, and may be slow).

However, it turns out that the efinet driver in grub2 will already
know the configuration configure of the network interface that was used
for PXE booting (since grub is parsing the DHCP ACK that the EFI
firmware received).

See grub_efi_net_config_real and grub_machine_get_bootlocation from:
http://git.savannah.gnu.org/cgit/grub.git/tree/grub-core/net/drivers/efi/efinet.c
http://git.savannah.gnu.org/cgit/grub.git/tree/grub-core/kern/efi/init.c
and for the patch introducing this:
http://git.savannah.gnu.org/cgit/grub.git/commit/?id=cae730b4526f250a3d5073c00911e35b7abdd7d7

Co-authored-by: Stefan Seyfried <stefan.seyfried@sap.com>

**Let grub2 provide the MAC address for BOOTIF in UEFI mode**

In UEFI PXE boot mode, grub will know from which interface we're
PXE-booting from, and can provide automatically the correct MAC address.

This will be fine, because the PXE config is fine (since we configure
DHCP to only boot from the interfaces that we want).

This solves issues when, for instance, the discovery image boots from
one interface that turns out to not be in the admin conduit after
network.json resolution.

Generally speaking, this also makes sense because we simply rely on
"reality" (since grub will put the right value), and not on something
that could be possibly wrong due to outdated chef data.

Co-authored-by: Stefan Seyfried <stefan.seyfried@sap.com>