### PR TITLE
upgrade: Move step to mark the admin upgrade end

### DIFF
--- a/crowbar_framework/config/initializers/end_adminupgrade.rb
+++ b/crowbar_framework/config/initializers/end_adminupgrade.rb
@@ -1,0 +1,23 @@
+#
+# Copyright 2018, SUSE LINUX GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# When starting crowbar during the upgrade (e.g. after a reboot),
+# mark the end of "admin server upgrade" step.
+if File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-running") &&
+    !File.exist?("/var/run/crowbar/admin-server-upgrading")
+  upgrade_status = ::Crowbar::UpgradeStatus.new(Logger.new(STDOUT))
+  upgrade_status.end_step if upgrade_status.current_step == :admin
+end

--- a/crowbar_framework/config/puma.rb
+++ b/crowbar_framework/config/puma.rb
@@ -52,19 +52,6 @@ end
   FileUtils.mkdir_p File.join(ROOT, name)
 end
 
-# When starting the process during the upgrade (after reboot),
-# mark the end of "admin server upgrade" step.
-if File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-running") &&
-    !File.exist?("/var/run/crowbar/admin-server-upgrading")
-  CROWBAR_LIB_DIR = "/opt/dell/crowbar_framework/lib".freeze
-  $LOAD_PATH.push CROWBAR_LIB_DIR if Dir.exist?(CROWBAR_LIB_DIR)
-
-  require "logger"
-  require "crowbar/upgrade_status"
-  upgrade_status = ::Crowbar::UpgradeStatus.new(Logger.new(Logger::STDOUT))
-  upgrade_status.end_step if upgrade_status.current_step == :admin
-end
-
 stdout_redirect(
   "/var/log/crowbar/production.log",
   "/var/log/crowbar/production.log",


### PR DESCRIPTION
This move the step to mark the end of the admin node's upgrade from the
puma startup to the initializer of the rails app. Which seems to be a
more appropriate place. It also removes the need to require additional
modules and update the LOADPATH.
