### PR TITLE
provisioner: Ensure that crowbarctl is installed on nodes

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -352,6 +352,9 @@ protocol = crowbar_node["crowbar"]["apache"]["ssl"] ? "https" : "http"
 server = "#{protocol}://#{address}"
 password = crowbar_node["crowbar"]["users"]["crowbar"]["password"]
 verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
+
+package "ruby2.1-rubygem-crowbar-client"
+
 template "/etc/crowbarrc" do
   source "crowbarrc.erb"
   variables(


### PR DESCRIPTION
Now that crowbar_join requires crowbarctl, we need to make sure that previously installed nodes also have it.