### PR TITLE
Add common cinder group for all nodes (bsc#1087896)

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -72,6 +72,15 @@
         <home>/</home>
         <shell>/sbin/nologin</shell>
       </user>
+      <user>
+        <username>cinder</username>
+        <user_password>!</user_password>
+        <encrypted config:type="boolean">true</encrypted>
+        <uid>203</uid>
+        <gid>203</gid>
+        <home>/var/lib/cinder</home>
+        <shell>/sbin/nologin</shell>
+      </user>
   </users>
   <groups config:type="list">
     <!-- for making HA on shared NFS backend storage work -->
@@ -92,6 +101,12 @@
       <groupname>kvm</groupname>
       <group_password>x</group_password>
       <userlist>qemu</userlist>
+    </group>
+    <group>
+      <gid>203</gid>
+      <groupname>cinder</groupname>
+      <group_password>x</group_password>
+      <userlist>cinder</userlist>
     </group>
   </groups>
   <networking>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -187,8 +187,10 @@ fi
 add_group glance 200
 add_group qemu 201
 add_group kvm 202
+add_group cinder 203
 add_user glance 200 glance
 add_user qemu 201 kvm
+add_user cinder 203 cinder
 
 # Check that we're really on the admin network
 # --------------------------------------------


### PR DESCRIPTION
So that new nodes don't get different uids and clash when NFS is used.

Also related to bsc#968251.

This is a forward port of https://github.com/crowbar/crowbar-core/pull/1536

https://bugzilla.suse.com/show_bug.cgi?id=1087896
https://bugzilla.suse.com/show_bug.cgi?id=968251