### PR TITLE
[4.0] upgrade: Fix check for ceph presence

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -102,7 +102,7 @@ module Api
       def ceph_status
         ret = {}
         ceph_nodes = ::Node.find("roles:ceph-* AND ceph_config_environment:*")
-        ret[:crowbar_ceph_nodes] = ceph_nodes.any?
+        ret[:crowbar_ceph_nodes] = true if ceph_nodes.any?
         ret
       end
 


### PR DESCRIPTION
We're checking the return hash for empty? so we want it empty
when the test passes.

https://github.com/crowbar/crowbar-core/blob/master/crowbar_framework/app/models/api/upgrade.rb#L116 requires empty hash on correct case