### PR TITLE
offline: Remove offline lib

### DIFF
--- a/crowbar_framework/lib/offline/role-.template
+++ b/crowbar_framework/lib/offline/role-.template
@@ -1,1 +1,0 @@
-{"name":"$NAME$","default_attributes":{"crowbar":{}},"_rev":"$GUID$","json_class":"Chef::Role","env_run_lists":{},"run_list":[],"description":"$DESCRIPTION$","chef_type":"role","override_attributes":{}}


### PR DESCRIPTION
This isn't used anywhere and it's outdated so let's drop it.

Note: Testbuild will fail as the folder is mentioned in the spec.
