### PR TITLE
[5.0] upgrade: Port openstack db backup to mysql

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -484,6 +484,9 @@ module Api
           ::Crowbar::UpgradeStatus.new.end_step
           return
         end
+        # Note: Trying to (gu)estimate the size of the (compressed) database
+        #       SQL dump from the sizes report via the below query is probably a
+        #       bit far fetched. Is there a more realistic way for this?
         query = "SELECT SUM(pg_database_size(pg_database.datname)) FROM pg_database;"
         cmd = "PGPASSWORD=#{psql[:pass]} psql -t -h #{psql[:host]} -U #{psql[:user]} -c '#{query}'"
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -477,27 +477,34 @@ module Api
           return
         end
 
-        psql = postgres_params
-        if psql.nil?
+        db_node = openstack_db_node
+        if db_node.nil?
           # This can happen if only the crowbar node was deployed and will be upgraded
           Rails.logger.warn("Can not get database parameters for OpenStack backup. Skipping...")
           ::Crowbar::UpgradeStatus.new.end_step
           return
         end
+
+        db_user = "root"
+        db_password = db_node["database"]["mysql"]["server_root_password"]
+
         # Note: Trying to (gu)estimate the size of the (compressed) database
         #       SQL dump from the sizes report via the below query is probably a
         #       bit far fetched. Is there a more realistic way for this?
-        query = "SELECT SUM(pg_database_size(pg_database.datname)) FROM pg_database;"
-        cmd = "PGPASSWORD=#{psql[:pass]} psql -t -h #{psql[:host]} -U #{psql[:user]} -c '#{query}'"
-
+        size_query = "SELECT SUM(data_length + index_length) FROM information_schema.tables ;"
+        cmd = "echo \"#{size_query}\" | mysql -N -u #{db_user} -p#{db_password}"
         Rails.logger.debug("Checking size of OpenStack database")
-        db_size = run_cmd(cmd)
+        # Note: We need to run this on a database node since the mysql root
+        #       user doesn't have remote access to the mysql server.
+        db_size = db_node.run_ssh_cmd(cmd, "60s")
         unless db_size[:exit_code].zero?
           Rails.logger.error(
-            "Failed to check size of OpenStack database: #{db_size[:stdout_and_stderr]}"
+            "Failed to check size of OpenStack database: \n" \
+            "    stdout: #{db_size[:stdout]} \n" \
+            "    stderr: #{db_size[:stderr]}"
           )
           raise ::Crowbar::Error::Upgrade::DatabaseSizeError.new(
-            db_size[:stdout_and_stderr]
+            "stdout: #{db_size[:stdout]}\n stderr:#{db_size[:stderr]}"
           )
         end
 
@@ -510,15 +517,20 @@ module Api
             free_space[:stdout_and_stderr]
           )
         end
-        if free_space[:stdout_and_stderr].strip.to_i < db_size[:stdout_and_stderr].strip.to_i
+        if free_space[:stdout_and_stderr].strip.to_i < db_size[:stdout].strip.to_i
           Rails.logger.error("Not enough free disk space to create the OpenStack database dump")
           raise ::Crowbar::Error::Upgrade::NotEnoughDiskSpaceError.new("#{crowbar_lib_dir}/backup")
         end
 
         Rails.logger.debug("Creating OpenStack database dump")
