### PR TITLE
upgrade: Remove the database step

### DIFF
--- a/crowbar_framework/config/puma.rb
+++ b/crowbar_framework/config/puma.rb
@@ -52,6 +52,18 @@ end
   FileUtils.mkdir_p File.join(ROOT, name)
 end
 
+# When starting the process during the upgrade (after reboot),
+# mark the end of "admin server upgrade" step.
+if File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-running")
+  CROWBAR_LIB_DIR = "/opt/dell/crowbar_framework/lib".freeze
+  $LOAD_PATH.push CROWBAR_LIB_DIR if Dir.exist?(CROWBAR_LIB_DIR)
+
+  require "logger"
+  require "crowbar/upgrade_status"
+  upgrade_status = ::Crowbar::UpgradeStatus.new(Logger.new(Logger::STDOUT))
+  upgrade_status.end_step if upgrade_status.current_step == :admin
+end
+
 stdout_redirect(
   "/var/log/crowbar/production.log",
   "/var/log/crowbar/production.log",

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -316,7 +316,6 @@ module Crowbar
         :backup_crowbar,
         :repocheck_crowbar,
         :admin,
-        :database,
         :repocheck_nodes,
         :services,
         :backup_openstack,

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -26,9 +26,6 @@
     "admin":{
       "status":"pending"
     },
-    "database":{
-      "status":"pending"
-    },
     "repocheck_nodes":{
       "status":"pending"
     },

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -210,9 +210,6 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_step).to eql :admin
       expect(subject.start_step(:admin)).to be true
       expect(subject.end_step).to be true
-      expect(subject.current_step).to eql :database
-      expect(subject.start_step(:database)).to be true
-      expect(subject.end_step).to be true
       expect(subject.current_step).to eql :repocheck_nodes
       expect(subject.start_step(:repocheck_nodes)).to be true
       expect(subject.end_step).to be true
@@ -264,9 +261,6 @@ describe Crowbar::UpgradeStatus do
         Crowbar::Error::StartStepOrderError
       )
       expect { subject.start_step(:admin) }.to raise_error(
-        Crowbar::Error::StartStepOrderError
-      )
-      expect { subject.start_step(:database) }.to raise_error(
         Crowbar::Error::StartStepOrderError
       )
       expect { subject.start_step(:services) }.to raise_error(
@@ -378,8 +372,6 @@ describe Crowbar::UpgradeStatus do
       expect(subject.start_step(:repocheck_crowbar)).to be true
       expect(subject.end_step).to be true
       expect(subject.start_step(:admin)).to be true
-      expect(subject.end_step).to be true
-      expect(subject.start_step(:database)).to be true
       expect(subject.end_step).to be true
       expect(subject.start_step(:repocheck_nodes)).to be true
       expect(subject.end_step).to be true


### PR DESCRIPTION
Previously we had crowbar-init finishing admin upgrade step at the
point the admin server came back from reboot.
Now, crowbar-init is not needed any more during upgrade so let
crowabr itself make the end of step action once it is started.
