### PR TITLE
upgrade: Check input is a valid node for nodes

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -183,6 +183,12 @@ class Api::UpgradeController < ApiController
           ::Crowbar::UpgradeStatus.new.start_step(:nodes)
         end
       else
+        # At this point params[:component] should be a node, if it is not,
+        # raise an error.
+        unless Node.all.map(&:name).include? params[:component]
+          raise ::Crowbar::Error::UpgradeError, "Component must be 'all', "\
+            "'controllers', 'resume', 'postpone' or a node name."
+        end
         if substep != :compute_nodes && status != :finished
           raise ::Crowbar::Error::UpgradeError.new(
             "Controller nodes must be upgraded first!"


### PR DESCRIPTION
The else clause for upgrade nodes assumes input is valid, and if it
isn't, returns an unhelpful message about how controller nodes need to
be upgraded first. Validate the input to provide a helpful error.
