### PR TITLE
[4.0] Bring back the suport for ceph nodes during the upgrade

### DIFF
--- a/crowbar.yml
+++ b/crowbar.yml
@@ -82,6 +82,9 @@ nav:
     upgrade:
       order: 40
       route: '"/upgrade"'
+    ceph_pre_upgrade:
+      order: 30
+      route: 'ceph_pre_upgrade_path'
   help:
     order: 80
     route: 'docs_path'

--- a/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
@@ -18,6 +18,13 @@ class CephPreUpgradeController < ApplicationController
     ceph_nodes = get_ceph_nodes
     @prepared = nodes_prepared(ceph_nodes)
     @no_ceph_nodes = ceph_nodes.empty?
+
+    respond_to do |format|
+      format.json do
+        render json: { prepared: @prepared, no_ceph_nodes: @no_ceph_nodes }
+      end
+      format.html
+    end
   end
 
   def prepare
@@ -41,12 +48,19 @@ class CephPreUpgradeController < ApplicationController
       status = :unprocessable_entity
     end
 
-    if status == :ok
-      flash[:notice] = success_msg
-    else
-      flash[:alert] = error_msg
+    respond_to do |format|
+      format.json do
+        render json: status
+      end
+      format.html do
+        if status == :ok
+          flash[:notice] = success_msg
+        else
+          flash[:alert] = error_msg
+        end
+        redirect_to ceph_pre_upgrade_url
+      end
     end
-    redirect_to ceph_pre_upgrade_url
   end
 
   private

--- a/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
@@ -15,8 +15,9 @@
 #
 class CephPreUpgradeController < ApplicationController
   def index
-    # FIXME: Check if Ceph is actually deployed!
-    @prepared = nodes_prepared
+    ceph_nodes = get_ceph_nodes
+    @prepared = nodes_prepared(ceph_nodes)
+    @no_ceph_nodes = ceph_nodes.empty?
   end
 
   def prepare
@@ -50,9 +51,13 @@ class CephPreUpgradeController < ApplicationController
 
   private
 
-  def nodes_prepared
+  def get_ceph_nodes
+    NodeObject.find("roles:ceph-* AND ceph_config_environment:*")
+  end
+
+  def nodes_prepared(nodes)
     ret = true
-    NodeObject.find("roles:ceph-* AND ceph_config_environment:*").each do |node|
+    nodes.each do |node|
       ret &&= node.state == "crowbar_upgrade"
     end
     ret

--- a/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/ceph_pre_upgrade_controller.rb
@@ -1,0 +1,60 @@
+#
+# Copyright 2017, SUSE LINUX Products GmbH
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class CephPreUpgradeController < ApplicationController
+  def index
+    # FIXME: Check if Ceph is actually deployed!
+    @prepared = nodes_prepared
+  end
+
+  def prepare
+    status = :ok
+    error_msg = ""
+
+    begin
+      service_object = CrowbarService.new(Rails.logger)
+      if params["nodes_action"] == "revert"
+        Rails.logger.info("Reverting state of ceph nodes to ready....")
+        service_object.revert_nodes_from_crowbar_upgrade(true)
+        success_msg = I18n.t("ceph_pre_upgrade.success_revert")
+      else
+        Rails.logger.info("Preparing ceph nodes for upgrade....")
+        service_object.prepare_nodes_for_crowbar_upgrade(true)
+        success_msg = I18n.t("ceph_pre_upgrade.success_prepare")
+      end
+    rescue => e
+      error_msg = e.message
+      Rails.logger.error error_msg
+      status = :unprocessable_entity
+    end
+
+    if status == :ok
+      flash[:notice] = success_msg
+    else
+      flash[:alert] = error_msg
+    end
+    redirect_to ceph_pre_upgrade_url
+  end
+
+  private
+
+  def nodes_prepared
+    ret = true
+    NodeObject.find("roles:ceph-* AND ceph_config_environment:*").each do |node|
+      ret &&= node.state == "crowbar_upgrade"
+    end
+    ret
+  end
+end

--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -102,7 +102,30 @@ module Api
       def ceph_status
         ret = {}
         ceph_nodes = ::Node.find("roles:ceph-* AND ceph_config_environment:*")
