### PR TITLE
[4.0] Rabbitmq block client port on startup experimental option backport

### DIFF
--- a/crowbar_framework/config/experimental.yml
+++ b/crowbar_framework/config/experimental.yml
@@ -23,6 +23,8 @@ default: &default
      - updater
   skip_unchanged_nodes:
     enabled: false
+  haproxy_balance:
+    enabled: true
 
 development:
   <<: *default


### PR DESCRIPTION
Added experimental option to active the haproxy balance for rabbitmq.

Related with crowbar/crowbar-openstack#1573. The precense of this option in the experimental config file is not required but show how to activate this feature.

(cherry picked from commit 5f8edbe07329241d6a881091245c17708f16a893)
Backport #1550