### PR TITLE
[5.0] ohai: fix path to check for aacraid driver (bsc#1085170 bsc#1103882)

### DIFF
--- a/chef/cookbooks/ohai/files/default/plugins/linux/block_device_extended.rb
+++ b/chef/cookbooks/ohai/files/default/plugins/linux/block_device_extended.rb
@@ -31,11 +31,11 @@ if File.exist?("/sys/block")
     parts = File.realpath(dir, "/sys/block/").split("/")
     # example:
     # /sys/devices/pci0000:00/0000:00:02.0/0000:03:00.0/host0/target0:1:4/0:1:4:0/block/sdb
-    parts = parts[0..4] + ["driver"]
+    parts = parts[0..5] + ["driver"]
     path = parts.join("/")
     # example:
-    # /sys/devices/pci0000:00/0000:00:02.0/driver
-    # -> ../../../bus/pci/drivers/aacraid
+    # /sys/devices/pci0000:00/0000:00:02.0/0000:03:00.0/driver
+    # -> ../../../../bus/pci/drivers/aacraid
     next unless File.exist?(path) && File.readlink(path).split("/")[-1] == "aacraid"
     block[dir]["removable"] = "0"
   end


### PR DESCRIPTION
The check never worked before. On the 2 variants of machines I have seen
these are nested one deeper. While this may be different on different
hardware, checking every driver in the tree is more expensive.

Follow up for: a7312a8274312a0b1b0621e2578cf2290748b61c
Backport of: https://github.com/crowbar/crowbar-core/pull/1650