### PR TITLE
upgrade: Do not upgrade compute-related packages to Pike

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -77,29 +77,18 @@ log "No HA setup found..."
 
 <% if @compute_node %>
 
-log "Upgrading packages needed for nova-compute node"
-
-zypper --non-interactive up openstack-nova-compute
-
 log "Restarting services for Pike"
 
-zypper --non-interactive up <%= @neutron_agent %>
 <% unless @remote_node %>
 systemctl restart <%= @neutron_agent %>
 <% end %>
 
-<% if @l3_agent %>
-zypper --non-interactive up <%= @l3_agent %>
-<% unless @remote_node %>
+<% if @l3_agent && !@remote_node %>
 systemctl restart <%= @l3_agent %>
 <% end %>
-<% end %>
 
-<% if @metadata_agent %>
-zypper --non-interactive up <%= @metadata_agent %>
-<% unless @remote_node %>
+<% if @metadata_agent && !@remote_node%>
 systemctl restart <%= @metadata_agent %>
-<% end %>
 <% end %>
 
 <% if @remote_node %>
@@ -112,7 +101,6 @@ systemctl restart openstack-nova-compute.service
 
 <% if @cinder_volume %>
 log "Upgrading and setting cinder-volume configuration"
-zypper --non-interactive up openstack-cinder-volume
 systemctl restart openstack-cinder-volume.service
 <% end %>
 


### PR DESCRIPTION
It does not seem to be necessary to upgrade openstack packages
to from Newton to Pike version for them to work with Pike-based control plane.

Restart of current services (after control plane upgrade) is enough.

Note: these specific packages will be upgraded at some point,
but together with all packages on the node.