### PR TITLE
provisioner: Use BarclampLibrary to search for available boot disks

### DIFF
--- a/chef/cookbooks/provisioner/recipes/bootdisk.rb
+++ b/chef/cookbooks/provisioner/recipes/bootdisk.rb
@@ -23,6 +23,19 @@ if node["crowbar_wall"]["registering"]
  node.save
 end
 
+# Look at the disks known by BarclampLibrary first
+unless node[:crowbar_wall][:boot_device]
+  BarclampLibrary::Barclamp::Inventory::Disk.unclaimed(node, true).each do |unclaimed_disk|
+    next if unclaimed_disk.nil? || unclaimed_disk.removable?
+    dev = unclaimed_disk.name
+    unclaimed_disk.claim("Boot")
+    dev = dev.split("/")[-1]
+    node[:crowbar_wall][:boot_device] = dev
+    node.save
+    break
+  end
+end
+
 # Find the first thing that looks like a hard drive based on
 # PCI bus enumeration, and use it as the target disk.
 # Unless some other barclamp has set it, that is.


### PR DESCRIPTION
Sometimes looking for a disk under /dev/disk/by-path does not give
correct results  - paths for some devices might yet exist.

So get the list of unclaimed devices from BarclampLibrary, which has it
from ohai. Exclude removable devices.

See https://bugzilla.suse.com/show_bug.cgi?id=1063523 for initial problem discussion