### PR TITLE
provisioner: remove repos before adding ours

### DIFF
--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -277,6 +277,7 @@ fi
 # Setup the repos
 # ---------------
 
+rm -f /etc/zypp/repos.d/*.repo
 <% @repos.keys.sort.each do |name| %>
 zypper -n ar "<%= @repos[name][:url] %>" "<%= name %>"
   <% unless @repos[name][:priority] == 99 -%>


### PR DESCRIPTION
to make it easier to re-run crowbar_register in case of errors