### PR TITLE
[4.0] upgrade: Do not allow manila-share on compute nodes

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -191,6 +191,7 @@ module Api
           "heat-server",
           "horizon-server",
           "manila-server",
+          "manila-share",
           "trove-server"
         ]
         ret = {}


### PR DESCRIPTION
Non-disruptive upgrade cannot have manila shares on compute nodes.
It seems upgraded (Pike based) control plane cannot communicate with
old (Newton based) shares on (still not upgraded) compute nodes.
