### PR TITLE
service: fix failure on transition to readying

### DIFF
--- a/chef/data_bags/crowbar/template-salt.json
+++ b/chef/data_bags/crowbar/template-salt.json
@@ -23,10 +23,8 @@
       "config": {
         "environment": "salt-base-config",
         "mode": "full",
-        "transitions": true,
+        "transitions": false,
         "transition_list": [
-          "installed",
-          "readying"
         ]
       }
     }

--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -292,7 +292,7 @@ class ServiceObject
     [200, { versions: ["1.0"] }]
   end
 
-  def transition
+  def transition(inst, name, state)
     [200, {}]
   end
 


### PR DESCRIPTION
When the salt barclamp is used, a transition to readying is failing
with this error:

  salt transition to default failed.
  wrong number of arguments (3 for 0)
  /opt/dell/crowbar_framework/app/models/service_object.rb:295:in `transition'
  /opt/dell/crowbar_framework/app/models/crowbar_service.rb:202:in `block (2 levels) in transition'
  /opt/dell/crowbar_framework/app/models/crowbar_service.rb:186:in `each'
  /opt/dell/crowbar_framework/app/models/crowbar_service.rb:186:in `block in transition'
  /opt/dell/crowbar_framework/app/models/crowbar_service.rb:185:in `each'
  /opt/dell/crowbar_framework/app/models/crowbar_service.rb:185:in `transition'
  /opt/dell/crowbar_framework/app/controllers/barclamp_controller.rb:126:in `transition'

This is due to incorrect number of arguments being specified on the
base service_object

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
