### PR TITLE
Bump schema revision to 300 after release

### DIFF
--- a/chef/data_bags/crowbar/migrate/crowbar/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/crowbar/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/dns/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/dns/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/ipmi/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/ipmi/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/network/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/network/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/ntp/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/ntp/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/migrate/salt/300_noop.rb
+++ b/chef/data_bags/crowbar/migrate/salt/300_noop.rb
@@ -1,0 +1,7 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-crowbar.json
+++ b/chef/data_bags/crowbar/template-crowbar.json
@@ -42,7 +42,7 @@
     "crowbar": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 300,
       "element_states": {
         "crowbar": [ "all" ],
         "crowbar-upgrade": [ "readying", "ready", "applying", "crowbar_upgrade" ]

--- a/chef/data_bags/crowbar/template-dns.json
+++ b/chef/data_bags/crowbar/template-dns.json
@@ -16,7 +16,7 @@
     "dns": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 102,
+      "schema-revision": 300,
       "element_states": {
         "dns-server": [ "readying", "ready", "applying" ],
         "dns-client": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-ipmi.json
+++ b/chef/data_bags/crowbar/template-ipmi.json
@@ -18,7 +18,7 @@
     "ipmi": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 300,
       "element_states": {
         "ipmi": [ "discovering", "hardware-installing", "readying" ],
         "bmc-nat-router": [ "readying", "ready", "applying" ],

--- a/chef/data_bags/crowbar/template-network.json
+++ b/chef/data_bags/crowbar/template-network.json
@@ -269,7 +269,7 @@
     "network": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 101,
+      "schema-revision": 300,
       "element_states": {
         "network": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-ntp.json
+++ b/chef/data_bags/crowbar/template-ntp.json
@@ -11,7 +11,7 @@
     "ntp": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 100,
+      "schema-revision": 300,
       "element_states": {
         "ntp-server": [ "readying", "ready", "applying" ],
         "ntp-client": [ "readying", "ready", "applying" ]

--- a/chef/data_bags/crowbar/template-salt.json
+++ b/chef/data_bags/crowbar/template-salt.json
@@ -9,7 +9,7 @@
     "salt": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 1,
+      "schema-revision": 300,
       "element_states": {
         "salt-ssh": [ "readying", "ready", "applying" ]
       },

--- a/chef/data_bags/crowbar/template-suse_manager_client.json
+++ b/chef/data_bags/crowbar/template-suse_manager_client.json
@@ -9,7 +9,7 @@
   "deployment": {
     "suse_manager_client": {
       "crowbar-revision": 0,
-      "schema-revision": 100,
+      "schema-revision": 300,
       "crowbar-applied": false,
       "element_states": {
         "suse-manager-client": [ "readying", "ready", "applying" ]


### PR DESCRIPTION
To give some head room for future schema migrations in the
stable/5.0-pike branch we bump the schema revision for all barclamps to
300. The migration itself is a noop it's just there to ensure the
schema-revision is increased on all existing proposals and roles (mainly
needed for future upgrades from stable/5.0-pike).
