### PR TITLE
[5.0] upgrade: Remove nova-cert service after the node upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -89,8 +89,7 @@ template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   action :create
   variables(
     use_ha: use_ha || remote_node,
-    cluster_founder: is_cluster_founder,
-    nova_controller: roles.include?("nova-controller")
+    cluster_founder: is_cluster_founder
   )
 end
 
@@ -233,6 +232,7 @@ template "/usr/sbin/crowbar-chef-upgraded.sh" do
   owner "root"
   group "root"
   variables(
-    crowbar_join: "#{web_path}/crowbar_join.sh"
+    crowbar_join: "#{web_path}/crowbar_join.sh",
+    nova_controller: roles.include?("nova-controller")
   )
 end

--- a/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-chef-upgraded.sh.erb
@@ -45,5 +45,19 @@ rm -f /usr/sbin/crowbar_join_tmp
 systemctl start cron
 systemctl enable cron
 
+# Remove nova-cert service which has been deprecated in Newton and is not present in Pike
+<% if @nova_controller %>
+
+set +x
+source /root/.openrc
+set -x
+
+for id in `openstack --insecure compute service list --service nova-cert -f value -c ID`; do
+  log "Removing nova-cert service $id"
+  openstack compute service delete $id
+done
+<% end %>
+
+
 touch $UPGRADEDIR/crowbar-chef-upgraded-ok
 log "$BASH_SOURCE is finished."

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -34,19 +34,6 @@ fi
 
 rm -f $UPGRADEDIR/crowbar-shutdown-services-before-upgrade-failed
 
-<% if @nova_controller && (!@use_ha || @cluster_founder) %>
-# Remove nova-cert service which has been deprecated in Newton and is not present in Pike
-
-set +x
-source /root/.openrc
-set -x
-
-for id in `openstack --insecure compute service list --service nova-cert -f value -c ID`; do
-  log "Removing nova-cert service $id"
-  openstack compute service delete $id
-done
-<% end %>
-
 <% if @use_ha %>
 
 <% if @cluster_founder %>


### PR DESCRIPTION
nova-cert service got deprecated and needs to be removed when upgrading
to Pike. Let's do the removal after the node is fully upgraded and
service's binary is not present, so its accidental (re)start does not cause
recreating deleted nova-cert.
