### PR TITLE
[5.0] upgrade: Add an initial check if there's anything running on a host

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
@@ -34,6 +34,14 @@ set -x
 
 openstack --insecure compute service set --disable "$host" nova-compute
 
+# Initial check if there's anything running on a host
+if ! nova --insecure list --all-tenants --host "$host" --fields host,status 2>/dev/null | grep -e ACTIVE -e MIGRATING | grep "$host"; then
+    touch $UPGRADEDIR/crowbar-evacuate-host-ok
+    log "No running VM's found on $host, exiting now."
+    log "$BASH_SOURCE is finished."
+    exit 0
+fi
+
 <% if @needs_block_migrate %>
 blockmigrate="--block-migrate"
 <% else %>


### PR DESCRIPTION
This is necessary after some failure and retry.
When the compute node upgrade fails e.g. during OS installation and
user retries the step, first think that crowbar does is to live-evacuate
the host that has failed the upgrade. However the script for live-evacuation
could fail because nova-compute service might be stopped on the node already.

So we add the initial check that makes sure there are no running instances
on the host (they should not be, otherwise the OS upgrade would not start).

(cherry picked from commit 9e66773db2a339c9d2801ed2f686c1a26da5eed2)