### PR TITLE
[4.0] provisioner: replace curl calls to crowbar API with crowbarctl 

### DIFF
--- a/bin/gather_logs.sh
+++ b/bin/gather_logs.sh
@@ -18,6 +18,7 @@
 
 if [[ -f /etc/crowbar.install.key ]]; then
     export CROWBAR_KEY=$(cat /etc/crowbar.install.key)
+    export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
 fi
 mkdir -p /tmp/crowbar-logs
 tarname="${1-$(date '+%Y%m%d-%H%M%S')}"
@@ -47,11 +48,10 @@ sort_by_last() {
 	-o 'UserKnownHostsFile /dev/null')
     logs=(/var/log /etc)
     logs+=(/var/chef/cache /var/cache/chef /opt/dell/crowbar_framework/db)
-    curlargs=(-o /dev/null -D - --connect-timeout 30 --max-time 120 --insecure \
-    --location)
-    [[ $CROWBAR_KEY ]] && curlargs+=(--digest -u "$CROWBAR_KEY")
-    for to_get in nodes proposals roles; do
-	curl "${curlargs[@]}" "http://localhost/$to_get" || :
+    crowbarctl node list -U machine-install -P $CROWBAR_PASS
+
+    for to_get in proposals roles; do
+        crowbarctl $to_get proposal list crowbar
     done
     for node in $(sudo -H knife node list); do
 	tarfile="${node%%.*}-${tarname}.tar.gz"

--- a/bin/gather_logs.sh
+++ b/bin/gather_logs.sh
@@ -48,10 +48,10 @@ sort_by_last() {
 	-o 'UserKnownHostsFile /dev/null')
     logs=(/var/log /etc)
     logs+=(/var/chef/cache /var/cache/chef /opt/dell/crowbar_framework/db)
-    crowbarctl node list -U machine-install -P $CROWBAR_PASS
+    crowbarctl node list -U machine-install -P $CROWBAR_PASS --no-verify-ssl
 
     for to_get in proposals roles; do
-        crowbarctl $to_get proposal list crowbar -U machine-install -P $CROWBAR_PASS
+        crowbarctl $to_get proposal list crowbar -U machine-install -P $CROWBAR_PASS --no-verify-ssl
     done
     for node in $(sudo -H knife node list); do
 	tarfile="${node%%.*}-${tarname}.tar.gz"

--- a/bin/gather_logs.sh
+++ b/bin/gather_logs.sh
@@ -51,7 +51,7 @@ sort_by_last() {
     crowbarctl node list -U machine-install -P $CROWBAR_PASS
 
     for to_get in proposals roles; do
-        crowbarctl $to_get proposal list crowbar
+        crowbarctl $to_get proposal list crowbar -U machine-install -P $CROWBAR_PASS
     done
     for node in $(sudo -H knife node list); do
 	tarfile="${node%%.*}-${tarname}.tar.gz"

--- a/bin/transition.sh
+++ b/bin/transition.sh
@@ -22,17 +22,7 @@ if [[ $(cat /proc/cmdline) =~ $key_re ]]; then
 elif [[ -f /etc/crowbar.install.key ]]; then
     export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
 fi
-
-HOST="127.0.0.1"
-
-post_state() {
-  local curlargs=(-o "/var/log/crowbar/$1-$2.json" --connect-timeout 60 -s \
-      -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
-      -H "Accept: application/json" -H "Content-Type: application/json" \
-      --insecure --location)
-  [[ $CROWBAR_KEY ]] && curlargs+=(-u "$CROWBAR_KEY" --digest --anyauth)
-  curl "${curlargs[@]}" "http://${HOST}/crowbar/crowbar/1.0/transition/default"
-}
+export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
 
 if [ "$1" == "" ]
 then
@@ -51,7 +41,7 @@ do
   if [ $1 == $line ]
   then
     echo "Transitioning node $1 to state $2"
-    post_state $1 $2
+    crowbarctl node transition $1 $2 -U machine-install -P $CROWBAR_PASS
     break
   fi
 done

--- a/bin/transition.sh
+++ b/bin/transition.sh
@@ -41,7 +41,7 @@ do
   if [ $1 == $line ]
   then
     echo "Transitioning node $1 to state $2"
-    crowbarctl node transition $1 $2 -U machine-install -P $CROWBAR_PASS
+    crowbarctl node transition $1 $2 -U machine-install -P $CROWBAR_PASS --no-verify-ssl
     break
   fi
 done

--- a/chef/cookbooks/crowbar/files/default/crowbar
+++ b/chef/cookbooks/crowbar/files/default/crowbar
@@ -32,12 +32,12 @@ case $1 in
         rm -rf /var/run/crowbar/looper-chef-client.lock /var/run/crowbar/chef-client.run /var/run/crowbar/chef-client.lock
 
         # Mark us as readying, and get our cert.
-	crowbarctl node transition $HOSTNAME "readying" -U machine-install -P $CROWBAR_PASS
+	crowbarctl node transition $HOSTNAME "readying" -U machine-install -P $CROWBAR_PASS --no-verify-ssl
         if [ -f /etc/default/tftpd-hpa ] ; then
           service tftpd-hpa stop
           service tftpd-hpa start
         fi
-	crowbarctl node transition $HOSTNAME "ready" -U machine-install -P $CROWBAR_PASS
+	crowbarctl node transition $HOSTNAME "ready" -U machine-install -P $CROWBAR_PASS --no-verify-ssl
 
 	echo "Done";;
     stop) bluepill crowbar-webserver stop;;

