### PR TITLE
[4.0] upgrade: Finish only controllers step

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -706,8 +706,8 @@ module Api
           upgrade_controller_clusters
           upgrade_non_compute_nodes
           prepare_all_compute_nodes
+          ::Crowbar::UpgradeStatus.new.save_substep(substep, :finished)
         end
-        ::Crowbar::UpgradeStatus.new.save_substep(substep, :finished)
       end
 
       def remaining_nodes


### PR DESCRIPTION
If do_controllers_substep is called with substep other than :ceph_nodes or :controller_nodes it should not finish the substep silently.