### PR TITLE
[5.0] upgrade: Adapt the rabbitmq client's config after rabbitmq setup change

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -129,6 +129,11 @@ end
 
 swift_storage = roles.include? "swift-storage"
 
+rabbitmq_server = search(:node, "run_list_map:rabbitmq-server").first
+# original DRBD setup is switched to cluster one in prepare_nodes_for_os_upgrade
+rabbitmq_cluster = rabbitmq_server[:rabbitmq][:ha][:enabled] &&
+  rabbitmq_server[:rabbitmq][:ha][:storage][:mode] == "drbd"
+
 # Following script executes all actions that are needed directly on the node
 # directly before the OS upgrade is initiated.
 template "/usr/sbin/crowbar-pre-upgrade.sh" do
@@ -145,7 +150,8 @@ template "/usr/sbin/crowbar-pre-upgrade.sh" do
     cinder_volume: cinder_volume,
     neutron_agent: neutron_agent,
     l3_agent: l3_agent,
-    metadata_agent: metadata_agent
+    metadata_agent: metadata_agent,
+    rabbitmq_cluster: rabbitmq_cluster
   )
 end
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -87,6 +87,24 @@ log "No HA setup found..."
 
 <% if @compute_node %>
 
+<% if @rabbitmq_cluster %>
+
+# update rabbitmq config for clients if it was changed
+zypper --non-interactive install crudini
+
+crudini --set /etc/neutron/neutron.conf.d/200-crowbar-upgrade.conf oslo_messaging_rabbit rabbit_ha_queues true
+crudini --set /etc/neutron/neutron.conf.d/200-crowbar-upgrade.conf oslo_messaging_rabbit amqp_durable_queues true
+
+crudini --set /etc/nova/nova.conf.d/200-crowbar-upgrade.conf oslo_messaging_rabbit rabbit_ha_queues true
+crudini --set /etc/nova/nova.conf.d/200-crowbar-upgrade.conf oslo_messaging_rabbit amqp_durable_queues true
+
+<% if @cinder_volume %>
+crudini --set /etc/cinder/cinder.conf.d/200-crowbar-upgrade.conf oslo_messaging_rabbit rabbit_ha_queues true
+crudini --set /etc/cinder/cinder.conf.d/200-crowbar-upgrade.conf oslo_messaging_rabbit amqp_durable_queues true
+<% end %>
+
+<% end %>
+
 log "Restarting services for Pike"
 
 <% unless @remote_node %>

--- a/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
@@ -137,7 +137,8 @@ initiate_node_upgrade()
 
     # Remove possibly existing temporary config files from the compute nodes
     rm -f /etc/nova/nova.conf.d/200-crowbar-upgrade.conf
-    rm -f /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf
+    rm -f /etc/neutron/neutron.conf.d/200-crowbar-upgrade.conf
+    rm -f /etc/cinder/cinder.conf.d/200-crowbar-upgrade.conf
 
     # Signalize that the upgrade correctly ended
     echo "<%= @target_platform_version %>" >> $UPGRADEDIR/crowbar-upgrade-os-ok


### PR DESCRIPTION
If rabbitmq is using DRBD in SOC7, it's switched to the clustered
setup automatically.
We need to update some configuration files on the nodes temporarily,
so that nova API works when doing live-migration (that is, before the
compute node is fully upgraded).

(cherry picked from commit 043e5aaadc43be65d3b94c0a83903eb5ce8e2d4f)
