### PR TITLE
[5.0] Revert "upgrade: Remove manipulation with ceph nodes from upgrade workflow

### DIFF
--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -256,8 +256,13 @@ module Api
             ret["os"] ||= []
             ret["os"].push(arch) unless ret["os"].include?(arch)
 
-            ret["openstack"] ||= []
-            ret["openstack"].push(arch) unless ret["openstack"].include?(arch)
+            if ceph_node?(node)
+              ret["ceph"] ||= []
+              ret["ceph"].push(arch) unless ret["ceph"].include?(arch)
+            else
+              ret["openstack"] ||= []
+              ret["openstack"].push(arch) unless ret["openstack"].include?(arch)
+            end
 
             if pacemaker_node?(node)
               ret["ha"] ||= []
@@ -265,6 +270,10 @@ module Api
             end
           end
         end
+      end
+
+      def ceph_node?(node)
+        node.roles.include?("ceph-config-default")
       end
 
       def pacemaker_node?(node)

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -434,7 +434,7 @@ module Api
         check_for_running_instances if upgrade_mode == :normal
 
         # For all nodes in cluster, set the pre-upgrade attribute
-        upgrade_nodes = ::Node.find("state:crowbar_upgrade")
+        upgrade_nodes = ::Node.find("state:crowbar_upgrade AND NOT roles:ceph-*")
         upgrade_nodes.each do |node|
           node.set_pre_upgrade_attribute
         end
@@ -681,6 +681,10 @@ module Api
       end
 
       def do_controllers_substep(substep)
+        if substep == :ceph_nodes
+          join_ceph_nodes
+          substep = :controller_nodes
+        end
         if substep == :controller_nodes
           upgrade_controller_clusters
           upgrade_non_compute_nodes
@@ -716,6 +720,10 @@ module Api
         end
 
         if substep.nil? || substep.empty?
+          substep = :ceph_nodes
+        end
+
+        if substep == :ceph_nodes && substep_status == :finished
           substep = :controller_nodes
         end
 
@@ -894,6 +902,23 @@ module Api
         ].map { |f| "/usr/sbin/crowbar-#{f}.sh" }.join(" ")
         scripts_to_delete << " /etc/neutron/lbaas-connection.conf"
         node.run_ssh_cmd("rm -f #{scripts_to_delete}")
+      end
+
+      # Ceph nodes were upgraded independently, we only need to make them ready again
+      def join_ceph_nodes
+        ceph_nodes = ::Node.find("roles:ceph-*")
+        ceph_nodes.sort! { |n| n.upgrading? ? -1 : 1 }
+
+        ceph_nodes.each do |node|
+          return true if node.upgraded?
+          Rails.logger.info("Joining ceph node #{node.name}")
+          node_api = Api::Node.new node.name
+          node_api.save_node_state("ceph", "upgrading")
+          node_api.join_and_chef
+          node_api.save_node_state("ceph", "upgraded")
+        end
+        ::Crowbar::UpgradeStatus.new.save_substep(:ceph_nodes, :finished)
+        save_nodes_state([], "", "")
       end
 
       def finalize_nodes_upgrade

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -92,7 +92,7 @@ describe Api::Crowbar do
 
   context "with addons enabled" do
     it "lists the enabled addons" do
-      ["ha"].each do |addon|
+      ["ceph", "ha"].each do |addon|
         allow(Api::Crowbar).to(
           receive(:addon_installed?).with(addon).
           and_return(true)
@@ -108,7 +108,7 @@ describe Api::Crowbar do
         )
       end
 
-      expect(subject.class.addons).to eq(["ha"])
+      expect(subject.class.addons).to eq(["ceph", "ha"])
     end
   end
 
@@ -132,9 +132,8 @@ describe Api::Crowbar do
   context "with cloud not healthy" do
     it "finds a node that is not ready" do
       allow(NodeObject).to(
-        receive(:find_all_nodes).and_return(
-          [NodeObject.find_node_by_name("testing.crowbar.com")]
-        )
+        receive(:find).with("NOT roles:ceph-*").
+        and_return([NodeObject.find_node_by_name("testing.crowbar.com")])
       )
       allow_any_instance_of(NodeObject).to(receive(:ready?).and_return(false))
 

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -164,9 +164,8 @@ describe Api::Upgrade do
         :prepare_nodes_for_os_upgrade
       ).and_return(true)
       allow(Node).to(
-        receive(:find).with("state:crowbar_upgrade").and_return(
-          [Node.find_by_name("testing.crowbar.com")]
-        )
+        receive(:find).with("state:crowbar_upgrade AND NOT roles:ceph-*").
+        and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow_any_instance_of(Node).to(
         receive(:set_pre_upgrade_attribute).and_return([200, ""])
@@ -457,6 +456,7 @@ describe Api::Upgrade do
   context "upgrading the nodes in normal mode" do
     it "successfully upgrades controller nodes" do
       allow(Api::Upgrade).to receive(:remaining_nodes).and_return(1)
+      allow(Api::Upgrade).to receive(:join_ceph_nodes).and_return(true)
 
       allow(Api::Upgrade).to receive(:upgrade_mode).and_return(:normal)
 
@@ -539,6 +539,7 @@ describe Api::Upgrade do
       testing = Node.find_by_name("testing.crowbar.com")
 
       allow(Node).to(receive(:find).with("state:crowbar_upgrade").and_return([testing]))
+      allow(Api::Upgrade).to receive(:join_ceph_nodes).and_return(true)
       allow(Api::Upgrade).to receive(:upgrade_controller_clusters).and_return(true)
 
       # upgrade_non_compute_nodes:
@@ -637,6 +638,7 @@ describe Api::Upgrade do
         :start_step
       ).with(:nodes).and_return(true)
       allow(Api::Upgrade).to receive(:remaining_nodes).and_return(1)
+      allow(Api::Upgrade).to receive(:join_ceph_nodes).and_return(true)
       allow(Node).to(
         receive(:find).
         with(


### PR DESCRIPTION
This reverts commit cfb0aabb046f492ab82b565915e6cd797870c537.
Reverts https://github.com/crowbar/crowbar-core/pull/1578

This is the experimental support for upgrading with ceph roles


Note to myself: what about the list of nodes in `prepare_nodes_for_os_upgrade` ?