### PR TITLE
ohai: Correct aacraid drivers disk removable flag (bsc#1085170)

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/linux/block_device_extended.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/linux/block_device_extended.rb
@@ -1,6 +1,6 @@
 provides "block_device"
 
-if File.exists?("/sys/block")
+if File.exist?("/sys/block")
   require "pathname"
 
   block = Mash.new
@@ -9,37 +9,35 @@ if File.exists?("/sys/block")
     block[dir] = Mash.new
 
     %w{size removable}.each do |check|
-      if File.exists?("/sys/block/#{dir}/#{check}")
+      if File.exist?("/sys/block/#{dir}/#{check}")
         File.open("/sys/block/#{dir}/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
       end
     end
 
     %w{model rev state timeout vendor}.each do |check|
-      if File.exists?("/sys/block/#{dir}/device/#{check}")
+      if File.exist?("/sys/block/#{dir}/device/#{check}")
         File.open("/sys/block/#{dir}/device/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
       end
     end
 
     %w{rotational}.each do |check|
-      if File.exists?("/sys/block/#{dir}/queue/#{check}")
+      if File.exist?("/sys/block/#{dir}/queue/#{check}")
         File.open("/sys/block/#{dir}/queue/#{check}") { |f| block[dir][check] = f.read_nonblock(1024).strip }
       end
     end
 
     # correct that the aacraid driver always sets the removable flag
-    if block[dir]["removable"] == "1"
-      parts = File.realpath(dir, "/sys/block/").split("/")
-      # example:
-      # /sys/devices/pci0000:00/0000:00:02.0/0000:03:00.0/host0/target0:1:4/0:1:4:0/block/sdb
-      parts = parts[0..4] + ["driver"]
-      path = parts.join("/")
-      # example:
-      # /sys/devices/pci0000:00/0000:00:02.0/driver
-      # -> ../../../bus/pci/drivers/aacraid
-      if File.exists?(path) && File.readlink(path).split("/")[-1] == "aacraid"
-        block[dir]["removable"] = "0"
-      end
-    end
+    next unless block[dir]["removable"] == "1"
+    parts = File.realpath(dir, "/sys/block/").split("/")
+    # example:
+    # /sys/devices/pci0000:00/0000:00:02.0/0000:03:00.0/host0/target0:1:4/0:1:4:0/block/sdb
+    parts = parts[0..4] + ["driver"]
+    path = parts.join("/")
+    # example:
+    # /sys/devices/pci0000:00/0000:00:02.0/driver
+    # -> ../../../bus/pci/drivers/aacraid
+    next unless File.exist?(path) && File.readlink(path).split("/")[-1] == "aacraid"
+    block[dir]["removable"] = "0"
   end
 
   disk_path = Pathname.new "/dev/disk"


### PR DESCRIPTION
This is determined from /sys/block/xxx/removable and is always set for
aacraid. It is useful to distinguish removable and hotswappable.
Removable should mean humans will remove this during normal operation
like an USB stick, where as hotswappable disks are only removed for servicing.

https://github.com/torvalds/linux/blob/7b1cd95d65eb3b1e13f8a90eb757e0ea232c7899/drivers/scsi/aacraid/aachba.c#L3117
gives its reason as: "Do not cache partition table for arrays". I
suspect that there is a better way for a kernel driver to behave, since
this is not the first controller with hotpluggable disks.

(cherry picked from commit a7312a8274312a0b1b0621e2578cf2290748b61c)
Backport of https://github.com/crowbar/crowbar-core/pull/1515
