### PR TITLE
crowbar: Do not rewrite the value of 'insecure' if it already exist

### DIFF
--- a/chef/data_bags/crowbar/migrate/crowbar/200_add_insecure_attribute.rb
+++ b/chef/data_bags/crowbar/migrate/crowbar/200_add_insecure_attribute.rb
@@ -1,5 +1,5 @@
 def upgrade(ta, td, a, d)
-  a["apache"]["insecure"] = ta["apache"]["insecure"]
+  a["apache"]["insecure"] = ta["apache"]["insecure"] unless a["apache"].key?("insecure")
   return a, d
 end
 


### PR DESCRIPTION
The insecure value might be present from before the upgrade. Without
the check for presence, we would always rewrite the value to default one.

(cherry picked from commit af3a53e1d9ce21464daf72d5d7d3f28b592c97ae)

Port of https://github.com/crowbar/crowbar-core/pull/1711