### PR TITLE
[4.0] upgrade: Remove database step from the list of 7-8 upgrade steps

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -335,7 +335,6 @@ module Crowbar
         :backup_crowbar,
         :repocheck_crowbar,
         :admin,
-        :database,
         :repocheck_nodes,
         :services,
         :backup_openstack,

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -26,9 +26,6 @@
     "admin":{
       "status":"pending"
     },
-    "database":{
-      "status":"pending"
-    },
     "repocheck_nodes":{
       "status":"pending"
     },

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -215,9 +215,6 @@ describe Crowbar::UpgradeStatus do
       expect(subject.current_step).to eql :admin
       expect(subject.start_step(:admin)).to be true
       expect(subject.end_step).to be true
-      expect(subject.current_step).to eql :database
-      expect(subject.start_step(:database)).to be true
-      expect(subject.end_step).to be true
       expect(subject.current_step).to eql :repocheck_nodes
       expect(subject.start_step(:repocheck_nodes)).to be true
       expect(subject.end_step).to be true
@@ -269,9 +266,6 @@ describe Crowbar::UpgradeStatus do
         Crowbar::Error::StartStepOrderError
       )
       expect { subject.start_step(:admin) }.to raise_error(
-        Crowbar::Error::StartStepOrderError
-      )
-      expect { subject.start_step(:database) }.to raise_error(
         Crowbar::Error::StartStepOrderError
       )
       expect { subject.start_step(:services) }.to raise_error(
@@ -383,8 +377,6 @@ describe Crowbar::UpgradeStatus do
       expect(subject.start_step(:repocheck_crowbar)).to be true
       expect(subject.end_step).to be true
       expect(subject.start_step(:admin)).to be true
-      expect(subject.end_step).to be true
-      expect(subject.start_step(:database)).to be true
       expect(subject.end_step).to be true
       expect(subject.start_step(:repocheck_nodes)).to be true
       expect(subject.end_step).to be true


### PR DESCRIPTION
During 7 to 8 upgrade, crowbar database does not need to be changed. Partial port of 
https://github.com/crowbar/crowbar-core/pull/1586