### PR TITLE
ntp: Make listening net configurable (bsc#1047941)

### DIFF
--- a/chef/cookbooks/ntp/templates/default/ntp.conf.erb
+++ b/chef/cookbooks/ntp/templates/default/ntp.conf.erb
@@ -4,6 +4,9 @@ driftfile <%= @driftfile %>
 
 interface ignore wildcard
 interface listen <%= @admin_interface %>
+<% @listen_interfaces.each do |interface| %>
+interface listen <%= interface %>
+<% end %>
 
 # Enable this if you want statistics to be logged.
 #statsdir /var/log/ntpstats/
@@ -31,9 +34,25 @@ server <%= ntp_server %> iburst minpoll 4
 # that might be intended to block requests from certain clients could also end
 # up blocking replies from your own upstream servers.
 
+<% if @is_server -%>
+# By default, ignore all inbound traffic from all hosts
+restrict -4 default ignore
+restrict -6 default ignore
+
+# Exchange time with all hosts in the admin subnet, but don't allow configuration.
+restrict <%= @admin_subnet %> mask <%= @admin_netmask %> notrap nomodify nopeer noquery
+
+# Exchange time with external NTP servers, but don't allow configuration
+# and use rate-limiting.
+<% @ntp_servers.each do |ntp_server| -%>
+restrict <%= ntp_server %> kod limited notrap nomodify nopeer noquery
+<% end -%>
+
+<% else -%>
 # By default, exchange time with everybody, but don't allow configuration.
-restrict -4 default kod notrap nomodify nopeer noquery
-restrict -6 default kod notrap nomodify nopeer noquery
+restrict -4 default notrap nomodify nopeer noquery
+restrict -6 default notrap nomodify nopeer noquery
+<% end -%>
 
 # Local users may interrogate the ntp server more closely.
 restrict 127.0.0.1
@@ -42,7 +61,6 @@ restrict ::1
 # Clients from this (example!) subnet have unlimited access, but only if
 # cryptographically authenticated.
 #restrict 192.168.123.0 mask 255.255.255.0 notrust
-
 
 # If you want to provide time to your local subnet, change the next line.
 # (Again, the address is an example only.)

--- a/chef/data_bags/crowbar/migrate/ntp/100_add_listens.rb
+++ b/chef/data_bags/crowbar/migrate/ntp/100_add_listens.rb
@@ -1,0 +1,9 @@
+def upgrade(ta, td, a, d)
+  a["server_listen_on_networks"] = ta["server_listen_on_networks"]
+  [a, d]
+end
+
+def downgrade(ta, td, a, d)
+  a.delete("server_listen_on_networks")
+  [a, d]
+end

--- a/chef/data_bags/crowbar/template-ntp.json
+++ b/chef/data_bags/crowbar/template-ntp.json
@@ -3,14 +3,15 @@
   "description": "Common NTP service for the cluster. An NTP server or servers can be specified and all other nodes will be clients of them.",
   "attributes": {
     "ntp": {
-      "external_servers": [ ]
+      "external_servers": [ ],
+      "server_listen_on_networks": [ ]
     }
   },
   "deployment": {
     "ntp": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 1,
+      "schema-revision": 100,
       "element_states": {
         "ntp-server": [ "readying", "ready", "applying" ],
         "ntp-client": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-ntp.schema
+++ b/chef/data_bags/crowbar/template-ntp.schema
@@ -16,6 +16,11 @@
               "type": "seq",
               "required": true,
               "sequence": [ { "type": "str" } ]
+            },
+            "server_listen_on_networks": {
+              "type": "seq",
+              "required": false,
+              "sequence": [ { "type": "str" } ]
             }
           }
         }

--- a/crowbar_framework/app/models/ntp_service.rb
+++ b/crowbar_framework/app/models/ntp_service.rb
@@ -74,6 +74,16 @@ class NtpService < ServiceObject
   def apply_role_pre_chef_call(old_role, role, all_nodes)
     Rails.logger.debug("NTP apply_role_pre_chef_call: entering #{all_nodes.inspect}")
 
+    net_svc = NetworkService.new @logger
+    listen_networks = role.default_attributes["ntp"]["server_listen_on_networks"] || []
+    server_nodes_names = role.override_attributes["ntp"]["elements"]["ntp-server"]
+    server_nodes = server_nodes_names.map { |n| Node.find_by_name(n) }
+    server_nodes.each do |node|
+      listen_networks.each do |network|
+        net_svc.allocate_ip "default", network, "host", node.name
+      end
+    end
+
     save_config_to_databag(old_role, role)
 
     Rails.logger.debug("NTP apply_role_pre_chef_call: leaving")


### PR DESCRIPTION
(forward port of #1389)

In cases where the admin network is firewalled from the outside world,
the cloud ntp servers will not be able to connect to external ntp
servers to synchronize. This patch adds the option to set additional
listen interfaces for nodes with the ntp-server role so those ntp
servers can sync with outside servers.

On the ntp-server host, only packets from configured external NTP servers
and from hosts in the admin network are allowed; everything else is
ignored. In addition to that, the rate-limiting feature has been
enabled for requests coming from the external NTP servers.

On the ntp-client hosts, the NTP configuration is not changed by this patch.
