### PR TITLE
[4.0] apache: copytruncate apache logs bsc#1083093

### DIFF
--- a/chef/cookbooks/apache2/templates/default/apache.logrotate.erb
+++ b/chef/cookbooks/apache2/templates/default/apache.logrotate.erb
@@ -1,15 +1,11 @@
 /var/log/apache2/*.log {
     compress
+    copytruncate
     dateext
     maxage 365
     rotate 99
     size=+4096k
     notifempty
     missingok
-    create 644 root root
     sharedscripts
-    postrotate
-     systemctl reload apache2.service
-     sleep 60
-    endscript
 }


### PR DESCRIPTION
apache2 reload causes responses 406 from keystone. Remove the reload
and copytruncate instead.

(cherry picked from commit bcc0f77cde6f83b25b1770b40da38d845e30e1d7)

Backport-of: https://github.com/crowbar/crowbar-core/pull/1508
