### PR TITLE
upgrade: Better check for upgraded nodes - do not rely on state.

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -728,8 +728,8 @@ module Api
           # Upgrade controller clusters only
           do_controllers_substep(substep)
           # Finalize only upgraded nodes (compute nodes might be postponed)
-          ::Node.find("state:ready").each do |node|
-            finalize_node_upgrade node
+          ::Node.all.each do |node|
+            finalize_node_upgrade(node) if !node.admin? && node.upgraded?
           end
         else
           # Upgrade given compute node


### PR DESCRIPTION
Seems like that the check for nodes that are 'ready' does not work in 100%.
Maybe some nodes are readying or chef-client did not run for a long time
and they are considered unknown.

So better check the node attributes instead.

Here https://ci.suse.de/view/Cloud/view/Cloud8/job/cloud-mkcloud8-job-upgrade-nondisruptive-ha-mariadb-x86_64/57/ the post-upgrade redeployment of keystone has failed because the founder still thought it's being upgraded.
... well, that's still weird, it should have been deleted in the last `finalize_nodes_upgrade` anyway...