### PR TITLE
crowbar: fix call to gensslcert

### DIFF
--- a/chef/cookbooks/crowbar/recipes/default.rb
+++ b/chef/cookbooks/crowbar/recipes/default.rb
@@ -426,9 +426,9 @@ if node[:crowbar][:apache][:ssl]
     Chef::Log.info("Generating SSL certificates for Crowbar.")
     bash "generate apache certificate" do
       code <<-GENSSLCERT
-        (umask 377 ; /usr/bin/gensslcert -c crowbar )
+        (umask 377 ; /usr/bin/gensslcert -C crowbar )
       GENSSLCERT
-      not_if { file.size?(node[:crowbar][:apache][:ssl_crt_file]) }
+      not_if { ::File.size?(node[:crowbar][:apache][:ssl_crt_file]) }
     end
   end
 end


### PR DESCRIPTION
Use -C (common name) instead of -c (country) parameter, and fix the
Ruby call to ::File.size?.

(cherry picked from commit 6f87dc73302f33922abf05e0341fd9313da3b46c)

**Why is this change necessary?**

currently ssl deployment with develcloud7 is broken

**How does it address the issue?**

backport the fix from master PR #1473