### PR TITLE
Ipv6 support in the crowbar_validator

### DIFF
--- a/crowbar_framework/app/models/crowbar_validator.rb
+++ b/crowbar_framework/app/models/crowbar_validator.rb
@@ -101,7 +101,8 @@ class CrowbarValidator < Kwalify::Validator
       when "IpAddress"
         cidr = (1..128).cover? Integer(value) rescue false
         begin
-          IPAddr.new(value) if !(path.include?("broadcast") && value.empty?) && !cidr
+          IPAddr.new(value) if !(path.is_a?(String) && path.include?("broadcast") \
+                                 && value.empty?) && !cidr
         rescue IPAddr::InvalidAddressError
           msg = "Should be an IP Address: #{value}"
           errors << Kwalify::ValidationError.new(msg, path)

--- a/crowbar_framework/app/models/crowbar_validator.rb
+++ b/crowbar_framework/app/models/crowbar_validator.rb
@@ -98,15 +98,28 @@ class CrowbarValidator < Kwalify::Validator
            errors << Kwalify::ValidationError.new(msg, path)
          end
       when "IpAddress"
-         regex = /\A(?:25[0-5]|(?:2[0-4]|1\d|[1-9])?\d)(?:\.(?:25[0-5]|(?:2[0-4]|1\d|[1-9])?\d)){3}\z/
-         if value[regex].nil?
+         regex_v4 = /\A(?:25[0-5]|(?:2[0-4]|1\d|[1-9])?\d)(?:\.(?:25[0-5]|(?:2[0-4]|1\d|[1-9])?\d)){3}\z/
+         regex_v6 = /\A(?:[0-9A-Fa-f]{0,4})(?:\:(?:[0-9A-Fa-f]{0,4})){2,7}\z/
+         regex_cidr = /\A(?:12[0-8]|(?:1[0-1]|\d)?\d)\z/
+         regex_empty = /\A\z/
+         error = false
+         if value[regex_v4].nil? && value[regex_v6].nil? && value[regex_cidr].nil?
+           error = true
+         end
+
+         if path.include? "broadcast" && value.empty?
+           error = false
+         end
+
+         if error
            msg = "Should be an IP Address: #{value}"
            errors << Kwalify::ValidationError.new(msg, path)
          end
       when "IpAddressMap"
          regex = /\A(?:25[0-5]|(?:2[0-4]|1\d|[1-9])?\d)(?:\.(?:25[0-5]|(?:2[0-4]|1\d|[1-9])?\d)){3}\z/
+         regex_v6 = /\A(?:[0-9A-Fa-f]{0,4})(?:\:(?:[0-9A-Fa-f]{0,4})){2,7}\z/
          value.each_key do |key|
-           if key[regex].nil?
+           if key[regex].nil? && key[regex_v6].nil?
              msg = "Should be an IP Address: #{key}"
              errors << Kwalify::ValidationError.new(msg, path)
            end

--- a/crowbar_framework/app/models/crowbar_validator.rb
+++ b/crowbar_framework/app/models/crowbar_validator.rb
@@ -100,9 +100,10 @@ class CrowbarValidator < Kwalify::Validator
          end
       when "IpAddress"
         cidr = (1..128).cover? Integer(value) rescue false
+        blank_broadcast = path.is_a?(String) && path.include?("broadcast") \
+          && value.empty?
         begin
-          IPAddr.new(value) if !(path.is_a?(String) && path.include?("broadcast") \
-                                 && value.empty?) && !cidr
+          IPAddr.new(value) unless blank_broadcast || cidr
         rescue IPAddr::InvalidAddressError
           msg = "Should be an IP Address: #{value}"
           errors << Kwalify::ValidationError.new(msg, path)


### PR DESCRIPTION
The crowbar validator uses the barclamp schema files to determine
if the current values are correct. When attempting to validate the
network.json file for the network barclamp that validator doesn't
understand ipv6 addresses.

This patch adds some extra regexes to the IpAddress validation to
understand not just IPv4 addresses but also IPv6 and CIDR netmasks.

This is one step closer to getting IPv6 support in crowbar.