### PR TITLE
Revert "upgrade: Do not upgrade compute-related packages to Pike"

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -77,18 +77,29 @@ log "No HA setup found..."
 
 <% if @compute_node %>
 
+log "Upgrading packages needed for nova-compute node"
+
+zypper --non-interactive up openstack-nova-compute
+
 log "Restarting services for Pike"
 
+zypper --non-interactive up <%= @neutron_agent %>
 <% unless @remote_node %>
 systemctl restart <%= @neutron_agent %>
 <% end %>
 
-<% if @l3_agent && !@remote_node %>
+<% if @l3_agent %>
+zypper --non-interactive up <%= @l3_agent %>
+<% unless @remote_node %>
 systemctl restart <%= @l3_agent %>
 <% end %>
+<% end %>
 
-<% if @metadata_agent && !@remote_node%>
+<% if @metadata_agent %>
+zypper --non-interactive up <%= @metadata_agent %>
+<% unless @remote_node %>
 systemctl restart <%= @metadata_agent %>
+<% end %>
 <% end %>
 
 <% if @remote_node %>
@@ -101,6 +112,7 @@ systemctl restart openstack-nova-compute.service
 
 <% if @cinder_volume %>
 log "Upgrading and setting cinder-volume configuration"
+zypper --non-interactive up openstack-cinder-volume
 systemctl restart openstack-cinder-volume.service
 <% end %>
 


### PR DESCRIPTION
This reverts commit 7d94b14fa3a9f902642493e5ec2cb293dcd90c02.

Turns out we might still need Pike client packages....see https://jira.prv.suse.net/browse/SCRD-3245 for more details.