### PR TITLE
upgrade: Added pre-check for database type

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -270,6 +270,10 @@ module Api
 
       def deployment_check
         ret = {}
+        # Only allow the upgrade for mariadb setup
+        # TODO: update the search if we allow multiple proposals
+        db_node = ::Node.find("roles:database-server").first
+        ret[:wrong_sql_engine] = true if db_node[:database][:sql_engine] != "mysql"
         # Make sure that node with nova-compute is not upgraded before nova-controller
         nova_order = BarclampCatalog.run_order("nova")
         ::Node.find("roles:nova-compute-*").each do |node|
@@ -289,7 +293,7 @@ module Api
             next if BarclampCatalog.category(b) != "OpenStack"
             wrong_roles.push role if BarclampCatalog.run_order(b) < nova_order
           end
-          ret = { controller_roles: { node: node.name, roles: wrong_roles } } if wrong_roles.any?
+          ret[:controller_roles] = { node: node.name, roles: wrong_roles } if wrong_roles.any?
         end
         ret
       end

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1555,14 +1555,22 @@ module Api
       end
 
       def deployment_errors(check)
-        {
-          controller_roles: {
+        ret = {}
+        if check[:controller_roles]
+          ret[:controller_roles] = {
             data: I18n.t("api.upgrade.prechecks.controller_roles.error",
               node: check[:controller_roles][:node],
               roles: check[:controller_roles][:roles]),
             help: I18n.t("api.upgrade.prechecks.controller_roles.help")
           }
-        }
+        end
+        if check[:wrong_sql_engine]
+          ret[:wrong_sql_engine] = {
+            data: I18n.t("api.upgrade.prechecks.wrong_sql_engine.error"),
+            help: I18n.t("api.upgrade.prechecks.wrong_sql_engine.help")
+          }
+        end
+        ret
       end
 
       def health_check_errors(check)

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -837,6 +837,9 @@ en:
         controller_roles:
           error: 'Found compute node %{node} with controller roles: %{roles}.'
           help: 'It is not possible to upgrade with such setup. These roles cannot be placed on compute node.'
+        wrong_sql_engine:
+          error: 'OpenStack database is not set up with MariaDB.'
+          help: 'It is not possible to upgrade when MariaDB is not set up. Database migration has to be done first.'
         unsupported_cluster_setup:
           error: 'Your cluster/role configuration is not supported by the non-disruptive upgrade process.'
           help: 'Please refer to the Deployment Guide for list of supported configurations.'

--- a/crowbar_framework/spec/fixtures/offline_chef/node_drbd.crowbar.com.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/node_drbd.crowbar.com.json
@@ -25,6 +25,9 @@
         }
       }
     },
+    "database": {
+      "sql_engine": "postgresql"
+    },
     "hostname": "drbd",
     "state": "discovered",
     "run_list_map": {}

--- a/crowbar_framework/spec/fixtures/offline_chef/node_testing.crowbar.com.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/node_testing.crowbar.com.json
@@ -25,6 +25,9 @@
     "state": "discovered",
     "nova": {
       "use_migration": true
+    },
+    "database": {
+      "sql_engine": "mysql"
     }
   },
   "name": "testing.crowbar.com",

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -22,6 +22,7 @@ describe Api::Crowbar do
     )
   end
   let!(:node) { Node.find_by_name("testing.crowbar.com") }
+  let!(:drbd_node) { Node.find_by_name("drbd.crowbar.com") }
   let!(:crowbar_role) { RoleObject.find_role_by_name("crowbar") }
   let!(:cinder_controller_role) { RoleObject.find_role_by_name("cinder-controller") }
 
@@ -499,6 +500,7 @@ describe Api::Crowbar do
 
   context "with correct barclamps deployment" do
     it "passes with nice compute nodes" do
+      allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
@@ -511,6 +513,7 @@ describe Api::Crowbar do
     end
 
     it "passes with remote compute node" do
+      allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
@@ -523,6 +526,7 @@ describe Api::Crowbar do
     end
 
     it "passes with compute node together with nova-controller " do
+      allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
@@ -537,6 +541,7 @@ describe Api::Crowbar do
 
   context "with broken barclamps deployment" do
     it "fails when cinder-controller is on compute node" do
+      allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
@@ -558,6 +563,21 @@ describe Api::Crowbar do
         controller_roles: { node: "testing.crowbar.com", roles: ["cinder-controller"] }
       )
     end
+    it "fails when postgresql is deployed as OpenStack DB" do
+      allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([drbd_node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
+      allow_any_instance_of(NodeObject).to(
+        receive(:roles).and_return(
+          ["nova-compute-kvm", "cinder-volume", "swift-storage"]
+        )
+      )
+      allow_any_instance_of(RoleObject).to(receive(:proposal?).and_return(false))
+
+      expect(subject.class.deployment_check).to eq(
+        wrong_sql_engine: true
+      )
+    end
+
   end
 
   context "with enough compute resources" do

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -133,6 +133,9 @@ describe Api::Upgrade do
         :addons
       ).and_return(["ceph", "ha"])
       allow(Api::Crowbar).to receive(
+        :deployment_check
+      ).and_return({})
+      allow(Api::Crowbar).to receive(
         :health_check
       ).and_return({})
       allow(Api::Crowbar).to receive(
@@ -939,6 +942,9 @@ describe Api::Upgrade do
       allow(Api::Crowbar).to receive(
         :addons
       ).and_return(["ceph", "ha"])
+      allow(Api::Crowbar).to receive(
+        :deployment_check
+      ).and_return({})
       allow(Api::Pacemaker).to(
         receive(:ha_presence_check).and_return({})
       )
@@ -965,6 +971,9 @@ describe Api::Upgrade do
       allow(Api::Crowbar).to receive(
         :addons
       ).and_return(["ceph", "ha"])
+      allow(Api::Crowbar).to receive(
+        :deployment_check
+      ).and_return({})
       allow(Api::Pacemaker).to receive(
         :ha_presence_check
       ).and_return(error: "ERROR")
@@ -990,6 +999,9 @@ describe Api::Upgrade do
       ).and_return(errors: ["Some Error"])
       allow(Api::Crowbar).to receive(
         :ha_config_check
+      ).and_return({})
+      allow(Api::Crowbar).to receive(
+        :deployment_check
       ).and_return({})
       allow(Api::Pacemaker).to receive(
         :health_report


### PR DESCRIPTION
For now, we require users to have MariaDB deployed before the
upgrade can be started.

(cherry picked from commit f44408d2eede37df7c4d3706ee549f1b554e0da5)

Port of https://github.com/crowbar/crowbar-core/pull/1575. This is not exactly needed in [master] (because here it's relevant for non-existing 8-9 upgrade), I'm porting it just for the code consistency.