### PR TITLE
[4.0] provisioner: Skip vxlan virtual devices

### DIFF
--- a/chef/cookbooks/ohai/recipes/default.rb
+++ b/chef/cookbooks/ohai/recipes/default.rb
@@ -98,7 +98,7 @@ o.all_plugins
 node.automatic_attrs.merge! o.data
 
 # drop virtual interfaces, to not overload chef
-virtual_intfs = ["tap", "qbr", "qvo", "qvb", "brq"]
+virtual_intfs = ["tap", "qbr", "qvo", "qvb", "brq", "vxl"]
 node.automatic_attrs["network"]["interfaces"].each_key do |intf|
   if virtual_intfs.include?(intf.slice(0..2))
     node.automatic_attrs["network"]["interfaces"].delete(intf)

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -58,7 +58,7 @@ admin_ip = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin").
 web_port = node[:provisioner][:web_port]
 provisioner_web = "http://#{admin_ip}:#{web_port}"
 dhcp_hosts_dir = node["provisioner"]["dhcp_hosts"]
-virtual_intfs = ["tap", "qbr", "qvo", "qvb", "brq", "ovs"]
+virtual_intfs = ["tap", "qbr", "qvo", "qvb", "brq", "ovs", "vxl"]
 
 crowbar_node = node_search_with_cache("roles:crowbar").first
 crowbar_protocol = crowbar_node[:crowbar][:apache][:ssl] ? "https" : "http"


### PR DESCRIPTION
On a 1000+ VM installation using vxlan tunnel devices the amount
of vxlan-$id devices collected by ohai was overflowing the chef
database causing total deployment outage. Skip virtual vxlan
devices from collection and generation in dhcp list to avoid
slowdowns.

(cherry picked from commit 468b18b6d318e09353650e3d953e060673c592f7)

Please help potential reviewers to understand this pull request and speed
up the process by writing a meaningful pull request message.

Answering the following questions can help, but is optional.

**Why is this change necessary?**

**How does it address the issue?**

**Is there additional information worth sharing like links to a Trello
card, bug references, testing advice or dependencies to other pull
requests?**

Backport of #1631 