### PR TITLE
[4.0] upgrade: New precheck added to check cluster node state

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1674,6 +1674,7 @@ module Api
         ret = {}
         crm_failures = check["crm_failures"]
         failed_actions = check["failed_actions"]
+        unready_nodes = check["unready_nodes"]
         ret[:clusters_health_crm_failures] = {
           data: crm_failures.values,
           help: I18n.t("api.upgrade.prechecks.clusters_health.crm_failures")
@@ -1682,6 +1683,12 @@ module Api
           data: failed_actions.values,
           help: I18n.t("api.upgrade.prechecks.clusters_health.failed_actions")
         } if failed_actions
+        if unready_nodes
+          ret[:clusters_health_unready_nodes] = {
+            data: unready_nodes.values,
+            help: I18n.t("api.upgrade.prechecks.clusters_health.unready_nodes")
+          }
+        end
         ret
       end
 

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -807,6 +807,7 @@ en:
         clusters_health:
           crm_failures: 'Please check that all cluster resources are online or refer to the SUSE High Availability documentation for possible troubleshooting.'
           failed_actions: 'Please clean the resource history and re−check the current state with "crm_resource -C" or refer to the SUSE High Availability documentation for possible troubleshooting.'
+          unready_nodes: 'Some pacemaker nodes are in maintenance or standby node. Make sure all nodes are online and ready.'
           help:
             default: 'Make sure clusters are healthy'
         no_resources:


### PR DESCRIPTION
The precheck is part of crowbar-ha. Here we are adding the presentation
layer.

Requires https://github.com/crowbar/crowbar-ha/pull/331