### PR TITLE
[4.0] Fix exception handling in get_log_lines

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1851,8 +1851,8 @@ class ServiceObject
       "Most recent logged lines from the Chef run: \n\n<pre>" +
         logged_lines.join + "</pre>"
     rescue
-      Rails.logger.error("Error reporting: Couldn't open /var/log/crowbar/chef-client/#{pid}.log ")
-      raise "Error reporting: Couldn't open  /var/log/crowbar/chef-client/#{pid}.log"
+      Rails.logger.error("Error reporting: Couldn't open /var/log/crowbar/chef-client/#{node}.log ")
+      raise "Error reporting: Couldn't open  /var/log/crowbar/chef-client/#{node}.log"
     end
   end
 


### PR DESCRIPTION
Error message was referencing pid.log file which is no longer used
since commit fda8ea9c187daaf3a3bbd1c8da4ffa3c17a06981

(cherry picked from commit 10b00fb0ab411e4ffdfb19ee7ee79bd6149cfcef)

Backport of https://github.com/crowbar/crowbar-core/pull/1632