### PR TITLE
network: Limit number of openvswitch threads per port (bsc#1110865)

### DIFF
--- a/chef/cookbooks/network/attributes/default.rb
+++ b/chef/cookbooks/network/attributes/default.rb
@@ -66,3 +66,14 @@ default[:network][:ovs_module] = "openvswitch"
 # This flag be overridden on the node/role level (e.g. by the neutron
 # barclamp) to indicate that a node needs openvswitch installed and running
 default[:network][:needs_openvswitch] = false
+
+# Open vSwitch older than 2.11 is starting 2*$(nproc)*3/4 netlink sockets per
+# number of cpu cores and per port. On machines with high core
+# count (e.g. 56 or higher) this can quickly exceed the total fd
+# limit set by ovs on itself on startup of 65536.
+
+# By Limit the handler threads to 8 per port we can handle ~ 4000 ports
+# instead of just ~ 700.
+# see https://mail.openvswitch.org/pipermail/ovs-dev/2018-September/352402.html
+# see bsc#1110865
+default[:network][:ovs_max_handler_threads] = 8

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -44,6 +44,10 @@ if node[:network][:needs_openvswitch]
   s.run_action :enable
   s.run_action :start
 
+  # limit the number of handler threads to avoid exceeding
+  # hardcoded 65536 limit in the ovs-start script (bsc##1110865)
+  ::Kernel.system("ovs-vsctl set Open_vSwitch . other_config:n-handler-threads=#{node[:network][:ovs_max_handler_threads]}")
+
   # Cleanup on SLE12. Disable (NOT stop) old sysvinit service for ovs to avoid
   # issues (https://bugzilla.suse.com/show_bug.cgi?id=935912). We use the
   # (differently named) systemd unit on newer suse platforms now.


### PR DESCRIPTION
Open vSwitch older than 2.11 is starting 2*$(nproc)*3/4 netlink sockets per
number of cpu cores and per port. On machines with high core
count (e.g. 56 or higher) this can quickly exceed the total fd
limit set by ovs on itself on startup of 65536.

By Limit the handler threads to 8 per port we can handle ~ 4000 ports
instead of just ~ 700.
see https://mail.openvswitch.org/pipermail/ovs-dev/2018-September/352402.html