### PR TITLE
repos: Fix product name to be SUSE OpenStack Cloud Crowbar for SMT

### DIFF
--- a/crowbar_framework/config/repos-cloud.yml
+++ b/crowbar_framework/config/repos-cloud.yml
@@ -40,7 +40,7 @@ suse-12.4:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP4:Update:Products:Cloud9/suse-openstack-cloud-crowbar/9/POOL/aarch64"
         fingerprint: ""
       url:
-      smt_path: "SUSE/Products/OpenStack-Cloud/9/aarch64/product"
+      smt_path: "SUSE/Products/OpenStack-Cloud-Crowbar/9/aarch64/product"
       ask_on_error: false
     suse-openstack-cloud-9-updates:
       name: "SUSE-OpenStack-Cloud-Crowbar-9-Updates"
@@ -50,7 +50,7 @@ suse-12.4:
         tag: "obsrepository://build.suse.de/SUSE:Updates:OpenStack-Cloud-Crowbar:9:aarch64/update"
         fingerprint: ""
       url:
-      smt_path: "SUSE/Updates/OpenStack-Cloud/9/aarch64/update"
+      smt_path: "SUSE/Updates/OpenStack-Cloud-Crowbar/9/aarch64/update"
       ask_on_error: false
     sle12-sp4-ha-pool:
       name: "SLE12-SP4-HA-Pool"
@@ -139,7 +139,7 @@ suse-12.4:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP4:Update:Products:Cloud9/suse-openstack-cloud-crowbar/9/POOL/x86_64"
         fingerprint: ""
       url:
-      smt_path: "SUSE/Products/OpenStack-Cloud/9/x86_64/product"
+      smt_path: "SUSE/Products/OpenStack-Cloud-Crowbar/9/x86_64/product"
       ask_on_error: false
     suse-openstack-cloud-9-updates:
       name: "SUSE-OpenStack-Cloud-Crowbar-9-Updates"
@@ -149,7 +149,7 @@ suse-12.4:
         tag: "obsrepository://build.suse.de/SUSE:Updates:OpenStack-Cloud-Crowbar:9:x86_64/update"
         fingerprint: ""
       url:
-      smt_path: "SUSE/Updates/OpenStack-Cloud/9/x86_64/update"
+      smt_path: "SUSE/Updates/OpenStack-Cloud-Crowbar/9/x86_64/update"
       ask_on_error: false
     sle12-sp4-ha-pool:
       name: "SLE12-SP4-HA-Pool"
@@ -242,7 +242,7 @@ suse-12.4:
         tag: "obsproduct://build.suse.de/SUSE:SLE-12-SP4:Update:Products:Cloud9/suse-openstack-cloud-crowbar/9/POOL/s390x"
         fingerprint: ""
       url:
-      smt_path: "SUSE/Products/OpenStack-Cloud/9/s390x/product"
+      smt_path: "SUSE/Products/OpenStack-Cloud-Crowbar/9/s390x/product"
       ask_on_error: false
     suse-openstack-cloud-9-updates:
       name: "SUSE-OpenStack-Cloud-Crowbar-9-Updates"
@@ -252,7 +252,7 @@ suse-12.4:
         tag: "obsrepository://build.suse.de/SUSE:Updates:OpenStack-Cloud-Crowbar:9:s390x/update"
         fingerprint: ""
       url:
-      smt_path: "SUSE/Updates/OpenStack-Cloud/9/s390x/update"
+      smt_path: "SUSE/Updates/OpenStack-Cloud-Crowbar/9/s390x/update"
       ask_on_error: false
     sle12-sp4-ha-pool:
       name: "SLE12-SP4-HA-Pool"


### PR DESCRIPTION
The product rename wasn't tested with SMT, obviously.