### PR TITLE
[4.0] upgrade: Added API calls for postponing/resuming compute nodes upgrade

### DIFF
--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -10,6 +10,7 @@
   "openstack_backup": null,
   "suggested_upgrade_mode": null,
   "selected_upgrade_mode": null,
+  "compute_nodes_postponed": false,
   "steps":{
     "prechecks":{
       "status":"pending"

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -387,6 +387,18 @@ describe Crowbar::UpgradeStatus do
       )
     end
 
+    it "postpones and resumes compute node upgrade" do
+      expect(subject.progress[:compute_nodes_postponed]).to be false
+
+      allow(FileUtils).to receive(:touch).and_return(true)
+      expect(subject.postpone).to be true
+      expect(subject.progress[:compute_nodes_postponed]).to be true
+
+      allow(FileUtils).to receive(:rm_f).and_return(true)
+      expect(subject.resume).to be true
+      expect(subject.progress[:compute_nodes_postponed]).to be false
+    end
+
     it "fails while saving the status initially" do
       allow_any_instance_of(Pathname).to(
         receive(:open).and_raise("Failed to write File")


### PR DESCRIPTION
(cherry picked from commit b8460e532c8b94acd72281113b652190a63b964d)

This is partial backport of https://github.com/crowbar/crowbar-core/pull/1574

We need it so the value of `compute_nodes_postponed` is present in the progress file from the start of 7-8 upgrade