### PR TITLE
upgrade: Do not finalize nodes that are not upgraded

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -863,6 +863,11 @@ module Api
         node.crowbar.delete "node_upgrade_state"
         node.save
 
+      end
+
+      def delete_upgrade_scripts(node)
+        return if node.admin?
+
         scripts_to_delete = [
           "prepare-repositories",
           "upgrade-os",
@@ -883,6 +888,7 @@ module Api
       def finalize_nodes_upgrade
         ::Node.find_all_nodes.each do |node|
           finalize_node_upgrade node
+          delete_upgrade_scripts node
         end
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -728,7 +728,7 @@ module Api
           # Upgrade controller clusters only
           do_controllers_substep(substep)
           # Finalize only upgraded nodes (compute nodes might be postponed)
-          ::Node.find("state:crowbar_upgrade").each do |node|
+          ::Node.find("state:ready").each do |node|
             finalize_node_upgrade node
           end
         else

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -868,9 +868,12 @@ class Node < ChefObject
 
   def upgraded?
     upgrade_state = crowbar["node_upgrade_state"] || ""
-    return false unless upgrade_state == "upgraded"
-    Rails.logger.info("Node #{@node.name} was already upgraded.")
-    true
+    if upgrade_state == "upgraded" ||
+        (upgrade_state == "" && !crowbar.key?("crowbar_upgrade_step"))
+      Rails.logger.info("Node #{@node.name} was already upgraded.")
+      return true
+    end
+    false
   end
 
   def upgrading?


### PR DESCRIPTION
Mistakingly, we were finalizing the nodes that were still not upgraded
which led to deletion of upgrade related scripts on those nodes.

Here it was broken: https://github.com/crowbar/crowbar-core/commit/cdb5be7e52ca5895533aed7c47671123dad543a0

Also, split "finalizing" (removing upgrade related node attributes) from upgrade script deletion. The scripts may still be needed.