### PR TITLE
Improve experimental API errors (bsc#1076240)

### DIFF
--- a/crowbar_framework/app/controllers/api/restart_management_controller.rb
+++ b/crowbar_framework/app/controllers/api/restart_management_controller.rb
@@ -17,6 +17,13 @@
 class Api::RestartManagementController < ApiController
   skip_before_filter :upgrade
 
+  before_action do
+    unless Rails.application.config.experimental.fetch("disallow_restart", {}).fetch("enabled", false)
+      render json: { error: I18n.t("api.experimental.disabled", option: "disallow_restart") },
+             status: :not_acceptable
+    end
+  end
+
   api :POST, "/api/restart_management/configuration", "Set the disallow restart value for cookbooks"
   header "Accept", "application/vnd.crowbar.v2.0+json", required: true
   param :disallow_restart, [true, false], desc: "Disallow service reboots", required: true

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -777,6 +777,8 @@ en:
       cache_error: 'Failed to cache sanity checks'
 
   api:
+    experimental:
+      disabled: 'This experimental API is currently disabled in experimental.yml config file (%{option} option).'
     error:
       destroy_failed: 'Failed to destroy %{component}'
     crowbar:

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -271,9 +271,6 @@ Rails.application.routes.draw do
 
     # service restart management
     resource :restart_management,
-      constraints: lambda { |request|
-        Rails.application.config.experimental.fetch("disallow_restart", {}).fetch("enabled", false)
-      },
       controller: :restart_management,
       only: [] do
       member do

--- a/crowbar_framework/spec/controllers/api/restart_management_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/restart_management_controller_spec.rb
@@ -200,34 +200,34 @@ describe Api::RestartManagementController, type: :request, focus: true do
   context "Feature disabled" do
 
     context "GET configuration" do
-      it "should fail to reach the route" do
-        expect do
-          get "/api/restart_management/configuration", {}, headers
-        end.to raise_error(ActionController::RoutingError)
+      it "should receive error response" do
+        get "/api/restart_management/configuration", {}, headers
+        expect(response).to have_http_status(:not_acceptable)
+        expect(ActiveSupport::JSON.decode(response.body)).to include("error")
       end
     end
 
     context "POST configuration" do
-      it "should fail to reach the route" do
-        expect do
-          post "/api/restart_management/configuration", {}, headers
-        end.to raise_error(ActionController::RoutingError)
+      it "should receive error response" do
+        post "/api/restart_management/configuration", {}, headers
+        expect(response).to have_http_status(:not_acceptable)
+        expect(ActiveSupport::JSON.decode(response.body)).to include("error")
       end
     end
 
     context "GET restarts" do
-      it "should fail to reach the route" do
-        expect do
-          get "/api/restart_management/restarts", {}, headers
-        end.to raise_error(ActionController::RoutingError)
+      it "should receive error response" do
+        get "/api/restart_management/restarts", {}, headers
+        expect(response).to have_http_status(:not_acceptable)
+        expect(ActiveSupport::JSON.decode(response.body)).to include("error")
       end
     end
 
     context "POST restarts" do
-      it "should fail to reach the route" do
-        expect do
-          post "/api/restart_management/restarts", {}, headers
-        end.to raise_error(ActionController::RoutingError)
+      it "should receive error response" do
+        post "/api/restart_management/restarts", {}, headers
+        expect(response).to have_http_status(:not_acceptable)
+        expect(ActiveSupport::JSON.decode(response.body)).to include("error")
       end
     end
   end


### PR DESCRIPTION
**Why is this change necessary?**
The experimental restart management API was enabled only if relevant
option was enabled in experimental.yml. When called with the option
disabled, crowbar returned 404 with no hint on what is wrong.

**How does it address the issue?**
Replaced routing condition with before_action in the controller to
enable better error reporting.

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
https://bugzilla.suse.com/show_bug.cgi?id=1076240