### PR TITLE
[3.0] network: Only set bond attributes when they change (bsc#1054268)

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -221,11 +221,14 @@ node["crowbar"]["network"].keys.sort{|a,b|
     ifs[bond.name]["type"] = "bond"
     ifs[bond.name]["miimon"] = miimon
     ifs[bond.name]["xmit_hash_policy"] = xmit_hash_policy
-    # Also save miimon and xmit_hash_policy to the NIC object, since that is
-    # safe to change on the fly, and will be used to write the configuration
+    # Save miimon and xmit_hash_policy to the NIC object if they are different,
+    # since writing them causes the kernel to emit messages about setting them,
+    # and we want the information saved so it makes it into the configuration
     # files.
-    bond.miimon = miimon
-    bond.xmit_hash_policy = xmit_hash_policy
+    bond.miimon = miimon unless bond.miimon == miimon
+    unless bond.xmit_hash_policy == xmit_hash_policy
+      bond.xmit_hash_policy = xmit_hash_policy
+    end
     our_iface = bond
     node.set["crowbar"]["bond_list"] = {} if node["crowbar"]["bond_list"].nil?
     node.set["crowbar"]["bond_list"][bond.name] = ifs[bond.name]["slaves"]


### PR DESCRIPTION
One side effect of the change to support xmit_hash_policy means the
network recipe writes the miimon and xmit_hash_policy attributes to
sysfs every time chef runs, which causes the kernel to log that. Only
set the attributes if they are different from the current setting.

(cherry picked from commit 588585ceb306d997472ac1f867d47fd79bb2c582)

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
