### PR TITLE
[4.0] upgrade: Make sure crowbarctl is installed with correct setup

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
@@ -26,6 +26,24 @@ if [[ -f $UPGRADEDIR/crowbar-chef-upgraded-ok ]] ; then
     exit 0
 fi
 
+# Make sure crowbarctl is installed on the nodes, it's required by crowbar-join
+zypper --non-interactive install ruby2.1-rubygem-crowbar-client
+
+# Prepare temporary crowbarrc file for crowbarctl
+if [[ -f /etc/crowbar.install.key ]]; then
+    export CROWBAR_PASS="$(sed -e 's/^machine-install://' /etc/crowbar.install.key)"
+fi
+
+cat <<EOF > /etc/crowbarrc
+[default]
+server = <%= @crowbar_protocol %>://<%= @admin_node_ip %>
+username = machine-install
+password = $CROWBAR_PASS
+<% unless @crowbar_verify_ssl %>
+verify_ssl = 0
+<% end %>
+EOF
+
 # Download the latest crowbar-join from the server
 curl -s -o /usr/sbin/crowbar_join_tmp <%= @crowbar_join %>
 


### PR DESCRIPTION
crowbarctl is required by crowbar-join in SOC7, but proper configuration
was not created when upgrading from SOC6.
So let's do an explicit installation and configuration during the
upgrade.
