### PR TITLE
[4.0] upgrade: Adapt ceph-related pre-checks to 7-8 upgrade

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -109,14 +109,12 @@ module Api
             errors: compute.empty? ? {} : compute_status_errors(compute)
           }
 
-          if Api::Crowbar.addons.include?("ceph")
-            ceph_status = Api::Crowbar.ceph_status
-            ret[:checks][:ceph_healthy] = {
-              required: true,
-              passed: ceph_status.empty?,
-              errors: ceph_status.empty? ? {} : ceph_health_check_errors(ceph_status)
-            }
-          end
+          ceph_status = Api::Crowbar.ceph_status
+          ret[:checks][:ceph_status] = {
+            required: true,
+            passed: ceph_status.empty?,
+            errors: ceph_status.empty? ? {} : ceph_errors(ceph_status)
+          }
 
           ha_config = Api::Pacemaker.ha_presence_check.merge(
             Api::Crowbar.ha_config_check
@@ -1594,26 +1592,12 @@ module Api
         }
       end
 
-      def ceph_health_check_errors(check)
+      def ceph_errors(check)
         ret = {}
-        if check[:health_errors]
-          ret[:ceph_not_healthy] = {
-            data: I18n.t("api.upgrade.prechecks.ceph_not_healthy.error",
-              error: check[:health_errors]),
-            help: I18n.t("api.upgrade.prechecks.ceph_not_healthy.help")
-          }
-        end
-        if check[:old_version]
-          ret[:ceph_old_version] = {
-            data: I18n.t("api.upgrade.prechecks.ceph_old_version.error"),
-            help: I18n.t("api.upgrade.prechecks.ceph_old_version.help")
-          }
-        end
-        if check[:not_prepared]
-          ret[:ceph_not_prepared] = {
-            data: I18n.t("api.upgrade.prechecks.ceph_not_prepared.error",
-              nodes: check[:not_prepared].join(", ")),
-            help: I18n.t("api.upgrade.prechecks.ceph_not_prepared.help")
+        if check[:crowbar_ceph_nodes]
+          ret[:crowbar_ceph_nodes] = {
+            data: I18n.t("api.upgrade.prechecks.crowbar_ceph_present.error"),
+            help: I18n.t("api.upgrade.prechecks.crowbar_ceph_present.help")
           }
         end
         ret

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -803,9 +803,6 @@ en:
         maintenance_updates_check:
           help:
             default: 'Make sure maintenance updates are installed'
-        ceph_health_check:
-          help:
-            default: 'Make sure Ceph is healthy'
         clusters_health:
           crm_failures: 'Please check that all cluster resources are online or refer to the SUSE High Availability documentation for possible troubleshooting.'
           failed_actions: 'Please clean the resource history and re−check the current state with "crm_resource -C" or refer to the SUSE High Availability documentation for possible troubleshooting.'
@@ -839,22 +836,9 @@ en:
         unsupported_cluster_setup:
           error: 'Your cluster/role configuration is not supported by the non-disruptive upgrade process.'
           help: 'Please refer to the Deployment Guide for list of supported configurations.'
-        ceph_not_healthy:
-          error: |
-            Ceph cluster health check has failed with:
-            
-            %{error}
-                       
-            Make sure cluster is healthy before proceeding with the upgrade.
-          help: 'Refer to the SUSE Enterprise Storage documentation for possible troubleshooting.'
-        ceph_old_version:
-          error: 'It appears you have an old version of SUSE Enterprise Storage installed. Upgrade to the latest version of SES before proceeding with the Cloud upgrade.'
-          help: 'Refer to the SUSE Enterprise Storage documentation for the information about upgrading.'
-        ceph_not_prepared:
-          error: 'Some ceph nodes are not prepared for the upgrade: %{nodes}.'
-          help: |
-            Unlike normal nodes, ceph nodes must already be upgraded and kept waiting in the upgrade state until the upgrade of whole Cloud is finished.
-            Refer to the SUSE Enterprise Storage documentation for the information about upgrading ceph nodes.
+        crowbar_ceph_present:
+          error: 'There are nodes with ceph roles present. Remove all ceph roles deployed by crowbar and migrate to external Ceph cluster.'
+          help: 'Refer to the SUSE Enterprise Storage documentation for the information about upgrading from Crowbar Deployment.'
       prepare:
         help:
           default: 'Refer to the error message in the response'

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -156,118 +156,14 @@ describe Api::Crowbar do
     end
   end
 
-  context "with ceph cluster healthy" do
-    it "succeeds to check ceph cluster health and version" do
-      allow(Node).to(
-        receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
-        and_return([Node.find_by_name("ceph.crowbar.com")])
-      )
-      allow(Node).to(receive(:find).with(
-        "run_list_map:ceph-mon AND ceph_config_environment:*"
-      ).and_return([Node.find_node_by_name("ceph")]))
-      allow_any_instance_of(Node).to(
-        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
-        and_return(exit_code: 0, stdout: "HEALTH_OK\n", stderr: "")
-      )
-      allow_any_instance_of(Node).to(
-        receive(:run_ssh_cmd).with("LANG=C ceph --version | cut -d ' ' -f 3").
-        and_return(exit_code: 0, stdout: "10.2.4-211-g12b091b\n", stderr: "")
-      )
-
-      expect(subject.class.ceph_status).to be_empty
-    end
-
-    it "succeeds to check ceph cluster health and version but finds unprepared node" do
-      allow(Node).to(
-        receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
-        and_return([Node.find_by_name("testing"), Node.find_by_name("ceph")])
-      )
-      allow(Node).to(receive(:find).with(
-        "run_list_map:ceph-mon AND ceph_config_environment:*"
-      ).and_return([Node.find_node_by_name("ceph")]))
-      allow_any_instance_of(Node).to(
-        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
-        and_return(exit_code: 0, stdout: "HEALTH_OK\n", stderr: "")
-      )
-      allow_any_instance_of(Node).to(
-        receive(:run_ssh_cmd).with("LANG=C ceph --version | cut -d ' ' -f 3").
-        and_return(exit_code: 0, stdout: "10.2.4-211-g12b091b\n", stderr: "")
-      )
-
-      expect(subject.class.ceph_status).to eq(not_prepared: ["testing.crowbar.com"])
-    end
-
-    it "succeeds to check ceph cluster health but fails on version" do
-      allow(Node).to(
-        receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
-        and_return([Node.find_by_name("ceph.crowbar.com")])
-      )
-      allow(Node).to(receive(:find).with(
-        "run_list_map:ceph-mon AND ceph_config_environment:*"
-      ).and_return([Node.find_node_by_name("ceph")]))
-      allow_any_instance_of(Node).to(
-        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
-        and_return(exit_code: 0, stdout: "HEALTH_OK\n", stderr: "")
-      )
-      allow_any_instance_of(Node).to(
-        receive(:run_ssh_cmd).with("LANG=C ceph --version | cut -d ' ' -f 3").
-        and_return(exit_code: 0, stdout: "0.94.9-93-g239fe15\n", stderr: "")
-      )
-
-      expect(subject.class.ceph_status).to eq(old_version: true)
-    end
-  end
-
-  context "with ceph cluster not healthy" do
-    it "fails when checking ceph cluster health" do
+  context "with ceph cluster deployed by crowbar" do
+    it "fails when ceph roles are found" do
       allow(Node).to(
         receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
-      allow(Node).to(receive(:find).with(
-        "run_list_map:ceph-mon AND ceph_config_environment:*"
-      ).and_return([Node.find_node_by_name("ceph")]))
-      allow_any_instance_of(Node).to(
-        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
-        and_return(exit_code: 1, stdout: "HEALTH_ERR\n", stderr: "")
-      )
-      expect(subject.class.ceph_status).to_not be_empty
-    end
-
-    it "fails when exit value of ceph check is 0 but stdout still not correct" do
-      allow(Node).to(
-        receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
-        and_return([Node.find_by_name("testing.crowbar.com")])
-      )
-      allow(Node).to(receive(:find).with(
-        "run_list_map:ceph-mon AND ceph_config_environment:*"
-      ).and_return([Node.find_node_by_name("ceph")]))
-      allow_any_instance_of(Node).to(
-        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
-        and_return(exit_code: 0, stdout: "HEALTH_WARN", stderr: "")
-      )
-      expect(subject.class.ceph_status).to_not be_empty
-    end
-
-    it "fails when connection to ceph cluster times out" do
-      allow(Node).to(
-        receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
-        and_return([Node.find_by_name("testing.crowbar.com")])
-      )
-      allow(Node).to(receive(:find).with(
-        "run_list_map:ceph-mon AND ceph_config_environment:*"
-      ).and_return([Node.find_node_by_name("ceph")]))
-      allow_any_instance_of(Node).to(
-        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
-        and_return(
-          exit_code: 1,
-          stdout: "",
-          stderr: "Error connecting to cluster: InterruptedOrTimeoutError"
-        )
-      )
-
       expect(subject.class.ceph_status).to eq(
-        health_errors: "Error connecting to cluster: InterruptedOrTimeoutError"
+        crowbar_ceph_nodes: true
       )
     end
   end

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -945,6 +945,9 @@ describe Api::Upgrade do
       allow(Api::Crowbar).to(
         receive(:health_check).and_return({})
       )
+      allow(Api::Crowbar).to(
+        receive(:ceph_status).and_return({})
+      )
       allow(Api::Crowbar).to receive(
         :ha_config_check
       ).and_return({})
@@ -970,6 +973,9 @@ describe Api::Upgrade do
       ).and_return(error: "ERROR")
       allow(Api::Crowbar).to(
         receive(:health_check).and_return({})
+      )
+      allow(Api::Crowbar).to(
+        receive(:ceph_status).and_return({})
       )
       allow(Api::Crowbar).to receive(
         :ha_config_check


### PR DESCRIPTION
We do not allow the upgrade when ceph roles are present (that is,
if ceph was deployed using crowbar).

We no longer check the ceph cluster health. Unfortunatelly crowbar
does not have a knowledge where the ceph nodes are.
