### PR TITLE
bind: Allow new zones configured via rndc

### DIFF
--- a/chef/cookbooks/bind9/templates/default/named.conf.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.erb
@@ -41,9 +41,11 @@ options {
         auth-nxdomain no;    # conform to RFC1035
         listen-on { <%= @ipaddress %>; };
         listen-on-v6 { <%= @ip6address %>; };
+        minimal-responses yes;
+        allow-new-zones yes;
 };
 
 include "/etc/bind/named.conf.default-zones";
 include "/etc/bind/named.conf.crowbar";
 include "/etc/bind/named.conf.local";
-
+include "/etc/named.d/rndc-access.conf";


### PR DESCRIPTION
This is a precondition for using rndc to manage bind and also
enables designate integration. Enabling it should not be harmful
as it listens to localhost only and requires a shared secred
from (/etc/rndc.key) to be available to both the client and the server
for proper communication. And that file is only readable by root.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
