### PR TITLE
upgrade: Stop cron before stopping any other service

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -19,6 +19,12 @@ log "Executing $BASH_SOURCE"
 
 set -x
 
+# Stop and disable cron early to avoid any cronjob trying to access openstack
+# APIs while upgrading the cluster. It will be enabled and started again after
+# the node is fully upgraded (as part of "crowbar-chef-upgraded.sh")
+systemctl stop cron
+systemctl disable cron
+
 <% if @nova_controller && (!@use_ha || @cluster_founder) %>
 # Remove nova-cert service which has been deprecated in Newton and is not present in Pike
 
@@ -73,8 +79,5 @@ do
 done
 
 <% end %>
-
-systemctl stop cron
-systemctl disable cron
 
 log "$BASH_SOURCE is finished."


### PR DESCRIPTION
There was a small race condition that caused cron jobs (e.g.
glance-scrubber) to run while the openstack services were offline
already. This polluted the service's log file and confused some of the
test done by mkcloud. Stopping cron a bit earlier during the upgrade
shoud avoid that.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.
