### PR TITLE
Dangerfile: Extend subject check to 70 chars

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -1,5 +1,10 @@
 # Check basic commit message formatting
-commit_lint.check warn: :all, disable: [:subject_cap]
+commit_lint.check warn: :all, disable: [:subject_cap, :subject_length]
+
+# Check for commit message being less than 70
+if git.commits.any? { |c| c.message.partition("\n")[0].length >= 70 }
+  warn('Please shorten commit subjects to less than 70 chars')
+end
 
 # Ensure a clean commit history
 if git.commits.any? { |c| c.message =~ /^Merge branch/ }


### PR DESCRIPTION
Rationale: we use them for rpm changelogs that are visible
to customers, so we want to have a little bit more detail in
there like a crowbar module prefix and an bugzilla id at the end.

The commonly accepted industry standard of 50 chars per commit subject
is therefore extended to 70 chars.

