### PR TITLE
Disable Danger subject_length check

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,5 @@
 # Check basic commit message formatting
-commit_lint.check warn: :all, disable: [:subject_cap]
+commit_lint.check warn: :all, disable: [:subject_cap, :subject_length]
 
 # Ensure a clean commit history
 if git.commits.any? { |c| c.message =~ /^Merge branch/ }


### PR DESCRIPTION
We typically include both the module component and a bug reference in
the subject of commit messages, which eats up space. Disable this check
even though 50 characters is standard.