### PR TITLE
upgrade: fix check for openvswitch package

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
@@ -80,12 +80,6 @@ initiate_node_upgrade()
     log "Executing zypper ref"
     zypper --no-color --releasever <%= @target_platform_version %> ref -f
 
-    # check to see if openvswitch is gonna be updated
-    is_openvswitch_updated=`zypper --no-color --non-interactive list-updates|grep -q openvswitch`
-    # check if openvswitch is enabled on boot
-    [ -f /etc/systemd/system/multi-user.target.wants/openvswitch.service ]
-    was_openvswitch_enabled=$?
-
     log "Executing zypper dist-upgrade"
     zypper --no-color --non-interactive dist-upgrade -l --recommends --replacefiles
     ret=$?
@@ -145,12 +139,14 @@ initiate_node_upgrade()
     rm -f /etc/nova/nova.conf.d/200-crowbar-upgrade.conf
     rm -f /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf
 
-    if [ $is_openvswitch_updated == 0 ] && [ $was_openvswitch_enabled == 0 ]; then
+    # START WORKAROUND bsc#1089476
+    if rpm --quiet -q openvswitch; then
       # mark openvswitch as enabled so it comes correctly after a node reboot
       # this is due to the package upgrade deleting the systemd unit and adding a new unit for the
       # service, which causes this new service unit to not be enabled.
       systemctl enable openvswitch
     fi
+    # END WORKAROUND bsc#1089476
 
     # Signalize that the upgrade correctly ended
     echo "<%= @target_platform_version %>" >> $UPGRADEDIR/crowbar-upgrade-os-ok


### PR DESCRIPTION
Instead of checking if the package is gonna be upgraded during
the upgrade, just check if the package is installed. This avoids
issues if the package has been already upgraded during a different
step or even before the upgrade.