### PR TITLE
crowbar: Use proper repo for cloud8 Update

### DIFF
--- a/crowbar_framework/config/repos-cloud.yml
+++ b/crowbar_framework/config/repos-cloud.yml
@@ -45,7 +45,7 @@ suse-12.3:
       required: "optional"
       features: ["openstack"]
       repomd:
-        tag: "obsrepository://build.suse.de/SUSE:Updates:OpenStack-Cloud:8:aarch64/update"
+        tag: "obsrepository://build.suse.de/SUSE:Updates:OpenStack-Cloud-Crowbar:8:aarch64/update"
         fingerprint: ""
       url:
       smt_path: "SUSE/Updates/OpenStack-Cloud/8/aarch64/update"
@@ -142,7 +142,7 @@ suse-12.3:
       required: "optional"
       features: ["openstack"]
       repomd:
-        tag: "obsrepository://build.suse.de/SUSE:Updates:OpenStack-Cloud:8:x86_64/update"
+        tag: "obsrepository://build.suse.de/SUSE:Updates:OpenStack-Cloud-Crowbar:8:x86_64/update"
         fingerprint: ""
       url:
       smt_path: "SUSE/Updates/OpenStack-Cloud/8/x86_64/update"
@@ -243,7 +243,7 @@ suse-12.3:
       required: "optional"
       features: ["openstack"]
       repomd:
-        tag: "obsrepository://build.suse.de/SUSE:Updates:OpenStack-Cloud:8:s390x/update"
+        tag: "obsrepository://build.suse.de/SUSE:Updates:OpenStack-Cloud-Crowbar:8:s390x/update"
         fingerprint: ""
       url:
       smt_path: "SUSE/Updates/OpenStack-Cloud/8/s390x/update"


### PR DESCRIPTION
The "crowbar" part was missing for the Update repos for cloud8.
 This is checked to match during the 7->8 upgrade and its
currently failing because the tag in the repodata.xml does not match
what we have on the repos-cloud.yml. Probably it was forgotten when
the rename of SOC8->SOCC8 was done.

Rename was done at https://github.com/crowbar/crowbar-core/commit/d7a7a921255225a103ff53ea46a8ec96b15af2d2