### PR TITLE
upgrade: Change rabbitmq settings during the upgrade

### DIFF
--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -465,6 +465,7 @@ describe Api::Upgrade do
     it "successfully upgrades controller nodes" do
       allow(Api::Upgrade).to receive(:remaining_nodes).and_return(1)
       allow(Api::Upgrade).to receive(:join_ceph_nodes).and_return(true)
+      allow(Api::Upgrade).to receive(:update_rabbitmq_setup).and_return(true)
 
       allow(Api::Upgrade).to receive(:upgrade_mode).and_return(:normal)
 
@@ -547,6 +548,7 @@ describe Api::Upgrade do
       drbd_slave = Node.find_by_name("drbd.crowbar.com")
       allow(Api::Upgrade).to receive(:remaining_nodes).and_return(1)
       allow(Api::Upgrade).to receive(:join_ceph_nodes).and_return(true)
+      allow(Api::Upgrade).to receive(:update_rabbitmq_setup).and_return(true)
       allow(Node).to(
         receive(:find).
         with(
@@ -620,6 +622,7 @@ describe Api::Upgrade do
 
       allow(Node).to(receive(:find).with("state:crowbar_upgrade").and_return([testing]))
       allow(Api::Upgrade).to receive(:join_ceph_nodes).and_return(true)
+      allow(Api::Upgrade).to receive(:update_rabbitmq_setup).and_return(true)
       allow(Api::Upgrade).to receive(:upgrade_controller_clusters).and_return(true)
 
       # upgrade_non_compute_nodes:
@@ -719,6 +722,7 @@ describe Api::Upgrade do
       ).with(:nodes).and_return(true)
       allow(Api::Upgrade).to receive(:remaining_nodes).and_return(1)
       allow(Api::Upgrade).to receive(:join_ceph_nodes).and_return(true)
+      allow(Api::Upgrade).to receive(:update_rabbitmq_setup).and_return(true)
       allow(Node).to(
         receive(:find).
         with(


### PR DESCRIPTION
Default rabbitmq HA setup is using native clustering. We need
to allow switch to this default from DRBD/shared storage setup
that is used in SOC7.

Requires https://github.com/crowbar/crowbar-openstack/pull/1637
Alternative to https://github.com/crowbar/crowbar-core/pull/1557