### PR TITLE
[4.0] upgrade: Exclude removed nodes from upgrade

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -673,7 +673,10 @@ module Api
             end
           end
         end
-        to_upgrade
+        # Filter out non-existent nodes (e.g. from unsaved proposals after "forget")
+        # Not using Node.all here as we only need node names
+        all_node_names = ChefObject.fetch_nodes_from_cdb.first.map(&:name)
+        to_upgrade.select { |node| all_node_names.include? node }
       end
 
       def upgrade_controllers_disruptive

--- a/crowbar_framework/spec/fixtures/nodes_for_upgrade.json
+++ b/crowbar_framework/spec/fixtures/nodes_for_upgrade.json
@@ -1,0 +1,6 @@
+[
+  {"name": "data"},
+  {"name": "services"},
+  {"name": "storage"},
+  {"name": "compute"}
+]


### PR DESCRIPTION
When some node is removed from crowbar (e.g. using "forget" operation) and
not all proposals are saved, this node was still included in some parts of
the upgrade process causing errors when trying to access node attributes.

Additional filtering was added to make sure we don't try to upgrade
non-existent nodes.