### PR TITLE
crowbar: move skip unready nodes out of experimental

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -694,11 +694,11 @@ class ServiceObject
   def validate_postponed_nodes(proposal)
     return unless upgrade_postponed?
 
-    skip_unready_nodes_enabled = Rails.application.config.experimental.fetch(
+    skip_unready_nodes_enabled = Rails.application.config.crowbar.fetch(
       "skip_unready_nodes", {}
     ).fetch("enabled", false)
 
-    skip_unready_nodes_roles = Rails.application.config.experimental.fetch(
+    skip_unready_nodes_roles = Rails.application.config.crowbar.fetch(
       "skip_unready_nodes", {}
     ).fetch("roles", [])
 
@@ -715,7 +715,7 @@ class ServiceObject
 
     validation_error "The upgrade of some nodes has been postponed: " +
       postponed_nodes.join(", ") + ". " \
-      "It is necessary to have 'skip_unready_nodes' experimental feature enabled for the roles " \
+      "It is necessary to have 'skip_unready_nodes' feature enabled for the roles " \
       "in this barclamp, so these nodes could be properly skipped when applying the barclamp."
   end
 
@@ -996,8 +996,7 @@ class ServiceObject
     # Cache some node attributes to avoid useless node reloads
     node_attr_cache = {}
 
-    # experimental option
-    skip_unready_nodes_enabled = Rails.application.config.experimental.fetch(
+    skip_unready_nodes_enabled = Rails.application.config.crowbar.fetch(
       "skip_unready_nodes", {}
     ).fetch("enabled", false)
 
@@ -1925,7 +1924,7 @@ class ServiceObject
 
   def skip_unready_nodes(bc, inst, new_elements, old_elements)
     logger.debug("skip_unready_nodes: enter for #{bc}:#{inst}")
-    skip_unready_nodes_roles = Rails.application.config.experimental.fetch(
+    skip_unready_nodes_roles = Rails.application.config.crowbar.fetch(
       "skip_unready_nodes", {}
     ).fetch("roles", [])
     pre_cached_nodes = {}

--- a/crowbar_framework/config/application.rb
+++ b/crowbar_framework/config/application.rb
@@ -63,6 +63,8 @@ module Crowbar
         Rails.logger.warn "Failed to load chef"
       end
     end
+    # normal options
+    config.crowbar = config_for(:crowbar)
     # experimental options
     config.experimental = config_for(:experimental)
   end

--- a/crowbar_framework/config/crowbar.yml
+++ b/crowbar_framework/config/crowbar.yml
@@ -1,0 +1,30 @@
+default: &default
+  skip_unready_nodes:
+    enabled: false
+    roles:
+    - bmc-nat-client
+    - ceilometer-agent
+    - deployer-client
+    - dns-client
+    - ipmi
+    - logging-client
+    - nova-compute-ironic
+    - nova-compute-kvm
+    - nova-compute-qemu
+    - nova-compute-vmware
+    - nova-compute-xen
+    - nova-compute-zvm
+    - ntp-client
+    - provisioner-base
+    - suse-manager-client
+    - swift-storage
+    - updater
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/crowbar_framework/config/experimental.yml
+++ b/crowbar_framework/config/experimental.yml
@@ -1,26 +1,6 @@
 default: &default
   disallow_restart:
     enabled: false
-  skip_unready_nodes:
-    enabled: false
-    roles:
-     - bmc-nat-client
-     - ceilometer-agent
-     - deployer-client
-     - dns-client
-     - ipmi
-     - logging-client
-     - nova-compute-ironic
-     - nova-compute-kvm
-     - nova-compute-qemu
-     - nova-compute-vmware
-     - nova-compute-xen
-     - nova-compute-zvm
-     - ntp-client
-     - provisioner-base
-     - suse-manager-client
-     - swift-storage
-     - updater
   skip_unchanged_nodes:
     enabled: false
 


### PR DESCRIPTION
Looks like this feature has been tested extensively on prod envs
with little to no failures so its time to move it out of the
experimental umbrella, make a normal config for it and document
it properly.

 * Creates a new config file (crowbar.yml) for normal config switches
 * Moves the config settings from the experimental to the normal config
 * Changes the calls to experimental settings to point tot he new file