### PR TITLE
upgrade: When upgrading to SOC8, delete deprecated nova-cert service

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -89,7 +89,8 @@ template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   action :create
   variables(
     use_ha: use_ha || remote_node,
-    cluster_founder: is_cluster_founder
+    cluster_founder: is_cluster_founder,
+    nova_controller: roles.include?("nova-controller")
   )
 end
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -19,6 +19,19 @@ log "Executing $BASH_SOURCE"
 
 set -x
 
+<% if @nova_controller && (!@use_ha || @cluster_founder) %>
+# Remove nova-cert service which has been deprecated in Newton and is not present in Pike
+
+set +x
+source /root/.openrc
+set -x
+
+for id in `openstack compute service list --service nova-cert -f value -c ID`; do
+  log "Removing nova-cert service $id"
+  openstack compute service delete $id
+done
+<% end %>
+
 <% if @use_ha %>
 
 <% if @cluster_founder %>


### PR DESCRIPTION
Removal from crowbar: https://github.com/crowbar/crowbar-openstack/pull/1091
Newton release notes for nova: https://docs.openstack.org/releasenotes/nova/newton.html
