### PR TITLE
upgrade: Raise the default timeouts for most time consuming actions

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -24,10 +24,10 @@ module Crowbar
       {
         prepare_repositories: @timeouts_config[:prepare_repositories] || 120,
         pre_upgrade: @timeouts_config[:pre_upgrade] || 300,
-        upgrade_os: @timeouts_config[:upgrade_os] || 900,
+        upgrade_os: @timeouts_config[:upgrade_os] || 1500,
         post_upgrade: @timeouts_config[:post_upgrade] || 600,
         evacuate_host: @timeouts_config[:evacuate_host] || 300,
-        chef_upgraded: @timeouts_config[:chef_upgraded] || 900,
+        chef_upgraded: @timeouts_config[:chef_upgraded] || 1200,
         router_migration: @timeouts_config[:router_migration] || 600,
         lbaas_evacuation: @timeouts_config[:lbaas_evacuation] || 600,
         delete_pacemaker_resources: @timeouts_config[:delete_pacemaker_resources] || 300,


### PR DESCRIPTION
Latest jobs have been failing because of timeout during OS upgrade.

See
https://ci.suse.de/view/Cloud/view/Cloud8/job/cloud-mkcloud8-job-upgrade-nondisruptive-ha-mariadb-x86_64/

`E, [2018-05-15T07:06:38.294506 #3501:0x00000000bc2640] ERROR -- Error while executing OS upgrade script. Possible error during execution of /usr/sbin/crowbar-upgrade-os.sh at d52-54-77-77-01-01.vn2.cloud.suse.de. Action did not finish after 900 seconds. Check /var/log/crowbar/node-upgrade.log for details.`
