### PR TITLE
upgrade: use proper product name for cloud 8

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -281,7 +281,7 @@ module Api
             }
           end
 
-          cloud_available = repo_version_available?(products, "suse-openstack-cloud", "8")
+          cloud_available = repo_version_available?(products, "suse-openstack-cloud-crowbar", "8")
           ret[:openstack] = {
             available: cloud_available,
             repos: [

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -282,7 +282,7 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to(
         receive(:repo_version_available?).with(
           Hash.from_xml(crowbar_repocheck_zypper)["stream"]["product_list"]["product"],
-          "suse-openstack-cloud",
+          "suse-openstack-cloud-crowbar",
           "8"
         ).and_return(true)
       )


### PR DESCRIPTION
As the iso name has changed from cloud7[0] to cloud8[1] the product
name that zypper return has also changed, so we should make sure
to check the proper product name

[0] SUSE-OPENSTACK-CLOUD-7-x86_64-Media1.iso
[1] SUSE-OPENSTACK-CLOUD-CROWBAR-8-x86_64-Media1.iso

Should fix error `mkcloud error code 11: Some repository is missing on admin server. Cannot upgrade.` on the `cloud-mkcloud8-job-upgrade-disruptive-x86_64` job
