### PR TITLE
[stable/4.0] upgrade: Check input is a valid node for nodes

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -151,6 +151,12 @@ class Api::UpgradeController < ApiController
           ::Crowbar::UpgradeStatus.new.start_step(:nodes)
         end
       else
+        # At this point params[:component] should be a node, if it is not,
+        # raise an error.
+        unless Node.all.map(&:name).include?(params[:component])
+          raise ::Crowbar::Error::UpgradeError, "Component must be 'all', "\
+            "'controllers' or a node name."
+        end
         if substep != :compute_nodes && status != :finished
           raise ::Crowbar::Error::UpgradeError.new(
             "Controller nodes must be upgraded first!"


### PR DESCRIPTION
The else clause for upgrade nodes assumes input is valid, and if it
isn't, returns an unhelpful message about how controller nodes need to
be upgraded first. Validate the input to provide a helpful error.

(cherry picked from commit d3cd42d8816b892b23cb332772a773b1768cd125)

https://github.com/crowbar/crowbar-openstack/pull/1692 is the PR for master.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
