### PR TITLE
[4.0] upgrade: Do not check if ceph roles are present on compute nodes

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -264,6 +264,9 @@ module Api
             next if ["cinder-volume", "swift-storage"].include? role
             # compute node roles are fine
             next if role.start_with?("nova-compute") || role == "pacemaker-remote"
+            # ceph roles are not allowed, but they are already handled by different check
+            # so we treat them as OK in this one
+            next if role.start_with?("ceph")
             r = RoleObject.find_role_by_name(role)
             next if r.proposal?
             b = r.barclamp


### PR DESCRIPTION
We already have a different check that does not allow the upgrade
if ceph roles are present _anywhere_. So it does not make sense
to flood user with duplicate error messages.