--- a/chef/cookbooks/crowbar/files/default/crowbar
+++ b/chef/cookbooks/crowbar/files/default/crowbar
@@ -23,16 +23,8 @@ IP="127.0.0.1"
 
 if [[ -f /etc/crowbar.install.key ]]; then
     export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
+    export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
 fi
-
-post_state() {
-  local curlargs=(-o /dev/null --connect-timeout 60 -s \
-      -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
-      -H "Accept: application/json" -H "Content-Type: application/json" \
-      --max-time 240 --insecure --location)
-  [[ $CROWBAR_KEY ]] && curlargs+=(-u "$CROWBAR_KEY" --digest --anyauth)
-  curl "${curlargs[@]}" "http://$IP/crowbar/crowbar/1.0/transition/default"
-}
 
 case $1 in
     start|'')
@@ -40,12 +32,12 @@ case $1 in
         rm -rf /var/run/crowbar/looper-chef-client.lock /var/run/crowbar/chef-client.run /var/run/crowbar/chef-client.lock
 
         # Mark us as readying, and get our cert.
-	post_state $HOSTNAME "readying"
+	crowbarctl node transition $HOSTNAME "readying" -U machine-install -P $CROWBAR_PASS
         if [ -f /etc/default/tftpd-hpa ] ; then
           service tftpd-hpa stop
           service tftpd-hpa start
         fi
-	post_state $HOSTNAME "ready"
+	crowbarctl node transition $HOSTNAME "ready" -U machine-install -P $CROWBAR_PASS
 
 	echo "Done";;
     stop) bluepill crowbar-webserver stop;;

--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -25,6 +25,10 @@ web_port = node[:provisioner][:web_port]
 provisioner_web="http://#{admin_ip}:#{web_port}"
 append_line = node[:provisioner][:discovery][:append].dup # We'll modify it inline
 
+crowbar_node = node_search_with_cache("roles:crowbar").first
+crowbar_protocol = crowbar_node[:crowbar][:apache][:ssl] ? "https" : "http"
+crowbar_verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
+
 tftproot = node[:provisioner][:root]
 
 discovery_dir = "#{tftproot}/discovery"
