### PR TITLE
upgrade: Adapt ceph-related checks to 7-8 upgrade

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -101,30 +101,7 @@ module Api
       def ceph_status
         ret = {}
         ceph_nodes = ::Node.find("roles:ceph-* AND ceph_config_environment:*")
-        return ret if ceph_nodes.empty?
-        mon_node = ::Node.find("run_list_map:ceph-mon AND ceph_config_environment:*").first
-
-        ssh_retval = mon_node.run_ssh_cmd("LANG=C ceph health --connect-timeout 5 2>&1")
-        # Some warnings do not need to be critical, but we have no way to find out.
-        # So we assume user knows how to tweak cluster settings to show the healthy state.
-        unless ssh_retval[:stdout].include? "HEALTH_OK"
-          ret[:health_errors] = ssh_retval[:stdout]
-          unless ssh_retval[:stderr].nil? || ssh_retval[:stderr].empty?
-            ret[:health_errors] += "; " unless ssh_retval[:stdout].empty?
-            ret[:health_errors] += ssh_retval[:stderr]
-          end
-          return ret
-        end
-        # ceph --version
-        # SES2.1:
-        # ceph version 0.94.9-93-g239fe15 (239fe153ffde6a22e1efcaf734ff28d6a703a0ba)
-        # SES4:
-        # ceph version 10.2.4-211-g12b091b (12b091b4a40947aa43919e71a318ed0dcedc8734)
-        ssh_retval = mon_node.run_ssh_cmd("LANG=C ceph --version | cut -d ' ' -f 3")
-        ret[:old_version] = true if ssh_retval[:stdout].to_f < 10.2
-
-        not_prepared = ceph_nodes.select { |n| n.state != "crowbar_upgrade" }.map(&:name)
-        ret[:not_prepared] = not_prepared unless not_prepared.empty?
+        ret[:crowbar_ceph_nodes] = ceph_nodes.any?
         ret
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -109,14 +109,12 @@ module Api
             errors: compute.empty? ? {} : compute_status_errors(compute)
           }
 
-          if Api::Crowbar.addons.include?("ceph")
-            ceph_status = Api::Crowbar.ceph_status
-            ret[:checks][:ceph_healthy] = {
-              required: true,
-              passed: ceph_status.empty?,
-              errors: ceph_status.empty? ? {} : ceph_health_check_errors(ceph_status)
-            }
-          end
+          ceph_status = Api::Crowbar.ceph_status
+          ret[:checks][:ceph_status] = {
+            required: true,
+            passed: ceph_status.empty?,
+            errors: ceph_status.empty? ? {} : ceph_errors(ceph_status)
+          }
 
           ha_config = Api::Pacemaker.ha_presence_check.merge(
             Api::Crowbar.ha_config_check
@@ -1569,26 +1567,12 @@ module Api
         }
       end
 
-      def ceph_health_check_errors(check)
+      def ceph_errors(check)
         ret = {}
-        if check[:health_errors]
-          ret[:ceph_not_healthy] = {
-            data: I18n.t("api.upgrade.prechecks.ceph_not_healthy.error",
-              error: check[:health_errors]),
-            help: I18n.t("api.upgrade.prechecks.ceph_not_healthy.help")
-          }
-        end
-        if check[:old_version]
-          ret[:ceph_old_version] = {
-            data: I18n.t("api.upgrade.prechecks.ceph_old_version.error"),
-            help: I18n.t("api.upgrade.prechecks.ceph_old_version.help")
-          }
-        end
-        if check[:not_prepared]
-          ret[:ceph_not_prepared] = {
-            data: I18n.t("api.upgrade.prechecks.ceph_not_prepared.error",
-              nodes: check[:not_prepared].join(", ")),
-            help: I18n.t("api.upgrade.prechecks.ceph_not_prepared.help")
+        if check[:crowbar_ceph_nodes]
+          ret[:crowbar_ceph_nodes] = {
+            data: I18n.t("api.upgrade.prechecks.crowbar_ceph_present.error"),
+            help: I18n.t("api.upgrade.prechecks.crowbar_ceph_present.help")
           }
         end
         ret

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -804,9 +804,6 @@ en:
         maintenance_updates_check:
           help:
             default: 'Make sure maintenance updates are installed'
-        ceph_health_check:
-          help:
-            default: 'Make sure Ceph is healthy'
         clusters_health:
           crm_failures: 'Please check that all cluster resources are online or refer to the SUSE High Availability documentation for possible troubleshooting.'
           failed_actions: 'Please clean the resource history and re−check the current state with "crm_resource -C" or refer to the SUSE High Availability documentation for possible troubleshooting.'
@@ -840,22 +837,9 @@ en:
         unsupported_cluster_setup:
           error: 'Your cluster/role configuration is not supported by the non-disruptive upgrade process.'
           help: 'Please refer to the Deployment Guide for list of supported configurations.'
-        ceph_not_healthy:
-          error: |
-            Ceph cluster health check has failed with:
-            
-            %{error}
-                       
-            Make sure cluster is healthy before proceeding with the upgrade.
-          help: 'Refer to the SUSE Enterprise Storage documentation for possible troubleshooting.'
-        ceph_old_version:
-          error: 'It appears you have an old version of SUSE Enterprise Storage installed. Upgrade to the latest version of SES before proceeding with the Cloud upgrade.'
-          help: 'Refer to the SUSE Enterprise Storage documentation for the information about upgrading.'
-        ceph_not_prepared:
-          error: 'Some ceph nodes are not prepared for the upgrade: %{nodes}.'
-          help: |
-            Unlike normal nodes, ceph nodes must already be upgraded and kept waiting in the upgrade state until the upgrade of whole Cloud is finished.
-            Refer to the SUSE Enterprise Storage documentation for the information about upgrading ceph nodes.
+        crowbar_ceph_present:
+          error: 'There are nodes with ceph roles present. Remove all ceph roles deployed by crowbar and migrate to external Ceph cluster.'
+          help: 'Refer to the SUSE Enterprise Storage documentation for the information about upgrading from Crowbar Deployment.'
       prepare:
         help:
           default: 'Refer to the error message in the response'

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -945,6 +945,9 @@ describe Api::Upgrade do
       allow(Api::Crowbar).to(
         receive(:health_check).and_return({})
       )
+      allow(Api::Crowbar).to(
+        receive(:ceph_status).and_return({})
+      )
       allow(Api::Crowbar).to receive(
         :ha_config_check
       ).and_return({})
@@ -970,6 +973,9 @@ describe Api::Upgrade do
       ).and_return(error: "ERROR")
       allow(Api::Crowbar).to(
         receive(:health_check).and_return({})
+      )
+      allow(Api::Crowbar).to(
+        receive(:ceph_status).and_return({})
       )
       allow(Api::Crowbar).to receive(
         :ha_config_check


### PR DESCRIPTION
We do not allow the upgrade when ceph roles are present (that is,
if ceph was deployed using crowbar).

We no longer check the ceph cluster health. Unfortunatelly crowbar
does not have a knowledge where the ceph nodes are.

(cherry picked from commit ecd8c28fbace2242f7a8e4d9694b8ee5ec7b45aa)

**Note** This is not really affecting 7-8 upgrade, porting only for code consistency.