### PR TITLE
rabbitmq: active the haproxy balancing option

### DIFF
--- a/crowbar_framework/config/experimental.yml
+++ b/crowbar_framework/config/experimental.yml
@@ -23,6 +23,8 @@ default: &default
      - updater
   skip_unchanged_nodes:
     enabled: false
+  haproxy_balance:
+    enabled: true
 
 development:
   <<: *default


### PR DESCRIPTION
Added experimental option to active the haproxy balance for rabbitmq.

Related with crowbar/crowbar-openstack#1571. The precense of this option in the experimental config file is not required but show how to activate this feature.