### PR TITLE
upgrade: Show the grep result when checking for not-migrated instances

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
@@ -64,7 +64,7 @@ if ! nova --insecure host-evacuate-live "$host" $blockmigrate; then
     exit 2
 fi
 
-while nova --insecure list --all-tenants --host "$host" --fields host,status 2>/dev/null | grep -e ACTIVE -e MIGRATING | grep -q "$host"; do
+while nova --insecure list --all-tenants --host "$host" --fields host,status 2>/dev/null | grep -e ACTIVE -e MIGRATING | grep "$host"; do
     log "There is still some VM running at $host..."
     sleep 10
 done


### PR DESCRIPTION
When debugging problems it is more useful if the grep results
are not hidden.

(cherry picked from commit 0011d10a5dd3ef57fc02abe1813d4853fa3a5a85)


backport of https://github.com/crowbar/crowbar-core/pull/1637