@@ -527,6 +531,8 @@ node[:provisioner][:supported_oses].each do |os, arches|
         source "crowbar_register.erb"
         variables(admin_ip: admin_ip,
                   admin_broadcast: admin_net.broadcast,
+                  crowbar_protocol: crowbar_protocol,
+                  crowbar_verify_ssl: crowbar_verify_ssl,
                   web_port: web_port,
                   ntp_servers_ips: ntp_servers,
                   os: os,

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -60,6 +60,10 @@ provisioner_web = "http://#{admin_ip}:#{web_port}"
 dhcp_hosts_dir = node["provisioner"]["dhcp_hosts"]
 virtual_intfs = ["tap", "qbr", "qvo", "qvb", "brq", "ovs"]
 
+crowbar_node = node_search_with_cache("roles:crowbar").first
+crowbar_protocol = crowbar_node[:crowbar][:apache][:ssl] ? "https" : "http"
+crowbar_verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
+
 discovery_dir = "#{tftproot}/discovery"
 pxecfg_subdir = "bios/pxelinux.cfg"
 uefi_subdir = "efi"
@@ -385,6 +389,8 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
         group "root"
         variables(
           admin_node_ip: admin_ip,
+          crowbar_protocol: crowbar_protocol,
+          crowbar_verify_ssl: crowbar_verify_ssl,
           web_port: web_port,
           packages: packages,
           repos: repos,

--- a/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
@@ -51,7 +51,7 @@
   <scripts>
     <chroot-scripts config:type="list">
       <script>
-        <chrooted config:type="boolean">false</chrooted>
+        <chrooted config:type="boolean">true</chrooted>
         <debug config:type="boolean">true</debug>
         <filename>crowbar_post</filename>
         <source>
@@ -64,9 +64,9 @@
           key_re='crowbar\.install\.key=([^ ]+)'
           if [[ $(cat /proc/cmdline) =~ $key_re ]]; then
               export CROWBAR_KEY="${BASH_REMATCH[1]}"
-              echo "$CROWBAR_KEY" >/mnt/etc/crowbar.install.key
-          elif [[ -f /mnt/etc/crowbar.install.key ]]; then
-              export CROWBAR_KEY="$(cat /mnt/etc/crowbar.install.key)"
+              echo "$CROWBAR_KEY" >/etc/crowbar.install.key
+          elif [[ -f /etc/crowbar.install.key ]]; then
+              export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
           fi
 
           export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
@@ -84,7 +84,7 @@ EOF
           curl -s -o /usr/sbin/crowbar_join <%= @crowbar_join %>
           chmod +x /usr/sbin/crowbar_join
 
-          mkdir -p /mnt/var/log/crowbar
+          mkdir -p /var/log/crowbar
           crowbarctl node transition $HOSTNAME "os-upgraded"
 
           # Wait for DHCP to update - this is mainly for virtual environments or really large deploys

--- a/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
@@ -68,21 +68,24 @@
           elif [[ -f /mnt/etc/crowbar.install.key ]]; then
               export CROWBAR_KEY="$(cat /mnt/etc/crowbar.install.key)"
           fi
-          post_state() {
-              mkdir -p /var/log/crowbar
-              local curlargs=(-o /dev/null --connect-timeout 60 -s \
-                -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
-                -H "Accept: application/json" -H "Content-Type: application/json" \
-                --max-time 240)
-              [[ $CROWBAR_KEY ]] && curlargs+=(-u "$CROWBAR_KEY" --digest --anyauth)
-              curl "${curlargs[@]}" "http://$IP/crowbar/crowbar/1.0/transition/default"
-          }
 
-          curl -s -o /mnt/usr/sbin/crowbar_join <%= @crowbar_join %>
-          chmod +x /mnt/usr/sbin/crowbar_join
+          export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
+
+          cat <<EOF > /etc/crowbarrc
+[default]
+server = <%= @crowbar_protocol %>://<%= @admin_node_ip %>
+username = machine-install
+password = $CROWBAR_PASS
+<% unless @crowbar_verify_ssl %>
+verify_ssl = 0
+<% end %>
+EOF
+
+          curl -s -o /usr/sbin/crowbar_join <%= @crowbar_join %>
+          chmod +x /usr/sbin/crowbar_join
 
           mkdir -p /mnt/var/log/crowbar
-          post_state $HOSTNAME "os-upgraded"
+          crowbarctl node transition $HOSTNAME "os-upgraded"
 
           # Wait for DHCP to update - this is mainly for virtual environments or really large deploys
           sleep 30

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -278,15 +278,17 @@ elif [[ -f /mnt/etc/crowbar.install.key ]]; then
 export CROWBAR_KEY="$(cat /mnt/etc/crowbar.install.key)"
 fi
 
-post_state() {
-mkdir -p /var/log/crowbar
-local curlargs=(-o /dev/null --connect-timeout 60 -s \
-  -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
-  -H "Accept: application/json" -H "Content-Type: application/json" \
-  --max-time 240 --insecure --location)
-[[ $CROWBAR_KEY ]] && curlargs+=(-u "$CROWBAR_KEY" --digest --anyauth)
-curl "${curlargs[@]}" "http://$IP/crowbar/crowbar/1.0/transition/default"
-}
+export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
+
+cat <<EOF > /mnt/etc/crowbarrc
+[default]
+server = <%= @crowbar_protocol %>://<%= @admin_node_ip %>
+username = machine-install
+password = $CROWBAR_PASS
+<% unless @crowbar_verify_ssl %>
+verify_ssl = 0
+<% end %>
+EOF
 
 mkdir -p /mnt/root/.ssh
 chmod 700 /mnt/root/.ssh
@@ -304,7 +306,7 @@ curl -s -o /mnt/usr/sbin/crowbar_join <%= @crowbar_join %>
 chmod +x /mnt/usr/sbin/crowbar_join
 
 mkdir -p /mnt/var/log/crowbar
-post_state $HOSTNAME "installed"
+crowbarctl node transition $HOSTNAME "installed"
 
 # Wait for DHCP to update - this is mainly for virtual environments or really large deploys
 sleep 30

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -260,7 +260,7 @@ sed -i s/"^[[:space:]]*DEFAULT_FS=.*"/DEFAULT_FS=\"<%= @default_fs %>\"/ /etc/sy
     <% end %>
     <chroot-scripts config:type="list">
         <script>
-            <chrooted config:type="boolean">false</chrooted>
+            <chrooted config:type="boolean">true</chrooted>
             <debug config:type="boolean">true</debug>
             <filename>crowbar_post</filename>
             <source>
@@ -273,14 +273,14 @@ HOSTNAME="<%= @node_fqdn %>"
 key_re='crowbar\.install\.key=([^ ]+)'
 if [[ $(cat /proc/cmdline) =~ $key_re ]]; then
 export CROWBAR_KEY="${BASH_REMATCH[1]}"
-echo "$CROWBAR_KEY" >/mnt/etc/crowbar.install.key
-elif [[ -f /mnt/etc/crowbar.install.key ]]; then
-export CROWBAR_KEY="$(cat /mnt/etc/crowbar.install.key)"
+echo "$CROWBAR_KEY" >/etc/crowbar.install.key
+elif [[ -f /etc/crowbar.install.key ]]; then
+export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
 fi
 
 export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
 
-cat <<EOF > /mnt/etc/crowbarrc
+cat <<EOF > /etc/crowbarrc
 [default]
 server = <%= @crowbar_protocol %>://<%= @admin_node_ip %>
 username = machine-install
@@ -290,22 +290,22 @@ verify_ssl = 0
 <% end %>
 EOF
 
-mkdir -p /mnt/root/.ssh
-chmod 700 /mnt/root/.ssh
-if ! curl -s -o /mnt/root/.ssh/authorized_keys.wget \
+mkdir -p /root/.ssh
+chmod 700 /root/.ssh
+if ! curl -s -o /root/.ssh/authorized_keys.wget \
     http://$HTTP_SERVER/authorized_keys ||\
-    grep -q "Error 404" /mnt/root/.ssh/authorized_keys.wget; then
-    rm -f /mnt/root/.ssh/authorized_keys.wget
+    grep -q "Error 404" /root/.ssh/authorized_keys.wget; then
+    rm -f /root/.ssh/authorized_keys.wget
 else
-    chmod 644 /mnt/root/.ssh/authorized_keys
-    cat /mnt/root/.ssh/authorized_keys.wget >> /mnt/root/.ssh/authorized_keys
-    rm -f /mnt/root/.ssh/authorized_keys.wget
+    chmod 644 /root/.ssh/authorized_keys
+    cat /root/.ssh/authorized_keys.wget >> /root/.ssh/authorized_keys
+    rm -f /root/.ssh/authorized_keys.wget
 fi
 
-curl -s -o /mnt/usr/sbin/crowbar_join <%= @crowbar_join %>
-chmod +x /mnt/usr/sbin/crowbar_join
+curl -s -o /usr/sbin/crowbar_join <%= @crowbar_join %>
+chmod +x /usr/sbin/crowbar_join
 
-mkdir -p /mnt/var/log/crowbar
+mkdir -p /var/log/crowbar
 crowbarctl node transition $HOSTNAME "installed"
 
 # Wait for DHCP to update - this is mainly for virtual environments or really large deploys

--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -65,33 +65,17 @@ log_to() {
 
 get_state() {
   local output
-  local curlargs=(--connect-timeout 60 -s -L \
-      -H "Accept: application/json" -H "Content-Type: application/json" \
-      --max-time 240 --insecure --location)
-  [[ $CROWBAR_KEY ]] && curlargs+=(-u "$CROWBAR_KEY" --digest --anyauth)
-  # we expect something like {"value":"ready"}
-  output=$(curl "${curlargs[@]}" "http://$IP/dashboard/$1/attribute/state" | \
-      tr -d "{}\"'[:space:][:cntrl:]")
+  # we expect something like "status": "Ready"
+  output=$(crowbarctl node status --json --filter $1 | grep status | \
+      tr '[:upper:]' '[:lower:]' | tr -d "\"'[:space:][:cntrl:]")
   # note that we removed all quotes, whitespaces and control characters, so
   # it's safe to use the variable if quoted
-  state="${output##value:}"
+  state="${output##status:}"
   if [ "$state" != "$output" ]; then
       echo "$state"
   else
       echo "unknown"
   fi
-}
-
-post_state() {
-  local curlargs=(-o /dev/null --connect-timeout 60 -s \
-      -L -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
-      -H "Accept: application/json" -H "Content-Type: application/json" \
-      --max-time 240 --insecure --location)
-  [[ $CROWBAR_KEY ]] && curlargs+=(-u "$CROWBAR_KEY" --digest --anyauth)
-  oldumask=`umask`
-  umask 077
-  curl "${curlargs[@]}" "http://$IP/crowbar/crowbar/1.0/transition/default"
-  umask $oldumask
 }
 
 wait_for_network() {
@@ -303,7 +287,7 @@ do_chef_client() {
     # we didn't succeed with chef-client, so let's try running it again with a
     # state where some roles will not be active
     echo_debug "Failed to run chef-client, trying with state \"recovering\""
-    post_state $HOSTNAME "recovering"
+    crowbarctl node transition  $HOSTNAME "recovering"
 
     echo_debug "Syncing Time"
     sync_time
@@ -313,7 +297,7 @@ do_chef_client() {
     echo_verbose "Running Chef Client (try 2, pass 1) - cache cleanup"
     if log_to chef chef-client $CHEF_CLIENT_OPTIONS; then
 	# it worked, cool, let's try again with "readying" state
-        post_state $HOSTNAME "readying"
+        crowbarctl node transition  $HOSTNAME "readying"
         echo_verbose "Running Chef Client (try 2, pass 2) - cache cleanup"
         if log_to chef chef-client $CHEF_CLIENT_OPTIONS; then
             return
@@ -504,7 +488,7 @@ if [ "$MODE" == "setup" -o "$MODE" == "start" ]; then
     sync_time
 
     # Mark us as readying, and get our cert.
-    post_state $HOSTNAME "readying"
+    crowbarctl node transition  $HOSTNAME "readying"
     final_state="ready"
 
     [ "$MODE" == "setup" ] && do_setup
@@ -519,7 +503,7 @@ if [ "$MODE" == "setup" -o "$MODE" == "start" ]; then
     do_chef_client
 
     # Transition to our final state
-    post_state $HOSTNAME "$final_state"
+    crowbarctl node transition  $HOSTNAME "$final_state"
 
     # make sure to keep hostname
     [ "$MODE" == "setup" ] && echo $HOSTNAME > /etc/HOSTNAME
@@ -529,8 +513,8 @@ if [ "$MODE" == "setup" -o "$MODE" == "start" ]; then
 
     [ $final_state == "ready" ] || EXVAL=1
 elif [ "$MODE" == "stop" ]; then
-    HOSTNAME=$(hostname -f)
     state=$(get_state $HOSTNAME)
+    HOSTNAME=$(hostname -f)
 
     case "$state" in
         "reset"|"reinstall"|"confupdate")
@@ -543,7 +527,7 @@ elif [ "$MODE" == "stop" ]; then
             else
                 final_state="shutdown"
             fi
-            post_state $HOSTNAME "$final_state"
+            crowbarctl node transition  $HOSTNAME "$final_state"
             ;;
      esac
 

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -94,46 +94,6 @@ fi
 # Helper functions
 # ----------------
 
-get_common_curl_args() {
-  local curlargs=(--connect-timeout 60 -s -L --max-time 240 --insecure --location)
-
-  [[ $CROWBAR_KEY ]] && curlargs+=(-u "$CROWBAR_KEY" --digest --anyauth)
-
-  echo ${curlargs[@]}
-}
-
-get_nodes_allow_fail() {
-  # --fail is important here as we rely on the failure to know if we can
-  # communicate with the admin server
-  local curlargs=($(get_common_curl_args) --fail -H "Accept: application/json")
-
-  curl "${curlargs[@]}" "http://$ADMIN_IP/crowbar/machines/1.0/"
-}
-
-get_node_allow_fail() {
-  # --fail is important here as we rely on the failure for 404
-  local curlargs=($(get_common_curl_args) --fail -H "Accept: application/json")
-
-  curl "${curlargs[@]}" "http://$ADMIN_IP/crowbar/machines/1.0/$HOSTNAME"
-}
-
-post_allocate() {
-  local curlargs=($(get_common_curl_args) \
-                  -X POST --data-binary "{ \"name\": \"$1\" }" \
-                  -H "Accept: application/json" -H "Content-Type: application/json")
-
-  curl "${curlargs[@]}" "http://$ADMIN_IP/crowbar/machines/1.0/allocate/0"
-}
-
-post_state() {
-  local curlargs=($(get_common_curl_args) \
-                  -o /dev/null
-                  -X POST --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
-                  -H "Accept: application/json" -H "Content-Type: application/json")
-
-  curl "${curlargs[@]}" "http://$ADMIN_IP/crowbar/crowbar/1.0/transition/default"
-}
-
 add_group() {
   gid=$(getent group $1 | cut -f 3 -d ":")
   if [[ -z "$gid" ]]; then
@@ -242,38 +202,6 @@ if test "x$MD5_ADMIN" != "x$MD5_LOCAL"; then
     exit 1
 fi
 
-
-# Check that we can really register this node
-# -------------------------------------------
-
-nodes=$(get_nodes_allow_fail || echo "")
-if test -z "$nodes"; then
-  echo "Failed to contact the administration server."
-  echo "Is the administration server up?"
-  exit 1
-fi
-
-# Copied from sledgehammer
-MAC=$(cat /sys/class/net/$BOOTDEV/address)
-if test $KEEP_EXISTING_HOSTNAME -ne 1; then
-  HOSTNAME="d${MAC//:/-}.${DOMAIN}"
-else
-  HOSTNAME=$(cat /etc/HOSTNAME)
-  if ! echo "$HOSTNAME" | grep -q "\.$DOMAIN$"; then
-    echo "The fully qualified domain name did not contain the $DOMAIN cloud domain."
-    exit 1
-  elif echo "${HOSTNAME%%.$DOMAIN}" | grep -q "\."; then
-    echo "The hostname is in a subdomain of the $DOMAIN cloud domain."
-    exit 1
-  fi
-fi
-
-if get_node_allow_fail > /dev/null; then
-  echo "This node seems to be already registered."
-  exit 1
-fi
-
-
 # Setup the repos
 # ---------------
 
@@ -310,7 +238,7 @@ PATTERNS_INSTALL="$PATTERNS_INSTALL Minimal base"
 <% elsif @platform == "opensuse" -%>
 PATTERNS_INSTALL="$PATTERNS_INSTALL base enhanced_base sw_management"
 <% end -%>
-PACKAGES_INSTALL="$PACKAGES_INSTALL netcat ruby2.1-rubygem-chef"
+PACKAGES_INSTALL="$PACKAGES_INSTALL netcat ruby2.1-rubygem-chef ruby2.1-rubygem-crowbar-client"
 
 # We also need ntp for this script
 PACKAGES_INSTALL="$PACKAGES_INSTALL ntp"
@@ -340,6 +268,51 @@ if ! which chef-client &> /dev/null; then
   echo "chef-client is not available."
   exit 1
 fi
+
+# Set up /etc/crowbarrc with crowbarctl credentials
+# -------------------------------------------
+export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
+
+cat <<EOF > /etc/crowbarrc
+[default]
+server = <%= @crowbar_protocol %>://<%= @admin_ip %>
+username = machine-install
+password = $CROWBAR_PASS
+<% unless @crowbar_verify_ssl %>
+verify_ssl = 0
+<% end %>
+EOF
+
+
+# Check that we can really register this node
+# -------------------------------------------
+
+if ! crowbarctl node list > /dev/null; then
+  echo "Failed to contact the administration server."
+  echo "Is the administration server up?"
+  exit 1
+fi
+
+# Copied from sledgehammer
+MAC=$(cat /sys/class/net/$BOOTDEV/address)
+if test $KEEP_EXISTING_HOSTNAME -ne 1; then
+  HOSTNAME="d${MAC//:/-}.${DOMAIN}"
+else
+  HOSTNAME=$(cat /etc/HOSTNAME)
+  if ! echo "$HOSTNAME" | grep -q "\.$DOMAIN$"; then
+    echo "The fully qualified domain name did not contain the $DOMAIN cloud domain."
+    exit 1
+  elif echo "${HOSTNAME%%.$DOMAIN}" | grep -q "\."; then
+    echo "The hostname is in a subdomain of the $DOMAIN cloud domain."
+    exit 1
+  fi
+fi
+
+if crowbarctl node show $HOSTNAME > /dev/null; then
+  echo "This node seems to be already registered."
+  exit 1
+fi
+
 
 
 # Some initial setup
@@ -401,28 +374,28 @@ TMP_ATTRIBUTES=$(mktemp --suffix .json)
 # Make sure that we have the right target platform
 echo "{ \"target_platform\": \"$CROWBAR_OS\", \"crowbar_wall\": { \"registering\": true } }" > "$TMP_ATTRIBUTES"
 
-post_state $HOSTNAME "discovering"
+crowbarctl node transition $HOSTNAME "discovering"
 chef-client -S http://$ADMIN_IP:4000/ -N "$HOSTNAME" --json-attributes "$TMP_ATTRIBUTES"
-post_state $HOSTNAME "discovered"
+crowbarctl node transition $HOSTNAME "discovered"
 # TODO need to find way of knowing that chef run is over on server side
 sleep 30
 
-post_allocate $HOSTNAME
+crowbarctl node allocate $HOSTNAME
 
 # Cheat to make sure that the bootdisk finder attribute will claim the right disks
 echo '{ "crowbar_wall": { "registering": true } }' > "$TMP_ATTRIBUTES"
 
 rm -f /etc/chef/client.pem
-post_state $HOSTNAME "hardware-installing"
+crowbarctl node transition $HOSTNAME "hardware-installing"
 chef-client -S http://$ADMIN_IP:4000/ -N "$HOSTNAME" --json-attributes "$TMP_ATTRIBUTES"
-post_state $HOSTNAME "hardware-installed"
+crowbarctl node transition $HOSTNAME "hardware-installed"
 #TODO
 #wait_for_pxe_state ".*_install"
 sleep 30
 
 rm -f "$TMP_ATTRIBUTES"
 
-post_state $HOSTNAME "installing"
+crowbarctl node transition $HOSTNAME "installing"
 
 # Obviously, on reboot from sledgehammer, we lose the client key
 rm -f /etc/chef/client.pem
@@ -449,7 +422,7 @@ systemctl enable chef-client.service
 curl -s -o /usr/sbin/crowbar_join $HTTP_SERVER/$CROWBAR_OS/$CROWBAR_ARCH/crowbar_join.sh
 chmod +x /usr/sbin/crowbar_join
 
-post_state $HOSTNAME "installed"
+crowbarctl node transition $HOSTNAME "installed"
 #TODO
 # Wait for DHCP to update
 sleep 30

--- a/updates/control_lib.sh
+++ b/updates/control_lib.sh
@@ -75,22 +75,15 @@ try_to() {
 }
 
 __post_state() {
-  local curlargs=(--connect-timeout 60 -s -L -X POST \
-      --data-binary "{ \"name\": \"$1\", \"state\": \"$2\" }" \
-      -H "Accept: application/json" -H "Content-Type: application/json" \
-      --insecure --location)
-  [[ $CROWBAR_KEY ]] && curlargs+=(-u "$CROWBAR_KEY" --digest --anyauth)
-  parse_node_data < <(curl "${curlargs[@]}" \
-      "http://$ADMIN_IP/crowbar/crowbar/1.0/transition/default")
+  # $1 = hostname, $2 = target state
+  PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
+  crowbarctl node transition "$1" "$2" -s "http://$ADMIN_IP" -U machine-install -P $PASS
 }
 
 __get_state() {
-    # $1 = hostname
-    local curlargs=(--connect-timeout 60 -s -L -H "Accept: application/json" \
-        -H "Content-Type: application/json" --insecure --location)
-  [[ $CROWBAR_KEY ]] && curlargs+=(-u "$CROWBAR_KEY" --digest)
-  parse_node_data < <(curl "${curlargs[@]}" \
-      "http://$ADMIN_IP/crowbar/machines/1.0/show?name=$1")
+  # $1 = hostname
+  PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
+  parse_node_data < <(crowbarctl node show $1 -s "http://$ADMIN_IP" -U machine-install -P $PASS --json)
 }
 
 post_state() { try_to "$MAXTRIES" 15 __post_state "$@"; }

--- a/updates/control_lib.sh
+++ b/updates/control_lib.sh
@@ -77,13 +77,13 @@ try_to() {
 __post_state() {
   # $1 = hostname, $2 = target state
   PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
-  crowbarctl node transition "$1" "$2" -s "http://$ADMIN_IP" -U machine-install -P $PASS
+  crowbarctl node transition "$1" "$2" -s "http://$ADMIN_IP" -U machine-install -P $PASS --no-verify-ssl
 }
 
 __get_state() {
   # $1 = hostname
   PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
-  parse_node_data < <(crowbarctl node show $1 -s "http://$ADMIN_IP" -U machine-install -P $PASS --json)
+  parse_node_data < <(crowbarctl node show $1 -s "http://$ADMIN_IP" -U machine-install -P $PASS --no-verify-ssl --json)
 }
 
 post_state() { try_to "$MAXTRIES" 15 __post_state "$@"; }


### PR DESCRIPTION
Backport of https://github.com/crowbar/crowbar-core/pull/1499

This replacement will fix some issues in relation with curl,
https, redirections and BasicAuth passwords."

Why is this change necessary?

This is part of ongoing work to use crowbarctl instead of direct curl calls to API. crowbarctl should know everything and no special options that we're building for curl command are necessary..

Trello card

https://trello.com/c/2SwQTBg1/399-p3-replace-curl-commands-in-crowbar-with-crowbarctl

requires sleshammer update https://build.suse.de/request/show/157590