### PR TITLE
upgrade: Reset RabbitMQ nodes during upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -150,6 +150,9 @@ template "/usr/sbin/crowbar-pre-upgrade.sh" do
   )
 end
 
+rabbitmq_servers = search(:node, "run_list_map:rabbitmq-server")
+use_rabbitmq_cluster = rabbitmq_servers.first[:rabbitmq][:cluster]
+mnesia_dir = rabbitmq_servers.first[:rabbitmq][:mnesiadir] || "/var/lib/rabbitmq/mnesia"
 template "/usr/sbin/crowbar-delete-pacemaker-resources.sh" do
   source "crowbar-delete-pacemaker-resources.sh.erb"
   mode "0755"
@@ -157,6 +160,9 @@ template "/usr/sbin/crowbar-delete-pacemaker-resources.sh" do
   group "root"
   action :create
   variables(
+    use_rabbitmq_cluster: use_rabbitmq_cluster,
+    mnesia_dir: mnesia_dir,
+    rabbitmq_nodes: rabbitmq_servers.map { |node| node["hostname"] },
     use_ha: use_ha
   )
 end

--- a/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
@@ -70,6 +70,20 @@ if [ $ret != 0 ] ; then
     exit $ret
 fi
 
+<% if @use_rabbitmq_cluster %>
+log "Resetting rabbitmq cluster..."
+# Reset the nodes in rabbitmq cluster to avoid ordering problems when cluster is re-built.
+# Re-synchronization of cluster can take a long time and include some restarts which can lead
+# to temporary service unavailability and confusing error messages in logs.
+# We could use rabbitmqctl force_reset here but it is less reliable in this case as it requires
+# rabbitmq to be (partially) running which can be hard to ensure.
+for node in <%= @rabbitmq_nodes.join(" ") %>; do
+    ssh $node rm -rf <%= @mnesia_dir %>
+done
+<% end %>
+
+
+
 <% else %>
 
 log "No HA setup found..."


### PR DESCRIPTION
RabbitMQ requires re-start of cluster to be started from former master
node or multiple resets are needed before sync status is reached.
It is easier to just reset the nodes before stopping the cluster and
start from scratch with new one after upgrade.

This can help avoid problems when someone tries to use not-yet-ready
RabbitMQ cluster immediately after controllers upgrade. It also
prevents some confusing error messages in logs.