### PR TITLE
upgrade: Unblock upgrade status API in Cloud8

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -16,7 +16,7 @@
 
 class Api::UpgradeController < ApiController
   # disable upgrade API until upgrade to next version is implemented
-  before_action do
+  before_action(except: :show) do
     # skip filter if we're in the middle of upgrade from previos version
     unless File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-running")
       render json: {


### PR DESCRIPTION
After finished 7->8 upgrade, cloud API is disabled. One exception is
upgrade status API which should still be available to let users query
status of finished upgrade (i.e. after upgrade was completed).