### PR TITLE
upgrade: fix horizon deprecated config

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
@@ -67,6 +67,15 @@ initiate_node_upgrade()
 
     trap cleanup INT EXIT
 
+    # we need to change the horizon django NullHandler in the custom conf files as its been
+    # deprecated so horizon related packages wont be able to install correctly, as they run some
+    # manage.py commands, which loads the conf files and errors out
+    # only needed from soc7 -> soc8
+    horizon_custom_config="/srv/www/openstack-dashboard/openstack_dashboard/local/local_settings.d/_100_local_settings.py"
+    if [[ -f $horizon_custom_config ]] ; then
+      sed -i s/django.utils.log.NullHandler/logging.NullHandler/g $horizon_custom_config
+    fi
+
     # Upgrade the distribution non-interactively
     log "Executing zypper ref"
     zypper --no-color --releasever <%= @target_platform_version %> ref -f


### PR DESCRIPTION
As during the upgrade we first update the packages, and then update
the configuration (via chef) when upgrading the node packages, any
horizon related package will fail to install due to those packages
%postun firing a manage.py command which loads our custom
_100_local_settings.py which contains a deprecated config item.
As by the time those packages are installed, django has already been
updated, it will fail to finish the install.

This patch will replace the outdated configuration in the config
prior to upgrading the packages so the package install can finish
correctly. The configuration will be upgraded by chef afterwards
so it will end up being correct no matter what.