### PR TITLE
Adjust installation profile for netcat (bsc#1091250)

### DIFF
--- a/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
@@ -143,7 +143,7 @@ EOF
 <% if @architecture == "x86_64" -%>
       <package>biosdevname</package>
 <% end -%>
-      <package>netcat</package>
+      <package>netcat-openbsd</package>
       <package>ruby2.1-rubygem-chef</package>
 <% if @is_ses -%>
       <package>ses-release</package>

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -361,7 +361,7 @@ sync
 <% elsif @platform == "suse" && @cpu_model == "amd" -%>
       <package>ucode-amd</package>
 <%end -%>
-      <package>netcat</package>
+      <package>netcat-openbsd</package>
       <package>ruby2.1-rubygem-chef</package>
       <package>ruby2.1-rubygem-crowbar-client</package>
 <% if @is_ses -%>

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -240,7 +240,7 @@ PATTERNS_INSTALL="$PATTERNS_INSTALL Minimal base"
 <% elsif @platform == "opensuse" -%>
 PATTERNS_INSTALL="$PATTERNS_INSTALL base enhanced_base sw_management"
 <% end -%>
-PACKAGES_INSTALL="$PACKAGES_INSTALL netcat ruby2.1-rubygem-chef ruby2.1-rubygem-crowbar-client"
+PACKAGES_INSTALL="$PACKAGES_INSTALL netcat-openbsd ruby2.1-rubygem-chef ruby2.1-rubygem-crowbar-client"
 
 # We also need ntp for this script
 PACKAGES_INSTALL="$PACKAGES_INSTALL ntp"


### PR DESCRIPTION
netcat is provided by netcat-openbsd and it seems autoyast
started to reject invalid package names recently, so this broke.
