### PR TITLE
upgrade: Add a validation check for postponed nodes.

### DIFF
--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -34,6 +34,10 @@ class ApplicationController < ActionController::Base
     Rails.env.test?
   }
   before_filter :upgrade, if: proc {
+    if File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-compute-nodes-postponed")
+      flash[:warning] = "Some nodes are not upgraded yet. " \
+        "Continue to <a href='/upgrade'>upgrade wizard</a> to complete the upgrade."
+    end
     File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-running") &&
       !File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-compute-nodes-postponed")
   }


### PR DESCRIPTION
- When the upgrade is not finished, show a link to wizard.
- Add a validation check to make sure postponed nodes can be skipped.
- Let skip_unready_nodes skip also nodes that are in crowbar_upgrade state 

https://jira.prv.suse.net/browse/SCRD-3745