### PR TITLE
upgrade: Do not start chef-client service from recipe

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -37,7 +37,9 @@ when "revert_to_ready", "done_os_upgrade"
   end
 
   service "chef-client" do
-    action [:enable, :start]
+    # Do not start chef-client right after the upgrade, we still might need to
+    # save some node data and do not want chef-client running on a node to interfere
+    action upgrade_step == "done_os_upgrade" ? :enable : [:enable, :start]
   end
 
 when "crowbar_upgrade"

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -866,12 +866,14 @@ module Api
       def finalize_node_upgrade(node)
         return unless node.crowbar.key? "crowbar_upgrade_step"
 
-        Rails.logger.info("Finalizing upgade of node #{node.name}")
+        Rails.logger.info("Finalizing upgrade of node #{node.name}")
 
         node.crowbar.delete "crowbar_upgrade_step"
         node.crowbar.delete "node_upgrade_state"
         node.save
 
+        Rails.logger.info("Starting chef-client service on #{node.name}")
+        node.ssh_cmd("systemctl start chef-client")
       end
 
       def delete_upgrade_scripts(node)


### PR DESCRIPTION
Originally chef-client was started when running crowbar_join after
the node upgrade. But we still need to save some node data after
this point (in finalize_node_upgrade) and there could be a chance that
chef-client is already running at the node. In such case, our node.save
would not have an effect and running chef-client saves the old reversion
of a node.

To prevent this, do not start chef-client service from that crowbar_join
but only explicitely from finalize_node_upgrade after the node data were
saved.

(cherry picked from commit 1b2bcb44d30f5a2d2cefaa6cdc36cc1adb9fe313)

port of https://github.com/crowbar/crowbar-core/pull/1689