### PR TITLE
[4.0] upgrade: Fix labels for SOC8 repositories

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -388,14 +388,14 @@ class Api::UpgradeController < ApiController
     "openstack": {
       "available": false,
       "repos": [
-        "SUSE-OpenStack-Cloud-8-Pool",
-        "SUSE-OpenStack-Cloud-8-Updates"
+        "SUSE-OpenStack-Cloud-Crowbar-8-Pool",
+        "SUSE-OpenStack-Cloud-Crowbar-8-Updates"
       ],
       "errors":
         "x86_64": {
           "missing": [
-            "SUSE-OpenStack-Cloud-8-Pool",
-            "SUSE-OpenStack-Cloud-8-Updates"
+            "SUSE-OpenStack-Cloud-Crowbar-8-Pool",
+            "SUSE-OpenStack-Cloud-Crowbar-8-Updates"
           ]
         }
       }

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -283,8 +283,8 @@ module Api
           ret[:openstack] = {
             available: cloud_available,
             repos: [
-              "SUSE-OpenStack-Cloud-8-Pool",
-              "SUSE-OpenStack-Cloud-8-Updates"
+              "SUSE-OpenStack-Cloud-Crowbar-8-Pool",
+              "SUSE-OpenStack-Cloud-Crowbar-8-Updates"
             ],
             errors: {}
           }

--- a/crowbar_framework/spec/fixtures/crowbar_repocheck.json
+++ b/crowbar_framework/spec/fixtures/crowbar_repocheck.json
@@ -10,8 +10,8 @@
   "openstack":{
     "available":true,
     "repos":[
-      "SUSE-OpenStack-Cloud-8-Pool",
-      "SUSE-OpenStack-Cloud-8-Updates"
+      "SUSE-OpenStack-Cloud-Crowbar-8-Pool",
+      "SUSE-OpenStack-Cloud-Crowbar-8-Updates"
     ],
     "errors":{}
   }


### PR DESCRIPTION
These are checked aready at SOC7 side, as the first part of 7-8 upgrade.

Partial backport of https://github.com/crowbar/crowbar-core/pull/1503