### PR TITLE
[stable/4.0] provisioner: Install microcode packages (bsc#1074665)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -377,6 +377,16 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
         cloud_available = true if name.include? "Cloud"
       end
 
+      cpu_model = ""
+      if mnode.key?("cpu") && mnode[:cpu].length >= 1
+        case mnode[:cpu]["0"][:model_name]
+        when /^Intel\(R\)/
+          cpu_model = "intel"
+        when /^AuthenticAMD/
+          cpu_model = "amd"
+        end
+      end
+
       autoyast_template = mnode[:state] == "os-upgrading" ? "autoyast-upgrade" : "autoyast"
       template "#{node_cfg_dir}/autoyast.xml" do
         mode 0o644
@@ -399,6 +409,7 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
           platform: target_platform_distro,
           target_platform_version: target_platform_version,
           architecture: arch,
+          cpu_model: cpu_model,
           is_ses: storage_available && !cloud_available,
           crowbar_join: "#{os_url}/crowbar_join.sh",
           default_fs: mnode[:crowbar_wall][:default_fs] || "ext4",

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -339,6 +339,11 @@ sync
 <% if @architecture == "x86_64" -%>
       <package>biosdevname</package>
 <% end -%>
+<% if @platform == "suse" && @cpu_model == "intel" -%>
+      <package>ucode-intel</package>
+<% elsif @platform == "suse" && @cpu_model == "amd" -%>
+      <package>ucode-amd</package>
+<%end -%>
       <package>netcat</package>
       <package>ruby2.1-rubygem-chef</package>
       <package>ruby2.1-rubygem-crowbar-client</package>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -319,6 +319,14 @@ case $ARCH in
     x86_64) PACKAGES_INSTALL+=" biosdevname";;
 esac
 
+# Also install relevant microcode packages
+case $(grep -m 1 'model name' /proc/cpuinfo) in
+    *Intel\(R\)*)
+        PACKAGES_INSTALL+=" ucode-intel";;
+    *AuthenticAMD*)
+        PACKAGES_INSTALL+=" ucode-amd";;
+esac
+
 zypper --non-interactive install -t pattern $PATTERNS_INSTALL
 # Auto-agree with the license since it was already agreed on for the admin server
 <% if @platform == "suse" && @target_platform_version.to_f >= 12.1 -%>


### PR DESCRIPTION
During provisioning of new nodes (using either crowbar-register or
autoyast) install the microcode packages for the relevant CPU vendor
(ucode-intel and ucode-amd) to help mitigate against side-channel
attacks.

(cherry picked from commit 89147b09bf984563d4d0c5a35c13896e904a3cff)

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
