### PR TITLE
[5.0] upgrade: disable network agents during upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -175,6 +175,14 @@ template "/usr/sbin/crowbar-router-migration.sh" do
   action :create
 end
 
+template "/usr/sbin/crowbar-set-network-agents-state.sh" do
+  source "crowbar-set-network-agents-state.sh.erb"
+  mode "0755"
+  owner "root"
+  group "root"
+  action :create
+end
+
 neutron_server = search(:node, "run_list_map:neutron-server").first
 template "/etc/neutron/lbaas-connection.conf" do
   source "lbaas-connection.conf"

--- a/chef/cookbooks/crowbar/templates/default/crowbar-set-network-agents-state.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-set-network-agents-state.sh.erb
@@ -1,0 +1,64 @@
+#!/bin/bash
+#
+# This script disables the l3, dhcp and l2 neutron agents on a certain
+# network node to avoid neutron to schedule any resource to this node
+# while it is being upgraded. After the upgrade completed the agents need
+# to be enabled again.
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+hostname=$1
+mode=$2
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-set-network-agents-state-failed
+
+agent_order="dhcp l3 openvswitch linuxbridge"
+# Enable in the reverse order of disabling (e.g. l2-agents should to be
+# active before l3 and dhcp)
+if [[ "$mode" = "enable" ]]; then
+    agent_order="linuxbridge openvswitch l3 dhcp"
+elif [[ "$mode" != "disable" ]]; then
+    echo "Invalid mode \"$mode\" for crowbar-set-network-agents-state."
+    echo 255 > $UPGRADEDIR/crowbar-set-network-agents-state-failed
+    exit 255
+fi
+
+set +x
+source /root/.openrc
+set -x
+
+for agenttype in $agent_order; do
+    # Using "neutron" here as the "openstack" client doesn't support
+    # listing agents by type in Newton (got added with later versions)
+    id=$(/usr/bin/neutron --insecure agent-list --binary neutron-$agenttype-agent --host $hostname -c id -f value)
+    if [ -n "$id" ]; then
+        log "Setting state of $agenttype agent ($id) on node $hostname to $mode"
+        /usr/bin/openstack --insecure network agent set --$mode $id
+        ret=$?
+        if [ $ret != 0 ] ; then
+            echo "Failed to set state of $agenttype agent ($id) on host: $hostname"
+            echo $ret > $UPGRADEDIR/crowbar-set-network-agents-state-failed
+            exit $ret
+        fi
+    else
+        log "Node $hostname doesn't run $agenttype."
+    fi
+done
+
+touch $UPGRADEDIR/crowbar-set-network-agents-state-ok
+log "$BASH_SOURCE is finished."

--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -31,6 +31,7 @@ module Crowbar
         chef_upgraded: @timeouts_config[:chef_upgraded] || 1200,
         router_migration: @timeouts_config[:router_migration] || 600,
         lbaas_evacuation: @timeouts_config[:lbaas_evacuation] || 600,
+        set_network_agents_state: @timeouts_config[:set_network_agents_state] || 300,
         delete_pacemaker_resources: @timeouts_config[:delete_pacemaker_resources] || 600,
         delete_cinder_services: @timeouts_config[:delete_cinder_services] || 300,
         wait_until_compute_started: @timeouts_config[:wait_until_compute_started] || 60


### PR DESCRIPTION
As a workaround for https://bugs.launchpad.net/neutron/+bug/1780453 we
are now setting the "ADMIN_STATE_UP" attribute to "down" before
upgrading a (network)-node. The attribute is reset to "up" after the
node was successfully upgrade and all services are running again. This
should e.g. avoid neutron/neutron-dhcp-agent to try to bring up e.g. a
dhcp port on a node where the Layer 2 agent (openvswitch-/linuxbridge-agent)
is not fully up yet.

(cherry picked from commit 2c85bc90d38c6b65d09ce83dfb9a1ad5a32eba10)
