### PR TITLE
[5.0] Crowbar: move skip unchanged batches feature out of experimental 5

### DIFF
--- a/crowbar_framework/app/models/service_object.rb
+++ b/crowbar_framework/app/models/service_object.rb
@@ -1000,7 +1000,7 @@ class ServiceObject
       "skip_unready_nodes", {}
     ).fetch("enabled", false)
 
-    skip_unchanged_nodes_enabled = Rails.application.config.experimental.fetch(
+    skip_unchanged_nodes_enabled = Rails.application.config.crowbar.fetch(
       "skip_unchanged_nodes", {}
     ).fetch("enabled", false)
 

--- a/crowbar_framework/config/crowbar.yml
+++ b/crowbar_framework/config/crowbar.yml
@@ -1,4 +1,6 @@
 default: &default
+  skip_unchanged_nodes:
+    enabled: false
   skip_unready_nodes:
     enabled: false
     roles:

--- a/crowbar_framework/config/experimental.yml
+++ b/crowbar_framework/config/experimental.yml
@@ -1,8 +1,6 @@
 default: &default
   disallow_restart:
     enabled: false
-  skip_unchanged_nodes:
-    enabled: false
 
 development:
   <<: *default


### PR DESCRIPTION
Looks like this feature has been tested extensively on prod envs
with little to no failures so its time to move it out of the
experimental umbrella, make a normal config for it and document
it properly.

Moves the config settings from the experimental to the normal config
Changes the calls to experimental settings to point tot he new file

(cherry picked from commit fabf65e4836d4c40736bfe658044e70099433575)
Backport from #1688