### PR TITLE
upgrade: Save the information which set of nodes should be upgraded

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -182,6 +182,7 @@ class Api::UpgradeController < ApiController
             (substep == :compute_nodes && status == :node_finished)
           ::Crowbar::UpgradeStatus.new.start_step(:nodes)
         end
+        ::Crowbar::UpgradeStatus.new.save_nodes_selected_for_upgrade(component)
       else
         # At this point params[:component] should be a node, if it is not,
         # raise an error.

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -65,7 +65,8 @@ module Crowbar
         suggested_upgrade_mode: nil,
         selected_upgrade_mode: nil,
         # if upgrade of compute nodes has been postponed
-        compute_nodes_postponed: false
+        compute_nodes_postponed: false,
+        nodes_selected_for_upgrade: nil
       }
       # in 'steps', we save the information about each step that was executed
       @progress[:steps] = upgrade_steps_7_8.map do |step|
@@ -236,6 +237,14 @@ module Crowbar
       ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
         load_while_locked
         progress[:openstack_backup] = backup_location
+        save
+      end
+    end
+
+    def save_nodes_selected_for_upgrade(selected)
+      ::Crowbar::Lock::LocalBlocking.with_lock(shared: false, logger: @logger, path: lock_path) do
+        load_while_locked
+        progress[:nodes_selected_for_upgrade] = selected
         save
       end
     end

--- a/crowbar_framework/spec/fixtures/upgrade_status.json
+++ b/crowbar_framework/spec/fixtures/upgrade_status.json
@@ -11,6 +11,7 @@
   "suggested_upgrade_mode": null,
   "selected_upgrade_mode": null,
   "compute_nodes_postponed": false,
+  "nodes_selected_for_upgrade": null,
   "steps":{
     "prechecks":{
       "status":"pending"

--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -32,6 +32,7 @@ describe Crowbar::UpgradeStatus do
   let(:current_action) { "os-upgrade" }
   let(:crowbar_backup) { "/var/lib/crowbar.tgz" }
   let(:openstack_backup) { "/var/lib/openstack.tgz" }
+  let(:all_nodes) { "all" }
 
   context "with a status file that does not exist" do
     it "ensures the default initial values are correct" do
@@ -380,6 +381,12 @@ describe Crowbar::UpgradeStatus do
       expect { subject.save_selected_upgrade_mode(:normal) }.to raise_error(
         Crowbar::Error::SaveUpgradeModeError
       )
+    end
+
+    it "checks and changes nodes for upgrade" do
+      expect(subject.progress[:nodes_selected_for_upgrade]).to be nil
+      expect(subject.save_nodes_selected_for_upgrade(all_nodes)).to be true
+      expect(subject.progress[:nodes_selected_for_upgrade]).to be all_nodes
     end
 
     it "postpones and resumes compute node upgrade" do


### PR DESCRIPTION
This could be important for showing the correct status in the UI.
