### PR TITLE
Postpone the upgrade of compute nodes

### DIFF
--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -34,7 +34,8 @@ class ApplicationController < ActionController::Base
     Rails.env.test?
   }
   before_filter :upgrade, if: proc {
-    File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-running")
+    File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-running") &&
+      !File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-compute-nodes-postponed")
   }
   before_filter :sanity_checks, unless: proc {
     Rails.env.test? || \

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -718,6 +718,14 @@ module Api
       def nodes(component = "all")
         status = ::Crowbar::UpgradeStatus.new
 
+        if component == "postpone"
+          status.postpone
+          return
+        elsif component == "resume"
+          status.resume
+          return
+        end
+
         substep = status.current_substep
         substep_status = status.current_substep_status
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -746,6 +746,10 @@ module Api
         when "controllers"
           # Upgrade controller clusters only
           do_controllers_substep(substep)
+          # Finalize only upgraded nodes (compute nodes might be postponed)
+          ::Node.find("state:crowbar_upgrade").each do |node|
+            finalize_node_upgrade node
+          end
         else
           # Upgrade given compute node
           upgrade_one_compute_node component

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -63,13 +63,16 @@ module Crowbar
         openstack_backup: nil,
         # :normal vs. :non_disruptive
         suggested_upgrade_mode: nil,
-        selected_upgrade_mode: nil
+        selected_upgrade_mode: nil,
+        # if upgrade of compute nodes has been postponed
+        compute_nodes_postponed: false
       }
       # in 'steps', we save the information about each step that was executed
       @progress[:steps] = upgrade_steps_7_8.map do |step|
         [step, { status: :pending }]
       end.to_h
       FileUtils.rm_f running_file
+      FileUtils.rm_f postponed_file
       save
     end
 
@@ -158,6 +161,10 @@ module Crowbar
       end
     end
 
+    def compute_nodes_postponed?
+      progress[:compute_nodes_postponed]
+    end
+
     # Check if given step is running.
     # Without argument, check if any step is running
     def running?(step_name = nil)
@@ -196,6 +203,25 @@ module Crowbar
         :repocheck_crowbar,
         :admin
       ].include?(current_step) && !running?
+    end
+
+    # Resume the upgrade that has been postponed
+    def resume
+      ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
+        load_while_locked
+        progress[:compute_nodes_postponed] = false
+        FileUtils.rm_f postponed_file
+        save
+      end
+    end
+
+    def postpone
+      ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
+        load_while_locked
+        progress[:compute_nodes_postponed] = true
+        FileUtils.touch postponed_file
+        save
+      end
     end
 
     def save_crowbar_backup(backup_location)
@@ -354,6 +380,10 @@ module Crowbar
 
     def lock_path
       "/opt/dell/crowbar_framework/tmp/upgrade_status_lock"
+    end
+
+    def postponed_file
+      "/var/lib/crowbar/upgrade/7-to-8-upgrade-compute-nodes-postponed"
     end
 
     def running_file

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -10,6 +10,7 @@
   "openstack_backup": null,
   "suggested_upgrade_mode": null,
   "selected_upgrade_mode": null,
+  "compute_nodes_postponed": false,
   "steps":{
     "prechecks":{
       "status":"pending"

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -390,6 +390,18 @@ describe Crowbar::UpgradeStatus do
       )
     end
 
+    it "postpones and resumes compute node upgrade" do
+      expect(subject.progress[:compute_nodes_postponed]).to be false
+
+      allow(FileUtils).to receive(:touch).and_return(true)
+      expect(subject.postpone).to be true
+      expect(subject.progress[:compute_nodes_postponed]).to be true
+
+      allow(FileUtils).to receive(:rm_f).and_return(true)
+      expect(subject.resume).to be true
+      expect(subject.progress[:compute_nodes_postponed]).to be false
+    end
+
     it "fails while saving the status initially" do
       allow_any_instance_of(Pathname).to(
         receive(:open).and_raise("Failed to write File")


### PR DESCRIPTION
Once all other nodes have been upgraded, we want users to allow postponing the upgrade of compute nodes. 

**TODO**

- [x] unit tests in the library
- [x] API change (controller action for postpone/resume)
- [x] crowbar to read indicator file so it allows barclamps editing (3rd commit)
- [x] adapt crowbarctl See https://github.com/crowbar/crowbar-client/pull/174