### PR TITLE
[5.0] upgrade: Revert parts of 826d376d9c7a6aad6ae019665da674849431e951

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -87,10 +87,10 @@ log "No HA setup found..."
 
 <% if @compute_node %>
 
-<% if @rabbitmq_cluster %>
-
-# update rabbitmq config for clients if it was changed
 zypper --non-interactive install crudini
+
+<% if @rabbitmq_cluster %>
+# update rabbitmq config for clients if it was changed
 
 crudini --set /etc/neutron/neutron.conf.d/200-crowbar-upgrade.conf oslo_messaging_rabbit rabbit_ha_queues true
 crudini --set /etc/neutron/neutron.conf.d/200-crowbar-upgrade.conf oslo_messaging_rabbit amqp_durable_queues true
@@ -106,6 +106,11 @@ crudini --set /etc/cinder/cinder.conf.d/200-crowbar-upgrade.conf oslo_messaging_
 <% end %>
 
 log "Restarting services for Pike"
+
+<% if @neutron_agent == "openstack-neutron-openvswitch-agent" %>
+crudini --set /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf ovs ovsdb_interface vsctl
+crudini --set /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf ovs of_interface ovs-ofctl
+<% end %>
 
 <% unless @remote_node %>
 systemctl restart <%= @neutron_agent %>

--- a/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
@@ -138,6 +138,7 @@ initiate_node_upgrade()
     # Remove possibly existing temporary config files from the compute nodes
     rm -f /etc/nova/nova.conf.d/200-crowbar-upgrade.conf
     rm -f /etc/neutron/neutron.conf.d/200-crowbar-upgrade.conf
+    rm -f /etc/neutron/neutron-openvswitch-agent.conf.d/200-crowbar-upgrade.conf
     rm -f /etc/cinder/cinder.conf.d/200-crowbar-upgrade.conf
 
     # Signalize that the upgrade correctly ended


### PR DESCRIPTION
Looks like wee need a workaround for a situation when neutron-ovs-agent
cuts itself of the network (bsc#1067482) and temporary change of of_interface
value seems to help.