### PR TITLE
apache: copytruncate apache logs bsc#1083093

### DIFF
--- a/chef/cookbooks/apache2/templates/default/apache.logrotate.erb
+++ b/chef/cookbooks/apache2/templates/default/apache.logrotate.erb
@@ -1,15 +1,11 @@
 /var/log/apache2/*.log {
     compress
+    copytruncate
     dateext
     maxage 365
     rotate 99
     size=+4096k
     notifempty
     missingok
-    create 644 root root
     sharedscripts
-    postrotate
-     systemctl reload apache2.service
-     sleep 60
-    endscript
 }


### PR DESCRIPTION
apache2 reload causes responses 406 from keystone. This change was
verified on a customer's setup.

bsc#1083093