### PR TITLE
[5.0] upgrade: disable clone_stateless_services on upgrade

### DIFF
--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -342,6 +342,16 @@ class CrowbarService < ServiceObject
       prop.save
     end
 
+    # change pacemaker setting to not use pacemaker for stateless services
+    pacemaker_proposals = Proposal.all.where(barclamp: "pacemaker")
+    pacemaker_proposals.each do |proposal|
+      role = proposal.role
+      proposal.raw_data["attributes"]["pacemaker"]["clone_stateless_services"] = false
+      role.default_attributes["pacemaker"]["clone_stateless_services"] = false
+      role.save
+      proposal.save
+    end
+
     # unset `db_synced` flag for OpenStack components
     ::Openstack::Upgrade.unset_db_synced
 


### PR DESCRIPTION
clone_stateless_services was introduced in order to not use pacemaker
for stateless services[0]

This alleviates the chef run as those resources do not need to be
checked/set and also they dont need any features that pacemaker
provides.

This is set as default false for new installs but if we are
upgrading we maintain the old style of having pacemaker
manage everything.
This makes no sense because during upgrade we remove all
resources so we can take advantage of that and move to the
new style which is simpler.

This also fixes some of the upgrade jobs that were failing after
the upgrade as the chef run was hitting the 900s time limit
during the "change keystone password test" by making the chef
runs shorter as we dont check/set that many pacemaker resources.

[0] https://github.com/crowbar/crowbar-ha/commit/ada1d41565c6a08a3d499f141fae7cb5c45fd052

(cherry picked from commit 9f7d4916d02c288627adde8cb7d205cb43303efe)

Backport of https://github.com/crowbar/crowbar-core/pull/1639