### PR TITLE
Allow sanity controller during upgrade

### DIFF
--- a/crowbar_framework/app/controllers/sanities_controller.rb
+++ b/crowbar_framework/app/controllers/sanities_controller.rb
@@ -17,6 +17,7 @@
 class SanitiesController < ApplicationController
   skip_before_filter :sanity_checks
   skip_before_filter :enforce_installer
+  skip_before_filter :upgrade
   before_filter :hide_navigation
 
   def show


### PR DESCRIPTION
As during the crowbar upgrade database step, a sanity check is
called, we need to skip the upgrade filter on the sanity
controller so it can be called even if we are in the middle of the
upgrade, otherwise we will be stuck in the database step

The sanity check was introduced in crowbar-init here: https://github.com/crowbar/crowbar-init/commit/29de8a8e2eeaf135ec028df05e6c285d3965be54