-        db_dump = run_cmd(
-          "PGPASSWORD=#{psql[:pass]} pg_dumpall -h #{psql[:host]} -U #{psql[:user]} | " \
-            "gzip > #{dump_path}"
+
+        # Note: We need to run this on a database node since the mysql root user
+        #       doesn't have remote access to the mysql server. But we can't
+        #       use Node.run_ssh_cmd here because we want to redirect to a file
+        #       on the crowbar node.
+        db_dump = run_cmd("sudo ssh -o ConnectTimeout=10 root@#{db_node.name} " \
+                          "\'mysqldump -u #{db_user} -p#{db_password} --all-databases | gzip\' " \
+                          "> #{dump_path}"
         )
         unless db_dump[:exit_code].zero?
           Rails.logger.error(
@@ -1731,17 +1743,13 @@ module Api
       #
       # openstackbackup helpers
       #
-      def postgres_params
+      def openstack_db_node
         db_node = ::Node.find("roles:database-config-default").first
         if db_node.nil?
           Rails.logger.warn("No node with role 'database-config-default' found")
           return nil
         end
-        {
-          user: "postgres",
-          pass: db_node[:postgresql][:password][:postgres],
-          host: db_node[:postgresql].config[:listen_addresses]
-        }
+        db_node
       end
 
       #

--- a/crowbar_framework/spec/fixtures/offline_chef/node_testing.crowbar.com.json
+++ b/crowbar_framework/spec/fixtures/offline_chef/node_testing.crowbar.com.json
@@ -27,7 +27,10 @@
       "use_migration": true
     },
     "database": {
-      "sql_engine": "mysql"
+      "sql_engine": "mysql",
+      "mysql": {
+          "server_root_password": "secret"
+      }
     }
   },
   "name": "testing.crowbar.com",

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -1059,12 +1059,25 @@ describe Api::Upgrade do
   end
 
   context "with a successful backup creation for OpenStack" do
+    let(:size_query) { "SELECT SUM(data_length + index_length) FROM information_schema.tables ;" }
+    let(:size_cmd) { "echo \"#{size_query}\" | mysql -N -u root -psecret" }
+    let(:db_node) do
+      Node.find_by_name("testing.crowbar.com")
+    end
+
     it "creates a backup for OpenStack" do
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :start_step
       ).with(:backup_openstack).and_return(true)
       allow(::Node).to receive(:find).with("roles:database-config-default").and_return(
-        [::Node.find_by_name("testing.crowbar.com")]
+        [db_node]
+      )
+      allow(db_node).to receive(:run_ssh_cmd).with(
+        size_cmd,
+        "60s"
+      ).and_return(
+        exit_code: 0,
+        stdout: "12345678"
       )
       allow(File).to receive(:exist?).with(
         "/var/lib/crowbar/backup/7-to-8-openstack_dump.sql.gz"
@@ -1072,11 +1085,6 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to receive(:run_cmd).and_return(
         exit_code: 0,
         stdout_and_stderr: ""
-      )
-      allow(Api::Upgrade).to receive(:postgres_params).and_return(
-        user: "postgres",
-        pass: "password",
-        host: "8.8.8.8"
       )
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :end_step
@@ -1103,13 +1111,18 @@ describe Api::Upgrade do
   context "with a failed backup creation for OpenStack" do
     let(:crowbar_lib_dir) { "/var/lib/crowbar" }
     let(:dump_path) { "#{crowbar_lib_dir}/backup/7-to-8-openstack_dump.sql.gz" }
-    let(:query) { "SELECT SUM(pg_database_size(pg_database.datname)) FROM pg_database;" }
-    let(:size_cmd) { "PGPASSWORD=password psql -t -h 8.8.8.8 -U postgres -c '#{query}'" }
+    let(:size_query) { "SELECT SUM(data_length + index_length) FROM information_schema.tables ;" }
+    let(:size_cmd) { "echo \"#{size_query}\" | mysql -N -u root -psecret" }
     let(:dump_cmd) do
-      "PGPASSWORD=password pg_dumpall -h 8.8.8.8 -U postgres | gzip > #{dump_path}"
+      "sudo ssh -o ConnectTimeout=10 root@testing.crowbar.com " \
+      "\'mysqldump -u root -psecret --all-databases | gzip\' " \
+      "> #{dump_path}"
     end
     let(:disk_space_cmd) do
       "LANG=C df -x 'tmpfs' -x 'devtmpfs' -B1 -l --output='avail' #{crowbar_lib_dir} | tail -n1"
+    end
+    let(:db_node) do
+      Node.find_by_name("testing.crowbar.com")
     end
 
     it "fails to create a backup for OpenStack" do
@@ -1117,19 +1130,15 @@ describe Api::Upgrade do
         :start_step
       ).with(:backup_openstack).and_return(true)
       allow(::Node).to receive(:find).with("roles:database-config-default").and_return(
-        [::Node.find_by_name("testing.crowbar.com")]
+        [db_node]
       )
       allow(File).to receive(:exist?).with(dump_path).and_return(false)
