### PR TITLE
upgrade: Do not add Newton specific config changes

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -104,14 +104,6 @@ template "/usr/sbin/crowbar-delete-cinder-services-before-upgrade.sh" do
   only_if { cinder_controller && (!use_ha || is_cluster_founder) }
 end
 
-# Find all ovs bridges that we manage to be able to reset their fail-mode
-# in preparation for the OS upgrade
-bridges_to_reset = []
-Barclamp::Inventory.list_networks(node).each do |network|
-  next unless network.add_ovs_bridge
-  bridges_to_reset << network.bridge_name
-end
-
 nova = search(:node, "run_list_map:nova-controller").first
 
 template "/usr/sbin/crowbar-evacuate-host.sh" do
@@ -161,7 +153,6 @@ template "/usr/sbin/crowbar-pre-upgrade.sh" do
     compute_node: compute_node,
     remote_node: remote_node,
     swift_storage: swift_storage,
-    bridges_to_reset: bridges_to_reset,
     cinder_volume: cinder_volume,
     neutron_agent: neutron_agent,
     l3_agent: l3_agent,

--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -75,32 +75,15 @@ log "No HA setup found..."
 
 <% end %>
 
-<% @bridges_to_reset.each do |bridge| %>
-log "Resetting fail-mode on ovs-bridge <%= bridge %>"
-ovs-vsctl set-fail-mode <%= bridge %> standalone
-<% end %>
-
-log "Reloading wicked configuration for all interfaces"
-wicked ifreload all
-
 <% if @compute_node %>
 
 log "Upgrading packages needed for nova-compute node"
 
 zypper --non-interactive up openstack-nova-compute
-# This is ugly, but fixing neutron spec to upgrade to correct version of pecan is even uglier:
-zypper --non-interactive up python-pecan
-zypper --non-interactive install crudini
 
-log "Upgrading configuration for Newton based packages"
-
-crudini --set /etc/nova/nova.conf.d/200-crowbar-upgrade.conf DEFAULT use_neutron true
+log "Restarting services for Pike"
 
 zypper --non-interactive up <%= @neutron_agent %>
-<% if @neutron_agent == "openstack-neutron-openvswitch-agent" %>
-crudini --set /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf ovs ovsdb_interface vsctl
-crudini --set /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf ovs of_interface ovs-ofctl
-<% end %>
 <% unless @remote_node %>
 systemctl restart <%= @neutron_agent %>
 <% end %>
@@ -134,10 +117,7 @@ systemctl restart openstack-cinder-volume.service
 <% end %>
 
 <% if @swift_storage %>
-log "Upgrading swift-storage configuration"
-crudini --set /etc/swift/object-server.conf DEFAULT bind_port 6200
-crudini --set /etc/swift/container-server.conf DEFAULT bind_port 6201
-crudini --set /etc/swift/account-server.conf DEFAULT bind_port 6202
+log "Restarting swift-storage services"
 systemctl restart openstack-swift-account
 systemctl restart openstack-swift-object
 systemctl restart openstack-swift-container

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1458,7 +1458,7 @@ module Api
       # Live migrate all instances of the specified
       # node to other available hosts.
       def live_evacuate_compute_node(controller, compute)
-        save_node_action("live-evacuting nova instances")
+        save_node_action("live-migrating nova instances from current node")
         controller.wait_for_script_to_finish(
           "/usr/sbin/crowbar-evacuate-host.sh",
           timeouts[:evacuate_host],


### PR DESCRIPTION
This was executed on a node running Liberty, to get some Newton
specific config bits. As we're on Newton now, we do not need them.


There might be other parts in this script that need to be removed or changed.