### PR TITLE
[5.0] upgrade: If pacemaker is used to manage the services, don't use systemctl

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -81,6 +81,12 @@ use_ha = roles.include? "pacemaker-cluster-member"
 remote_node = roles.include? "pacemaker-remote"
 is_cluster_founder = use_ha && node["pacemaker"]["founder"] == node[:fqdn]
 
+clone_stateless = if node["pacemaker"]
+  node["pacemaker"]["clone_stateless_services_orig"] || true
+else
+  true
+end
+
 template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   source "crowbar-shutdown-services-before-upgrade.sh.erb"
   mode "0755"
@@ -89,7 +95,8 @@ template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   action :create
   variables(
     use_ha: use_ha || remote_node,
-    cluster_founder: is_cluster_founder
+    cluster_founder: is_cluster_founder,
+    clone_stateless: clone_stateless
   )
 end
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -57,6 +57,7 @@ done
 
 <% end %>
 
+<% unless @clone_stateless %>
 # It's possible services are not managed by pacemaker (if clone_stateless_services was not set),
 # so to make sure that services are stopped, use additional systemctl commands.
 log "Stopping OpenStack services..."
@@ -67,6 +68,7 @@ for i in $(systemctl list-units openstack-* --no-legend | cut -d" " -f1 | grep -
     systemctl stop $i
     systemctl disable $i
 done
+<% end %>
 
 <% else %>
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -446,6 +446,15 @@ module Api
           timeouts[:shutdown_services]
         )
         Rails.logger.info("Services were shut down on all nodes.")
+
+        # Remove the temporary key from the role object
+        pacemaker_proposals = Proposal.all.where(barclamp: "pacemaker")
+        pacemaker_proposals.each do |proposal|
+          role = proposal.role
+          role.default_attributes["pacemaker"].delete "clone_stateless_services_orig"
+          role.save
+        end
+
         ::Crowbar::UpgradeStatus.new.end_step
       rescue ::Crowbar::Error::Upgrade::ServicesError => e
         ::Crowbar::UpgradeStatus.new.end_step(

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -349,6 +349,12 @@ class CrowbarService < ServiceObject
       role = proposal.role
       proposal.raw_data["attributes"]["pacemaker"]["clone_stateless_services"] = false
       proposal.raw_data["attributes"]["pacemaker"]["drbd"]["enabled"] = false
+      # Save the original value of clone_stateless_services, we need it for determining
+      # some actions from recipes.
+      unless role.default_attributes["pacemaker"].key? "clone_stateless_services_orig"
+        role.default_attributes["pacemaker"]["clone_stateless_services_orig"] =
+          role.default_attributes["pacemaker"]["clone_stateless_services"]
+      end
       role.default_attributes["pacemaker"]["clone_stateless_services"] = false
       role.default_attributes["pacemaker"]["drbd"]["enabled"] = false
       role.save


### PR DESCRIPTION
Usage of "systemctl stop" for shutting down the services should be limited
to the case when pacemaker is not managing those services, i.e. clone_stateless_services
is set to false. However, we're changing the value of this variable during the upgrade
so we must save the original one first.