### PR TITLE
upgrade: Allow neutron-sdn-cisco-aci-agents role on compute nodes

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -272,6 +272,7 @@ module Api
             # ceph roles are not allowed, but they are already handled by different check
             # so we treat them as OK in this one
             next if role.start_with?("ceph")
+            next if role == "neutron-sdn-cisco-aci-agents"
             r = RoleObject.find_role_by_name(role)
             next if r.proposal?
             b = r.barclamp


### PR DESCRIPTION
Nodes that are placed on compute nodes have to be explicitly allowed
for the upgrade usage, otherwise precheck will complain that such
setup is not possible to upgrade.

New neutron-sdn-cisco-aci-agents was added to 4.0 branch just recently
by commit 3e285f548fd18cc83260b8f0dc51cf18696758a8

See 
 - https://ci.suse.de/job/openstack-mkcloud/133567/console for a failed upgrade job
 - https://github.com/crowbar/crowbar-openstack/pull/1700 for the addition of a new role

If, on the other hand, it would break upgrade somehow to have such role on compute node, we must adapt the code in neutron service so it is not placed automatically on compute nodes...
