### PR TITLE
dns: Remove duplicate records check for dns barclamp

### DIFF
--- a/crowbar_framework/app/views/barclamp/dns/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/dns/_edit_attributes.html.haml
@@ -46,7 +46,7 @@
       .alert.alert-info
         = t('.records_hint')
 
-      %table.table.table-middle{ "data-dynamic" => "#record-entries", "data-namespace" => "records", "data-optional" => "", "data-invalid" => t(".record_invalid"), "data-duplicate" => t(".record_duplicate") }
+      %table.table.table-middle{ "data-dynamic" => "#record-entries", "data-namespace" => "records", "data-optional" => "", "data-invalid" => t(".record_invalid") }
         %thead
           %tr
             %th.col-sm-3

--- a/crowbar_framework/config/locales/dns/en.yml
+++ b/crowbar_framework/config/locales/dns/en.yml
@@ -40,7 +40,6 @@ en:
         record_add: 'Add'
         record_remove: 'Remove'
         record_invalid: 'Name and IP Addresses must not be empty!'
-        record_duplicate: 'There is already a record for this name defined!'
         no_records: 'Currently there are no records defined'
         records_hint: 'Do not forget the trailing dot in the aliased domain if it is a fully qualified domain name.'
       validation:


### PR DESCRIPTION
It is valid to set the same hostname for multiple "A" records,
so we should allow it.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
