### PR TITLE
Add ping support for IPv6

### DIFF
--- a/crowbar_framework/lib/crowbar/checks/network.rb
+++ b/crowbar_framework/lib/crowbar/checks/network.rb
@@ -60,16 +60,17 @@ module Crowbar
           unless ipv4_configured || ipv4_addrs.empty?
             return false
           end
-          # we don't really depend on IPv6, so no big deal
-          # unless ipv6_configured || ipv6_addrs.empty?
-          #   return false
-          # end
+
+          unless ipv6_configured || ipv6_addrs.empty?
+            return false
+          end
 
           true
         end
 
         def ping_succeeds?
-          system("ping -c 1 #{fqdn} > /dev/null 2>&1 || ping6 -c 1 #{fqdn} > /dev/null 2>&1")
+          return system("ping6 -c 1 #{fqdn} > /dev/null 2>&1") unless ipv6_addrs.empty?
+          system("ping -c 1 #{fqdn} > /dev/null 2>&1")
         end
 
         def hostname

--- a/crowbar_framework/lib/crowbar/checks/network.rb
+++ b/crowbar_framework/lib/crowbar/checks/network.rb
@@ -104,7 +104,9 @@ module Crowbar
               else
                 next unless ip_addr.ipv4?
               end
-              addresses.push address
+              # Sanitise the ip string, as ipv6 writing shortcuts can make
+              # string comparisons fail.
+              addresses.push ip_addr.to_s
             end
           end
         end

--- a/crowbar_framework/lib/crowbar/checks/network.rb
+++ b/crowbar_framework/lib/crowbar/checks/network.rb
@@ -69,7 +69,7 @@ module Crowbar
         end
 
         def ping_succeeds?
-          system("ping -c 1 #{fqdn} > /dev/null 2>&1")
+          system("ping -c 1 #{fqdn} > /dev/null 2>&1 || ping6 -c 1 #{fqdn} > /dev/null 2>&1")
         end
 
         def hostname

--- a/crowbar_framework/spec/lib/crowbar/checks/network_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/checks/network_spec.rb
@@ -71,7 +71,15 @@ describe Crowbar::Checks::Network do
     it "returns true if fqdn is pingable" do
       allow_any_instance_of(Kernel).to(
         receive(:system).with(
-          "ping -c 1 #{subject.fqdn} > /dev/null 2>&1 || "\
+          "ping -c 1 #{subject.fqdn} > /dev/null 2>&1"
+        ).and_return(true)
+      )
+      expect(subject.ping_succeeds?).to be true
+    end
+    it "returns true if fqdn is pingable and ipv6" do
+      allow(subject).to receive(:ipv6_addrs).and_return(["fd00:0:0:3::1"])
+      allow_any_instance_of(Kernel).to(
+        receive(:system).with(
           "ping6 -c 1 #{subject.fqdn} > /dev/null 2>&1"
         ).and_return(true)
       )
@@ -81,8 +89,7 @@ describe Crowbar::Checks::Network do
     it "returns false if fqdn is not pingable" do
       allow_any_instance_of(Kernel).to(
         receive(:system).with(
-          "ping -c 1 #{subject.fqdn} > /dev/null 2>&1 || "\
-          "ping6 -c 1 #{subject.fqdn} > /dev/null 2>&1"
+          "ping -c 1 #{subject.fqdn} > /dev/null 2>&1"
         ).and_return(false)
       )
       expect(subject.ping_succeeds?).to be false

--- a/crowbar_framework/spec/lib/crowbar/checks/network_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/checks/network_spec.rb
@@ -77,7 +77,7 @@ describe Crowbar::Checks::Network do
       expect(subject.ping_succeeds?).to be true
     end
     it "returns true if fqdn is pingable and ipv6" do
-      allow(subject).to receive(:ipv6_addrs).and_return(["fd00:0:0:3::1"])
+      allow(subject).to receive(:ipv6_addrs).and_return(["::1"])
       allow_any_instance_of(Kernel).to(
         receive(:system).with(
           "ping6 -c 1 #{subject.fqdn} > /dev/null 2>&1"

--- a/crowbar_framework/spec/lib/crowbar/checks/network_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/checks/network_spec.rb
@@ -71,16 +71,18 @@ describe Crowbar::Checks::Network do
     it "returns true if fqdn is pingable" do
       allow_any_instance_of(Kernel).to(
         receive(:system).with(
-          "ping -c 1 #{subject.fqdn} > /dev/null 2>&1"
+          "ping -c 1 #{subject.fqdn} > /dev/null 2>&1 || "\
+          "ping6 -c 1 #{subject.fqdn} > /dev/null 2>&1"
         ).and_return(true)
       )
       expect(subject.ping_succeeds?).to be true
     end
 
-    it "returns palse if fqdn is not pingable" do
+    it "returns false if fqdn is not pingable" do
       allow_any_instance_of(Kernel).to(
         receive(:system).with(
-          "ping -c 1 #{subject.fqdn} > /dev/null 2>&1"
+          "ping -c 1 #{subject.fqdn} > /dev/null 2>&1 || "\
+          "ping6 -c 1 #{subject.fqdn} > /dev/null 2>&1"
         ).and_return(false)
       )
       expect(subject.ping_succeeds?).to be false


### PR DESCRIPTION
Currently the SLE12 iptuils package is using iputils 20121221 which
has separate ping and ping6 binaries. Which is fine, but the ping
command only works with ipv4, even if given a FQDN the qaulifies to
ipv6.

SLE15's iputils is using 20161105, which has both ipv4 and ipv6 in
support in the ping command.

This change modifies the check to test with ping6 if ping fails, so
the check will work on legecy systems.

The other alternative is to update SLE12's iputils package which
may be a better alternative, but this change bypasses the problem.