### PR TITLE
upgrade: Do not allow cinder-volume on compute nodes

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -178,6 +178,7 @@ module Api
         # Make sure nova compute role is not mixed with a controller roles
         conflicting_roles = [
           "cinder-controller",
+          "cinder-volume",
           "glance-server",
           "keystone-server",
           "neutron-server",

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -180,7 +180,7 @@ describe Api::Crowbar do
 
       allow(Node).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
       allow_any_instance_of(Node).to(
-        receive(:roles).and_return(["nova-compute-kvm", "cinder-volume", "swift-storage"])
+        receive(:roles).and_return(["nova-compute-kvm", "swift-storage"])
       )
 
       expect(subject.class.ha_config_check).to eq({})
@@ -197,25 +197,18 @@ describe Api::Crowbar do
     end
 
     it "fails when controller role is deployed to compute node" do
-      allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
-      allow_any_instance_of(NodeObject).to(
-        receive(:roles).and_return(["nova-compute-kvm", "cinder-volume", "swift-storage"])
-      )
-
-      expect(subject.class.ha_config_check).to eq({})
-    end
-
-    it "fails when controller role is deployed to compute node" do
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-kvm").and_return([node]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
-          ["cinder-controller", "nova-compute-kvm", "neutron-server"]
+          ["cinder-controller", "nova-compute-kvm", "neutron-server", "cinder-volume"]
         )
       )
 
       expect(subject.class.ha_config_check).to eq(
-        role_conflicts: { "testing.crowbar.com" => ["cinder-controller", "neutron-server"] }
+        role_conflicts: {
+          "testing.crowbar.com" => ["cinder-controller", "neutron-server", "cinder-volume"]
+        }
       )
     end
 


### PR DESCRIPTION
Compute nodes need to work even when they are not upgraded
(for live-migration from Newton-based node to Pike-based one).

But cinder has to be fully upgraded everywhere. So we extend
the upgrade prechecks to make sure cinder services are not running
on compute nodes.

(cherry picked from commit ee8fa8252c8c4d90827d50357c7d141c46ca55b7)

Forward port of https://github.com/crowbar/crowbar-core/pull/1612