### PR TITLE
[4.0] crowbar: add validator for multiple nodes or cluster

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -855,6 +855,19 @@ class ServiceObject
   end
 
   #
+  # Ensure that the proposal contains at least 2 nodes for role or a cluster
+  #
+  def validate_multiple_for_role_or_cluster(proposal, role)
+    elements = proposal["deployment"][@bc_name]["elements"]
+
+    if !elements.key?(role) ||
+        (elements[role].length < 2 &&
+         elements[role].none? { |e| is_cluster? e })
+      validation_error("Need at least 2 #{role} nodes or a cluster.")
+    end
+  end
+
+  #
   # Ensure that the proposal contains an odd number of nodes for role
   #
   def validate_count_as_odd_for_role(proposal, role)


### PR DESCRIPTION
Backport from: https://github.com/crowbar/crowbar-core/pull/1546

There's some situation where the proposal validators need to check that
a number of nodes are present. This validator is already present. But if
a cluster is assigned to the proposal, then the cluster it is counted as
a single instance.

A new validator 'validate_multiple_for_role_or_cluster' has beed
added. It does check that at least 2 nodes are present or a cluster is
defined.

(cherry picked from commit b4b65638bde309d9eaa1e4eb57af782f61807c57)