-      allow(Api::Upgrade).to receive(:postgres_params).and_return(
-        user: "postgres",
-        pass: "password",
-        host: "8.8.8.8"
-      )
-      allow(Api::Upgrade).to receive(:run_cmd).with(
-        size_cmd
+      allow(db_node).to receive(:run_ssh_cmd).with(
+        size_cmd,
+        "60s"
       ).and_return(
         exit_code: 0,
-        stdout_and_stderr: ""
+        stdout: "12345678"
       )
       allow(Api::Upgrade).to receive(:run_cmd).with(
         disk_space_cmd
@@ -1155,17 +1164,16 @@ describe Api::Upgrade do
         :start_step
       ).with(:backup_openstack).and_return(true)
       allow(::Node).to receive(:find).with("roles:database-config-default").and_return(
-        [::Node.find_by_name("testing.crowbar.com")]
+        [db_node]
       )
       allow(File).to receive(:exist?).with(dump_path).and_return(false)
-      allow(Api::Upgrade).to receive(:postgres_params).and_return(
-        user: "postgres",
-        pass: "password",
-        host: "8.8.8.8"
-      )
-      allow(Api::Upgrade).to receive(:run_cmd).with(size_cmd).and_return(
+      allow(db_node).to receive(:run_ssh_cmd).with(
+        size_cmd,
+        "60s"
+      ).and_return(
         exit_code: 1,
-        stdout_and_stderr: "Error"
+        stdout: "12345678",
+        stderr: "Error"
       )
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :end_step
@@ -1179,23 +1187,19 @@ describe Api::Upgrade do
         :start_step
       ).with(:backup_openstack).and_return(true)
       allow(::Node).to receive(:find).with("roles:database-config-default").and_return(
-        [::Node.find_by_name("testing.crowbar.com")]
+        [db_node]
       )
       allow(File).to receive(:exist?).with(dump_path).and_return(false)
-      allow(Api::Upgrade).to receive(:postgres_params).and_return(
-        user: "postgres",
-        pass: "password",
-        host: "8.8.8.8"
-      )
       allow(Api::Upgrade).to receive(:run_cmd).with(disk_space_cmd).and_return(
         exit_code: 1,
         stdout_and_stderr: "Error"
       )
-      allow(Api::Upgrade).to receive(:run_cmd).with(
-        size_cmd
+      allow(db_node).to receive(:run_ssh_cmd).with(
+        size_cmd,
+        "60s"
       ).and_return(
         exit_code: 0,
-        stdout_and_stderr: ""
+        stdout: "12345678"
       )
       allow(Api::Upgrade).to receive(:run_cmd).with(
         dump_cmd
@@ -1215,17 +1219,15 @@ describe Api::Upgrade do
         :start_step
       ).with(:backup_openstack).and_return(true)
       allow(::Node).to receive(:find).with("roles:database-config-default").and_return(
-        [::Node.find_by_name("testing.crowbar.com")]
+        [db_node]
       )
       allow(File).to receive(:exist?).with(dump_path).and_return(false)
-      allow(Api::Upgrade).to receive(:postgres_params).and_return(
-        user: "postgres",
-        pass: "password",
-        host: "8.8.8.8"
-      )
-      allow(Api::Upgrade).to receive(:run_cmd).with(size_cmd).and_return(
+      allow(db_node).to receive(:run_ssh_cmd).with(
+        size_cmd,
+        "60s"
+      ).and_return(
         exit_code: 0,
-        stdout_and_stderr: "1000000"
+        stdout: "1000000"
       )
       allow(Api::Upgrade).to receive(:run_cmd).with(disk_space_cmd).and_return(
         exit_code: 0,


### PR DESCRIPTION
This was still relying on postgresql being the database backend for openstack. It went unnoticed for so long because the default values for the postgresql backend related chef attributes pointed the upgrade procedure to "localhost". So it created a dump of the admin node's database

backport of https://github.com/crowbar/crowbar-core/pull/1651