### PR TITLE
don't retry with installed state during failing crowbar_join (bsc#106…

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -304,29 +304,6 @@ do_chef_client() {
         fi
     fi
 
-    # we still didn't succeed with chef-client, so let's try running it again
-    # in "installed" state, to pretend we just come straight from a fresh
-    # install
-    echo_debug "Failed to run chef-client, trying with state \"installed\""
-    post_state $HOSTNAME "installed"
-
-    echo_debug "Syncing Time"
-    sync_time
-    echo_debug "Removing Chef Cache"
-    rm -rf /var/cache/chef/*
-    echo_debug "Checking Keys"
-    rm -f /etc/chef/client.pem
-
-    echo_verbose "Running Chef Client (try 3, pass 1) - password cleanup"
-    if log_to chef chef-client $CHEF_CLIENT_OPTIONS; then
-	# it worked, cool, let's try again with "readying" state
-        post_state $HOSTNAME "readying"
-        echo_verbose "Running Chef Client (try 3, pass 2) - password cleanup"
-        if log_to chef chef-client $CHEF_CLIENT_OPTIONS; then
-            return
-        fi
-    fi
-
     echo_error "chef-client run failed too many times, giving up."
     printf "Our IP address is: %s\n" "$(ip addr show)" >&2
     final_state="problem"


### PR DESCRIPTION
…3533)

If chef-client fails twice during crowbar_join, the logic is to try
running it a third time in "installed" state with client.pem removed,
to pretend we just come straight from a fresh install.  This is very
old logic originally written by Victor, and we don't know of any
scenario where this actually helps.  In contrast, we do know that it
is quite easy for chef-client to fail on nodes which successfully
installed a long time ago and are just running crowbar_join again on
boot up, e.g. after zypper up + reboot.  And in this case this logic
removes a perfectly good client.pem forever:

    https://bugzilla.suse.com/show_bug.cgi?id=1063533

Worse, pretending that a previously installed node is being freshly
installed could potentially lead to serious data loss, so it's safer
to just bail at this point and let the operator fix it.

(cherry picked from commit 5d7974dc2909312070153831882a8639a148eb38)

Backport of https://github.com/crowbar/crowbar-core/pull/1413