### PR TITLE
assign host to hostless keys

### DIFF
--- a/chef/cookbooks/provisioner/recipes/keys.rb
+++ b/chef/cookbooks/provisioner/recipes/keys.rb
@@ -37,10 +37,11 @@ root_pub_key = `cat /root/.ssh/id_rsa.pub`.chomp
 access_keys[node.name] = root_pub_key
 
 # Add additional keys
+nullnodecounter = 0
 node["provisioner"]["access_keys"].strip.split("\n").each do |key|
   key.strip!
   unless key.empty?
-    nodename = key.split(" ")[2]
+    nodename = key.split(" ")[2] || "hostless-key-#{nullnodecounter += 1}"
     access_keys[nodename] = key
   end
 end


### PR DESCRIPTION
"nodename" in keys is just a comment; so create a dummy because in case
of no(empty) comment 'keys.sort' in the template fails because in ruby 'nil'
does not have any order