### PR TITLE
crowbar: skip deleted nodes on updating data bags

### DIFF
--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -160,7 +160,7 @@ class DnsService < ServiceObject
     else
       if server_nodes.nil?
         server_nodes_names = role.override_attributes["dns"]["elements"]["dns-server"]
-        server_nodes = server_nodes_names.map { |n| Node.find_by_name(n) }
+        server_nodes = server_nodes_names.map { |n| Node.find_by_name(n) }.compact
       end
 
       addresses = server_nodes.map do |n|

--- a/crowbar_framework/app/models/logging_service.rb
+++ b/crowbar_framework/app/models/logging_service.rb
@@ -84,7 +84,7 @@ class LoggingService < ServiceObject
       config = nil
     else
       server_nodes_names = role.override_attributes["logging"]["elements"]["logging-server"]
-      server_nodes = server_nodes_names.map { |n| Node.find_by_name(n) }
+      server_nodes = server_nodes_names.map { |n| Node.find_by_name(n) }.compact
 
       addresses = server_nodes.map do |n|
         admin_net = n.get_network_by_type("admin")

--- a/crowbar_framework/app/models/ntp_service.rb
+++ b/crowbar_framework/app/models/ntp_service.rb
@@ -84,7 +84,7 @@ class NtpService < ServiceObject
       config = nil
     else
       server_nodes_names = role.override_attributes["ntp"]["elements"]["ntp-server"]
-      server_nodes = server_nodes_names.map { |n| Node.find_by_name(n) }
+      server_nodes = server_nodes_names.map { |n| Node.find_by_name(n) }.compact
 
       addresses = server_nodes.map do |n|
         admin_net = n.get_network_by_type("admin")


### PR DESCRIPTION
from an env where nodes were forgotten in a state where the dns and ntp barclamp was unclean. the stored proposal still had those deleted nodes, causing everything else to fall apart.