### PR TITLE
crowbar: disable ssl validation when generate_certs is used

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -351,7 +351,9 @@ address = crowbar_node["crowbar"]["network"]["admin"]["address"]
 protocol = crowbar_node["crowbar"]["apache"]["ssl"] ? "https" : "http"
 server = "#{protocol}://#{address}"
 password = crowbar_node["crowbar"]["users"]["crowbar"]["password"]
-verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
+verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"] ||
+  !crowbar_node["crowbar"]["apache"]["generate_certs"]
+
 template "/etc/crowbarrc" do
   source "crowbarrc.erb"
   variables(

--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -27,7 +27,8 @@ append_line = node[:provisioner][:discovery][:append].dup # We'll modify it inli
 
 crowbar_node = node_search_with_cache("roles:crowbar").first
 crowbar_protocol = crowbar_node[:crowbar][:apache][:ssl] ? "https" : "http"
-crowbar_verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
+crowbar_verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"] ||
+  !crowbar_node["crowbar"]["apache"]["generate_certs"]
 
 tftproot = node[:provisioner][:root]
 

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -62,7 +62,8 @@ virtual_intfs = ["tap", "qbr", "qvo", "qvb", "brq", "ovs"]
 
 crowbar_node = node_search_with_cache("roles:crowbar").first
 crowbar_protocol = crowbar_node[:crowbar][:apache][:ssl] ? "https" : "http"
-crowbar_verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
+crowbar_verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"] ||
+  !crowbar_node["crowbar"]["apache"]["generate_certs"]
 
 discovery_dir = "#{tftproot}/discovery"
 pxecfg_subdir = "bios/pxelinux.cfg"


### PR DESCRIPTION
The documentation of the option says that generate_certs is
implying insecure, and the javascript ui enforces insecure
being set when generate_certs is selected. However, if the
change happens outside javascript (like for example due
to the database migration that was added, or from CLI), insecure
was left turned off with no way to enable it, causing
related calls to fail (like installing machines and the like)
