### PR TITLE
control_lib: fix host allocation check

### DIFF
--- a/updates/control_lib.sh
+++ b/updates/control_lib.sh
@@ -46,6 +46,7 @@ parse_node_data() {
         echo "BMC_NETMASK=${BMC_NETMASK}"
         echo "CROWBAR_STATE=${CROWBAR_STATE}"
         echo "HOSTNAME=${HOSTNAME}"
+        echo "ADMIN_ADDRESS=${ADMIN_ADDRESS}"
         echo "ALLOCATED=${ALLOCATED}"
     else
         res=$?
@@ -78,6 +79,9 @@ __post_state() {
   # $1 = hostname, $2 = target state
   PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
   crowbarctl node transition "$1" "$2" -s "http://$ADMIN_IP" -U machine-install -P $PASS --no-verify-ssl
+  local RET=$?
+  __get_state "$1"
+  return $RET
 }
 
 __get_state() {


### PR DESCRIPTION
Before the "provisioner: replace curl calls to crowbar API with
crowbarctl" commit, __post_state did an implicit (at least partial)
get_state, updating ADMIN_ADDRESS. Without this, ADMIN_ADDRESS is
unset after allocation, causing the "PXE file contains .*install"
check to fail and the code having to time out after 300 seconds for
the host to be rebooted into installation.
Just add that __get_state in __post_state to fix this, also for other
unidentified cases where this implicit behaviour is expected.