-        ret[:crowbar_ceph_nodes] = true if ceph_nodes.any?
+        return ret if ceph_nodes.empty?
+        mon_node = ::Node.find("run_list_map:ceph-mon AND ceph_config_environment:*").first
+
+        ssh_retval = mon_node.run_ssh_cmd("LANG=C ceph health --connect-timeout 5 2>&1")
+        # Some warnings do not need to be critical, but we have no way to find out.
+        # So we assume user knows how to tweak cluster settings to show the healthy state.
+        unless ssh_retval[:stdout].include? "HEALTH_OK"
+          ret[:health_errors] = ssh_retval[:stdout]
+          unless ssh_retval[:stderr].nil? || ssh_retval[:stderr].empty?
+            ret[:health_errors] += "; " unless ssh_retval[:stdout].empty?
+            ret[:health_errors] += ssh_retval[:stderr]
+          end
+          return ret
+        end
+        # ceph --version
+        # SES2.1:
+        # ceph version 0.94.9-93-g239fe15 (239fe153ffde6a22e1efcaf734ff28d6a703a0ba)
+        # SES4:
+        # ceph version 10.2.4-211-g12b091b (12b091b4a40947aa43919e71a318ed0dcedc8734)
+        ssh_retval = mon_node.run_ssh_cmd("LANG=C ceph --version | cut -d ' ' -f 3")
+        ret[:old_version] = true if ssh_retval[:stdout].to_f < 10.2
+
+        not_prepared = ceph_nodes.select { |n| n.state != "crowbar_upgrade" }.map(&:name)
+        ret[:not_prepared] = not_prepared unless not_prepared.empty?
         ret
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -109,12 +109,14 @@ module Api
             errors: compute.empty? ? {} : compute_status_errors(compute)
           }
 
-          ceph_status = Api::Crowbar.ceph_status
-          ret[:checks][:ceph_status] = {
-            required: true,
-            passed: ceph_status.empty?,
-            errors: ceph_status.empty? ? {} : ceph_errors(ceph_status)
-          }
+          if Api::Crowbar.addons.include?("ceph")
+            ceph_status = Api::Crowbar.ceph_status
+            ret[:checks][:ceph_healthy] = {
+              required: true,
+              passed: ceph_status.empty?,
+              errors: ceph_status.empty? ? {} : ceph_health_check_errors(ceph_status)
+            }
+          end
 
           ha_config = Api::Pacemaker.ha_presence_check.merge(
             Api::Crowbar.ha_config_check
@@ -1619,12 +1621,26 @@ module Api
         }
       end
 
-      def ceph_errors(check)
+      def ceph_health_check_errors(check)
         ret = {}
