### PR TITLE
upgrade: Refresh repos before crowbar-ui update (bsc#1099392)

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1507,6 +1507,13 @@ module Api
             "Please re-try current step to finalize the upgrade."
           )
         end
+        zypper_refresh = run_cmd("sudo zypper-retry -n refresh")
+        unless zypper_refresh[:exit_code].zero?
+          raise_node_upgrade_error(
+            "Refreshing repos for crowbar-ui update has failed. " \
+            "Please re-try current step to finalize the upgrade."
+          )
+        end
         ui_update = run_cmd("sudo zypper-retry -n update crowbar-ui")
         unless ui_update[:exit_code].zero?
           raise_node_upgrade_error(


### PR DESCRIPTION
After removing crowbar-ui package lock, new version needs to be installed.
Additional `zypper ref` call was added to ensure repos are up to date before
installation.