### PR TITLE
Support RAID 0

### DIFF
--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -517,6 +517,7 @@ class NodesController < ApplicationController
     # if raid is selected, we need a couple of selected disks
     raid_disks_selected = params.fetch(:raid_disks, []).length
     if (params[:raid_type] == "raid1" and raid_disks_selected < 2) or \
+      (params[:raid_type] == "raid0" and raid_disks_selected < 1) or \
       (params[:raid_type] == "raid5" and raid_disks_selected < 3) or \
       (params[:raid_type] == "raid6" and raid_disks_selected < 4) or \
       (params[:raid_type] == "raid10" and raid_disks_selected < 4)

--- a/crowbar_framework/app/controllers/nodes_controller.rb
+++ b/crowbar_framework/app/controllers/nodes_controller.rb
@@ -516,11 +516,11 @@ class NodesController < ApplicationController
 
     # if raid is selected, we need a couple of selected disks
     raid_disks_selected = params.fetch(:raid_disks, []).length
-    if (params[:raid_type] == "raid1" and raid_disks_selected < 2) or \
-      (params[:raid_type] == "raid0" and raid_disks_selected < 1) or \
-      (params[:raid_type] == "raid5" and raid_disks_selected < 3) or \
-      (params[:raid_type] == "raid6" and raid_disks_selected < 4) or \
-      (params[:raid_type] == "raid10" and raid_disks_selected < 4)
+    if (params[:raid_type] == "raid1" && raid_disks_selected < 2) || \
+        (params[:raid_type] == "raid0" && raid_disks_selected < 1) || \
+        (params[:raid_type] == "raid5" && raid_disks_selected < 3) || \
+        (params[:raid_type] == "raid6" && raid_disks_selected < 4) || \
+        (params[:raid_type] == "raid10" && raid_disks_selected < 4)
       flash[:alert] = t("nodes.form.raid_disks_selected", node: @node.name)
       return false
     end

--- a/crowbar_framework/app/helpers/form_helper.rb
+++ b/crowbar_framework/app/helpers/form_helper.rb
@@ -70,6 +70,7 @@ module FormHelper
     options_for_select(
       [
         [t(".raid_types.single"), "single"],
+        [t(".raid_types.raid0"), "raid0"],
         [t(".raid_types.raid1"), "raid1"],
         [t(".raid_types.raid5"), "raid5"],
         [t(".raid_types.raid6"), "raid6"],

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -492,6 +492,7 @@ en:
       raid_type: 'Software RAID'
       raid_types:
         single: 'Single disk'
+        raid0: 'RAID 0'
         raid1: 'RAID 1'
         raid5: 'RAID 5'
         raid6: 'RAID 6'


### PR DESCRIPTION
we did not add this earlier, because RAID level 0 increases the
risk of data loss.
But there are advantages for compute nodes without important data:
- larger available disk space
- higher throughput