### PR TITLE
upgrade: Wait for services shutdown to finish

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -25,6 +25,15 @@ set -x
 systemctl stop cron
 systemctl disable cron
 
+mkdir -p $UPGRADEDIR
+
+if [[ -f $UPGRADEDIR/crowbar-shutdown-services-before-upgrade-ok ]] ; then
+    log "Services are already shut down."
+    exit 0
+fi
+
+rm -f $UPGRADEDIR/crowbar-shutdown-services-before-upgrade-failed
+
 <% if @nova_controller && (!@use_ha || @cluster_founder) %>
 # Remove nova-cert service which has been deprecated in Newton and is not present in Pike
 
@@ -50,16 +59,16 @@ for type in clone ms primitive; do
     do
         log "Stopping resource $resource"
         crm --force --wait resource stop $resource
+        ret=$?
+        if [ $ret != 0 ] ; then
+          log "Error occured during stopping resource $resource."
+          echo $ret > $UPGRADEDIR/crowbar-shutdown-services-before-upgrade-failed
+          exit $ret
+        fi
     done
 done
 
 <% end %>
-
-# stop cinder-volume at all nodes so the service could be removed from the database later
-if test -e /usr/sbin/rcopenstack-cinder-volume; then
-    log "Stopping cinder-volume service"
-    /usr/sbin/rcopenstack-cinder-volume stop
-fi
 
 <% else %>
 
@@ -80,4 +89,5 @@ done
 
 <% end %>
 
+touch $UPGRADEDIR/crowbar-shutdown-services-before-upgrade-ok
 log "$BASH_SOURCE is finished."

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -874,7 +874,7 @@ module Api
           "post-upgrade",
           "chef-upgraded"
         ].map { |f| "/usr/sbin/crowbar-#{f}.sh" }.join(" ")
-        scripts_to_delete << "/etc/neutron/lbaas-connection.conf"
+        scripts_to_delete << " /etc/neutron/lbaas-connection.conf"
         node.run_ssh_cmd("rm -f #{scripts_to_delete}")
       end
 

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -953,13 +953,11 @@ class Node < ChefObject
     out[:exit_code].zero?
   end
 
-  def shutdown_services_before_upgrade
+  def set_pre_upgrade_attribute
     if @node.roles.include?("pacemaker-cluster-member")
       # For all nodes in cluster, set the pre-upgrade attribute
       ssh_cmd("crm node attribute $(hostname) set pre-upgrade true")
     end
-    # Initiate the shutdown of services at each node
-    ssh_cmd("/usr/sbin/crowbar-shutdown-services-before-upgrade.sh")
   end
 
   def net_rpc_cmd(cmd)

--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -26,6 +26,7 @@ module Crowbar
         pre_upgrade: @timeouts_config[:pre_upgrade] || 300,
         upgrade_os: @timeouts_config[:upgrade_os] || 1500,
         post_upgrade: @timeouts_config[:post_upgrade] || 600,
+        shutdown_services: @timeouts_config[:shitdown_services] || 600,
         evacuate_host: @timeouts_config[:evacuate_host] || 300,
         chef_upgraded: @timeouts_config[:chef_upgraded] || 1200,
         router_migration: @timeouts_config[:router_migration] || 600,

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -84,6 +84,7 @@ describe Api::UpgradeController, type: :request do
         :prepare_nodes_for_os_upgrade
       ).and_return(true)
       allow_any_instance_of(Node).to receive(:ssh_cmd).and_return([200, {}])
+      allow(Api::Upgrade).to receive(:execute_scripts_and_wait_for_finish).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:start_step).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -169,24 +169,13 @@ describe Api::Upgrade do
         )
       )
       allow_any_instance_of(Node).to(
-        receive(:shutdown_services_before_upgrade).
-        and_return([200, ""])
+        receive(:set_pre_upgrade_attribute).and_return([200, ""])
       )
+      allow(Api::Upgrade).to receive(:execute_scripts_and_wait_for_finish).and_return(true)
+
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :end_step
       ).and_return(true)
-      allow_any_instance_of(Node).to(
-        receive(:wait_for_script_to_finish).with(
-          "/usr/sbin/crowbar-delete-cinder-services-before-upgrade.sh",
-          ::Crowbar::UpgradeTimeouts.new.values[:delete_cinder_services]
-        ).and_return(true)
-      )
-      allow(Api::Crowbar).to(
-        receive(:health_check).and_return({})
-      )
-      allow(Api::Crowbar).to(
-        receive(:compute_status).and_return({})
-      )
 
       expect(subject.class.services_without_delay).to be true
     end


### PR DESCRIPTION
The script was executed in the background and we did not wait for
it to finish. As a result, other scripts were started before this one was done.