-        if check[:crowbar_ceph_nodes]
-          ret[:crowbar_ceph_nodes] = {
-            data: I18n.t("api.upgrade.prechecks.crowbar_ceph_present.error"),
-            help: I18n.t("api.upgrade.prechecks.crowbar_ceph_present.help")
+        if check[:health_errors]
+          ret[:ceph_not_healthy] = {
+            data: I18n.t("api.upgrade.prechecks.ceph_not_healthy.error",
+              error: check[:health_errors]),
+            help: I18n.t("api.upgrade.prechecks.ceph_not_healthy.help")
+          }
+        end
+        if check[:old_version]
+          ret[:ceph_old_version] = {
+            data: I18n.t("api.upgrade.prechecks.ceph_old_version.error"),
+            help: I18n.t("api.upgrade.prechecks.ceph_old_version.help")
+          }
+        end
+        if check[:not_prepared]
+          ret[:ceph_not_prepared] = {
+            data: I18n.t("api.upgrade.prechecks.ceph_not_prepared.error",
+              nodes: check[:not_prepared].join(", ")),
+            help: I18n.t("api.upgrade.prechecks.ceph_not_prepared.help")
           }
         end
         ret

--- a/crowbar_framework/app/views/ceph_pre_upgrade/index.html.haml
+++ b/crowbar_framework/app/views/ceph_pre_upgrade/index.html.haml
@@ -1,0 +1,19 @@
+.row
+  .col-xs-12
+    %h1.page-header
+      = t(".title")
+    .alert.alert-info
+      = t(".hint_html")
+
+    = form_for :ceph_pre_upgrade, url: prepare_ceph_pre_upgrade_path, html: { role: "form" }, data: { blockui: t(".blockui_message") } do |f|
+
+      .panel-body.text-left
+        - if @prepared
+          = t(".nodes_prepared")
+        - else
+          = t(".nodes_not_prepared")
+
+      .panel-body.text-left
+        .btn-group
+          %input{ type: "hidden", name: "nodes_action", value: @prepared ? "revert" : "prepare" }
+          %input.btn.btn-default{ type: "submit", name: "submit", value: @prepared ? t(".revert") : t(".prepare") }

--- a/crowbar_framework/app/views/ceph_pre_upgrade/index.html.haml
+++ b/crowbar_framework/app/views/ceph_pre_upgrade/index.html.haml
@@ -5,15 +5,21 @@
     .alert.alert-info
       = t(".hint_html")
 
-    = form_for :ceph_pre_upgrade, url: prepare_ceph_pre_upgrade_path, html: { role: "form" }, data: { blockui: t(".blockui_message") } do |f|
+    - if @no_ceph_nodes
 
-      .panel-body.text-left
-        - if @prepared
-          = t(".nodes_prepared")
-        - else
-          = t(".nodes_not_prepared")
+      = t(".no_ceph_nodes")
 
-      .panel-body.text-left
-        .btn-group
-          %input{ type: "hidden", name: "nodes_action", value: @prepared ? "revert" : "prepare" }
-          %input.btn.btn-default{ type: "submit", name: "submit", value: @prepared ? t(".revert") : t(".prepare") }
+    - else
+
+      = form_for :ceph_pre_upgrade, url: prepare_ceph_pre_upgrade_path, html: { role: "form" }, data: { blockui: t(".blockui_message") } do |f|
+
+        .panel-body.text-left
+          - if @prepared
+            = t(".nodes_prepared")
+          - else
+            = t(".nodes_not_prepared")
+
+        .panel-body.text-left
+          .btn-group
+            %input{ type: "hidden", name: "nodes_action", value: @prepared ? "revert" : "prepare" }
+            %input.btn.btn-default{ type: "submit", name: "submit", value: @prepared ? t(".revert") : t(".prepare") }

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -84,6 +84,7 @@ en:
       logs: 'Exported Items'
       repositories: 'Repositories'
       backup: 'Backup & Restore'
+      ceph_pre_upgrade: 'Prepare Ceph Upgrade'
       upgrade: 'Upgrade'
     help: 'Help'
 
@@ -568,6 +569,18 @@ en:
       check_failed_fingerprint: 'Unexpected fingerprint'
       active: 'Active'
       active_repo_tooltip: 'Managed nodes will be automatically configured to use repositories only if they are marked as active'
+
+  ceph_pre_upgrade:
+    index:
+      title: 'Preparation of Ceph Nodes'
+      hint_html: |
+        The upgrade from SUSE Enterprise Storage 2.1 to 4 must be performed as outlined in the <a href="https://www.suse.com/documentation/ses-4/book_storage_admin/data/ceph_upgrade_to4.html">SUSE Enterprise Storage 4 documentation</a>.<br>
+        For this to work, the Ceph nodes must first be put into a prepared state, so that Crowbar will stop configuring them for the duration of the upgrade of both SUSE Enterprise Storage and SUSE OpenStack Cloud products.
+      prepare: 'Prepare for the Upgrade'
+      revert: 'Revert to normal state'
+      nodes_prepared: 'Ceph nodes are already prepared for the upgrade.'
+      nodes_not_prepared: 'Ceph nodes are currently not prepared for the upgrade.'
+      blockui_message: 'Processing, please wait...'
 
   installer:
     title: 'Installer'

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -581,6 +581,9 @@ en:
       nodes_prepared: 'Ceph nodes are already prepared for the upgrade.'
       nodes_not_prepared: 'Ceph nodes are currently not prepared for the upgrade.'
       blockui_message: 'Processing, please wait...'
+      no_ceph_nodes: 'No Ceph nodes were found. Upgrade preparation is not needed.'
+    success_prepare: 'Ceph nodes were successfully prepared for SES upgrade.'
+    success_revert: 'Ceph nodes were successfully reverted to normal state.'
 
   installer:
     title: 'Installer'

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -820,6 +820,9 @@ en:
         maintenance_updates_check:
           help:
             default: 'Make sure maintenance updates are installed'
+        ceph_health_check:
+          help:
+            default: 'Make sure Ceph is healthy'
         clusters_health:
           crm_failures: 'Please check that all cluster resources are online or refer to the SUSE High Availability documentation for possible troubleshooting.'
           failed_actions: 'Please clean the resource history and re−check the current state with "crm_resource -C" or refer to the SUSE High Availability documentation for possible troubleshooting.'
@@ -857,9 +860,22 @@ en:
         unsupported_cluster_setup:
           error: 'Your cluster/role configuration is not supported by the non-disruptive upgrade process.'
           help: 'Please refer to the Deployment Guide for list of supported configurations.'
-        crowbar_ceph_present:
-          error: 'There are nodes with ceph roles present. Remove all ceph roles deployed by crowbar and migrate to external Ceph cluster.'
-          help: 'Refer to the SUSE Enterprise Storage documentation for the information about upgrading from Crowbar Deployment.'
+        ceph_not_healthy:
+          error: |
+            Ceph cluster health check has failed with:
+            
+            %{error}
+                       
+            Make sure cluster is healthy before proceeding with the upgrade.
+          help: 'Refer to the SUSE Enterprise Storage documentation for possible troubleshooting.'
+        ceph_old_version:
+          error: 'It appears you have an old version of SUSE Enterprise Storage installed. Upgrade to the latest version of SES before proceeding with the Cloud upgrade.'
+          help: 'Refer to the SUSE Enterprise Storage documentation for the information about upgrading.'
+        ceph_not_prepared:
+          error: 'Some ceph nodes are not prepared for the upgrade: %{nodes}.'
+          help: |
+            Unlike normal nodes, ceph nodes must already be upgraded and kept waiting in the upgrade state until the upgrade of whole Cloud is finished.
+            Refer to the SUSE Enterprise Storage documentation for the information about upgrading ceph nodes.
       prepare:
         help:
           default: 'Refer to the error message in the response'

--- a/crowbar_framework/config/navigation.rb
+++ b/crowbar_framework/config/navigation.rb
@@ -40,6 +40,7 @@ SimpleNavigation::Configuration.run do |navigation|
       level2.item :backup, t("nav.utils.backup"), backups_path
       level2.item :upgrade, t("nav.utils.upgrade"), "/upgrade"
       level2.item :logs, t("nav.utils.logs"), utils_path
+      level2.item :ceph_pre_upgrade, t("nav.utils.ceph_pre_upgrade"), ceph_pre_upgrade_path
     end
   end
 end

--- a/crowbar_framework/config/navigation.rb
+++ b/crowbar_framework/config/navigation.rb
@@ -39,8 +39,8 @@ SimpleNavigation::Configuration.run do |navigation|
       level2.item :repositories, t("nav.utils.repositories"), repositories_path
       level2.item :backup, t("nav.utils.backup"), backups_path
       level2.item :upgrade, t("nav.utils.upgrade"), "/upgrade"
-      level2.item :logs, t("nav.utils.logs"), utils_path
       level2.item :ceph_pre_upgrade, t("nav.utils.ceph_pre_upgrade"), ceph_pre_upgrade_path
+      level2.item :logs, t("nav.utils.logs"), utils_path
     end
   end
 end

--- a/crowbar_framework/config/routes.rb
+++ b/crowbar_framework/config/routes.rb
@@ -94,6 +94,14 @@ Rails.application.routes.draw do
 
   # support paths
   get "utils", controller: :support, action: :index, as: "utils"
+
+  get "utils/ceph_pre_upgrade(.:format)",
+    controller: "ceph_pre_upgrade", action: "index", as: "ceph_pre_upgrade"
+  post "utils/ceph_pre_upgrade/prepare(.:format)",
+    controller: "ceph_pre_upgrade",
+    action: "prepare",
+    as: "prepare_ceph_pre_upgrade"
+
   scope :utils do
     get ":controller/1.0/export", action: :export, as: "utils_export"
     get ":controller/1.0", action: :utils

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -157,14 +157,118 @@ describe Api::Crowbar do
     end
   end
 
-  context "with ceph cluster deployed by crowbar" do
-    it "fails when ceph roles are found" do
+  context "with ceph cluster healthy" do
+    it "succeeds to check ceph cluster health and version" do
+      allow(Node).to(
+        receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
+        and_return([Node.find_by_name("ceph.crowbar.com")])
+      )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
+      allow_any_instance_of(Node).to(
+        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
+        and_return(exit_code: 0, stdout: "HEALTH_OK\n", stderr: "")
+      )
+      allow_any_instance_of(Node).to(
+        receive(:run_ssh_cmd).with("LANG=C ceph --version | cut -d ' ' -f 3").
+        and_return(exit_code: 0, stdout: "10.2.4-211-g12b091b\n", stderr: "")
+      )
+
+      expect(subject.class.ceph_status).to be_empty
+    end
+
+    it "succeeds to check ceph cluster health and version but finds unprepared node" do
+      allow(Node).to(
+        receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
+        and_return([Node.find_by_name("testing"), Node.find_by_name("ceph")])
+      )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
+      allow_any_instance_of(Node).to(
+        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
+        and_return(exit_code: 0, stdout: "HEALTH_OK\n", stderr: "")
+      )
+      allow_any_instance_of(Node).to(
+        receive(:run_ssh_cmd).with("LANG=C ceph --version | cut -d ' ' -f 3").
+        and_return(exit_code: 0, stdout: "10.2.4-211-g12b091b\n", stderr: "")
+      )
+
+      expect(subject.class.ceph_status).to eq(not_prepared: ["testing.crowbar.com"])
+    end
+
+    it "succeeds to check ceph cluster health but fails on version" do
+      allow(Node).to(
+        receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
+        and_return([Node.find_by_name("ceph.crowbar.com")])
+      )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
+      allow_any_instance_of(Node).to(
+        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
+        and_return(exit_code: 0, stdout: "HEALTH_OK\n", stderr: "")
+      )
+      allow_any_instance_of(Node).to(
+        receive(:run_ssh_cmd).with("LANG=C ceph --version | cut -d ' ' -f 3").
+        and_return(exit_code: 0, stdout: "0.94.9-93-g239fe15\n", stderr: "")
+      )
+
+      expect(subject.class.ceph_status).to eq(old_version: true)
+    end
+  end
+
+  context "with ceph cluster not healthy" do
+    it "fails when checking ceph cluster health" do
       allow(Node).to(
         receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
         and_return([Node.find_by_name("testing.crowbar.com")])
       )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
+      allow_any_instance_of(Node).to(
+        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
+        and_return(exit_code: 1, stdout: "HEALTH_ERR\n", stderr: "")
+      )
+      expect(subject.class.ceph_status).to_not be_empty
+    end
+
+    it "fails when exit value of ceph check is 0 but stdout still not correct" do
+      allow(Node).to(
+        receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
+        and_return([Node.find_by_name("testing.crowbar.com")])
+      )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
+      allow_any_instance_of(Node).to(
+        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
+        and_return(exit_code: 0, stdout: "HEALTH_WARN", stderr: "")
+      )
+      expect(subject.class.ceph_status).to_not be_empty
+    end
+
+    it "fails when connection to ceph cluster times out" do
+      allow(Node).to(
+        receive(:find).with("roles:ceph-* AND ceph_config_environment:*").
+        and_return([Node.find_by_name("testing.crowbar.com")])
+      )
+      allow(Node).to(receive(:find).with(
+        "run_list_map:ceph-mon AND ceph_config_environment:*"
+      ).and_return([Node.find_node_by_name("ceph")]))
+      allow_any_instance_of(Node).to(
+        receive(:run_ssh_cmd).with("LANG=C ceph health --connect-timeout 5 2>&1").
+        and_return(
+          exit_code: 1,
+          stdout: "",
+          stderr: "Error connecting to cluster: InterruptedOrTimeoutError"
+        )
+      )
+
       expect(subject.class.ceph_status).to eq(
-        crowbar_ceph_nodes: true
+        health_errors: "Error connecting to cluster: InterruptedOrTimeoutError"
       )
     end
   end

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -951,9 +951,6 @@ describe Api::Upgrade do
       allow(Api::Crowbar).to(
         receive(:health_check).and_return({})
       )
-      allow(Api::Crowbar).to(
-        receive(:ceph_status).and_return({})
-      )
       allow(Api::Crowbar).to receive(
         :ha_config_check
       ).and_return({})
@@ -982,9 +979,6 @@ describe Api::Upgrade do
       ).and_return(error: "ERROR")
       allow(Api::Crowbar).to(
         receive(:health_check).and_return({})
-      )
-      allow(Api::Crowbar).to(
-        receive(:ceph_status).and_return({})
       )
       allow(Api::Crowbar).to receive(
         :ha_config_check


### PR DESCRIPTION
This is experimental code that attempts to use the same way of handling ceph nodes from 6-7 upgrade to 7-8.

This includes:
- Port of https://github.com/crowbar/crowbar-core/pull/1077
- Port of https://github.com/crowbar/crowbar-core/pull/1079
- Revert of https://github.com/crowbar/crowbar-core/pull/1577