### PR TITLE
upgrade: Allow running schema migrations on upgrade

### DIFF
--- a/crowbar_framework/lib/schema_migration.rb
+++ b/crowbar_framework/lib/schema_migration.rb
@@ -26,7 +26,6 @@ module SchemaMigration
 
   def self.run_for_bc bc_name
     return unless File.exist?("/var/lib/crowbar/install/crowbar-installed-ok")
-    return if File.exist?("/var/run/crowbar/admin-server-upgrading")
     db_host = Rails.configuration.database_configuration[Rails.env]["host"]
     if ["localhost", "127.0.0.1"].include?(db_host) && !system("systemctl is-active postgresql")
       raise "Cannot run schema migrations for #{bc_name}. Database server is not running"


### PR DESCRIPTION
https://github.com/crowbar/crowbar/pull/2348 did not seem to help, and here's the reason why: https://github.com/crowbar/crowbar-core/commit/73357d9318084e73abc0a512eaeb5ba8c951c7c6


This is basically a revert of 73357d9318084e73abc0a512eaeb5ba8c951c7c6.

The code made sense in 6-7 upgrade, as we were creating new database and the migration
was explicitely called after data import.

For 7-8 upgrade, we are not changing crowbar database so we need to run the migrations
after package upgrade.

