### PR TITLE
[4.0] Update sprockets to 2.12.5 (bsc#1098369, CVE-2018-3760)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ group :development do
   gem "uglifier", "~> 2.7.2"
   gem "sass", "~> 3.4.13"
   gem "sprockets-standalone", "~> 1.2.1"
-  gem "sprockets", "~> 2.11.0"
+  gem "sprockets", "~> 2.12.5"
   gem "rspec", "~> 3.1.0"
 end
 


### PR DESCRIPTION
(cherry picked from commit 41341a3ba932b730755e9bf756d4780c408a685b)

Backport from #1620 
