### PR TITLE
bind: Disable listening on IPv6 addresses for now

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -371,6 +371,9 @@ if node["crowbar"]["admin_node"] && ::File.exist?("/var/lib/crowbar/install/disa
   end
 end
 
+### FIXME Change to "any" once IPv6 support has been implemented
+admin_addr6 = "none"
+
 # Rewrite our default configuration file
 template "/etc/bind/named.conf" do
   source "named.conf.erb"
@@ -379,7 +382,8 @@ template "/etc/bind/named.conf" do
   group bindgroup
   variables(forwarders: node[:dns][:forwarders],
             allow_transfer: allow_transfer,
-            ipaddress: admin_addr)
+            ipaddress: admin_addr,
+            ip6address: admin_addr6)
   notifies :restart, "service[bind9]", :immediately
 end
 

--- a/chef/cookbooks/bind9/templates/default/named.conf.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.erb
@@ -40,6 +40,7 @@ options {
 <% end -%>
         auth-nxdomain no;    # conform to RFC1035
         listen-on { <%= @ipaddress %>; };
+        listen-on-v6 { <%= @ip6address %>; };
 };
 
 include "/etc/bind/named.conf.default-zones";


### PR DESCRIPTION
The newer bind version in SLE12 SP4 enables listening on IPv6
by default, however we can't deal with that yet. disable it
so that we can bootstrap crowbar.

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**
