### PR TITLE
[4.0] upgrade: Raise the default timeouts for most time consuming actions

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -24,10 +24,10 @@ module Crowbar
       {
         prepare_repositories: @timeouts_config[:prepare_repositories] || 120,
         pre_upgrade: @timeouts_config[:pre_upgrade] || 300,
-        upgrade_os: @timeouts_config[:upgrade_os] || 900,
+        upgrade_os: @timeouts_config[:upgrade_os] || 1500,
         post_upgrade: @timeouts_config[:post_upgrade] || 600,
         evacuate_host: @timeouts_config[:evacuate_host] || 300,
-        chef_upgraded: @timeouts_config[:chef_upgraded] || 900,
+        chef_upgraded: @timeouts_config[:chef_upgraded] || 1200,
         router_migration: @timeouts_config[:router_migration] || 600,
         lbaas_evacuation: @timeouts_config[:lbaas_evacuation] || 600,
         delete_pacemaker_resources: @timeouts_config[:delete_pacemaker_resources] || 300,


### PR DESCRIPTION
Latest jobs have been failing because of timeout during OS upgrade.

(cherry picked from commit 50a68a5901e9fae09a9c58bb245f58d87c1f331b)

Backport of https://github.com/crowbar/crowbar-core/pull/1576