### PR TITLE
apache2: use apache2-worker

### DIFF
--- a/chef/cookbooks/apache2/recipes/default.rb
+++ b/chef/cookbooks/apache2/recipes/default.rb
@@ -22,7 +22,7 @@ package "apache2" do
   when "rhel", "fedora"
     package_name "httpd"
   when "debian", "suse"
-    package_name "apache2"
+    package_name "apache2-worker"
   when "arch"
     package_name "apache"
   end


### PR DESCRIPTION
The prefork module is being deprecated and has a higher
memory/performance overhead than the default worker module.
Also prefork prevents from using more modern technologies
like HTTP/2. Switch to worker instead.