### PR TITLE
[4.0] upgrade: Correctly check for the presence of various upgrade indication

### DIFF
--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -34,7 +34,7 @@ class ApplicationController < ActionController::Base
     Rails.env.test?
   }
   before_filter :upgrade, if: proc {
-    File.exist?("/var/lib/crowbar/upgrade/6-to-7-upgrade-running")
+    Dir.glob("/var/lib/crowbar/upgrade/*-upgrade-running").any?
   }
   before_filter :sanity_checks, unless: proc {
     Rails.env.test? || \


### PR DESCRIPTION
On SOC7, there could be 2 files indicating running upgrade: one for 6-7
and one for 7-8. Fix the check to make sure we do not miss one of these
situations.
