### PR TITLE
upgrade: Change rabbitmq settings during the upgrade

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -327,6 +327,21 @@ class CrowbarService < ServiceObject
       node.save
     end
 
+    # change rabbitmq/drbd setting to native queues setup (new default)
+    prop = Proposal.find_by(barclamp: "rabbitmq", name: "default")
+    role = prop.role
+    if role.default_attributes["rabbitmq"]["ha"]["storage"]["mode"] == "drbd"
+      role.default_attributes["rabbitmq"]["cluster"] = true
+      role.default_attributes["rabbitmq"]["erlang_cookie"] = random_password
+      role.save
+
+      prop.raw_data["attributes"]["rabbitmq"]["cluster"] = true
+      prop.raw_data["attributes"]["erlang_cookie"] =
+        role.default_attributes["rabbitmq"]["erlang_cookie"]
+
+      prop.save
+    end
+
     # unset `db_synced` flag for OpenStack components
     ::Openstack::Upgrade.unset_db_synced
 


### PR DESCRIPTION
Default rabbitmq HA setup in SOC8 is using native clustering.
Let's switch to this default when upgrading from the setup that is using
DRBD storage.

Requires  https://github.com/crowbar/crowbar-openstack/pull/1637
Alternative to https://github.com/crowbar/crowbar-core/pull/1552