### PR TITLE
upgrade: Increase the timeout for deleting pacemaker resources

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -30,7 +30,7 @@ module Crowbar
         chef_upgraded: @timeouts_config[:chef_upgraded] || 1200,
         router_migration: @timeouts_config[:router_migration] || 600,
         lbaas_evacuation: @timeouts_config[:lbaas_evacuation] || 600,
-        delete_pacemaker_resources: @timeouts_config[:delete_pacemaker_resources] || 300,
+        delete_pacemaker_resources: @timeouts_config[:delete_pacemaker_resources] || 600,
         delete_cinder_services: @timeouts_config[:delete_cinder_services] || 300,
         wait_until_compute_started: @timeouts_config[:wait_until_compute_started] || 60
       }


### PR DESCRIPTION
It took 321 seconds in https://ci.suse.de/job/openstack-mkcloud/121570/
More than a minute for stopping `cl-cinder-scheduler`

Another case here: https://ci.suse.de/job/openstack-mkcloud/121575

Stopping `cl-cinder-scheduler` took almost 2 minutes. 
(next longest one is 22 seconds for stopping `ms-galera`)