### PR TITLE
[5.0] upgrade: reduce keystone downtime

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -251,6 +251,22 @@ template "/usr/sbin/crowbar-post-upgrade.sh" do
   action :create
 end
 
+template "/usr/sbin/crowbar-shutdown-keystone.sh" do
+  source "crowbar-shutdown-keystone.sh.erb"
+  mode "0775"
+  owner "root"
+  group "root"
+  action :create
+end
+
+template "/usr/sbin/crowbar-migrate-keystone-and-start.sh" do
+  source "crowbar-migrate-keystone-and-start.sh.erb"
+  mode "0775"
+  owner "root"
+  group "root"
+  action :create
+end
+
 template "/usr/sbin/crowbar-chef-upgraded.sh" do
   source "crowbar-chef-upgraded.sh.erb"
   mode "0775"

--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -257,6 +257,7 @@ template "/usr/sbin/crowbar-shutdown-keystone.sh" do
   owner "root"
   group "root"
   action :create
+  only_if { roles.include? "keystone-server" }
 end
 
 template "/usr/sbin/crowbar-migrate-keystone-and-start.sh" do
@@ -265,6 +266,7 @@ template "/usr/sbin/crowbar-migrate-keystone-and-start.sh" do
   owner "root"
   group "root"
   action :create
+  only_if { roles.include? "keystone-server" }
 end
 
 template "/usr/sbin/crowbar-chef-upgraded.sh" do

--- a/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
@@ -35,7 +35,7 @@ log "Stopping pacemaker resources..."
 # Otherwise we could have services starting up in unwanted locations while deleting constraints.
 
 for type in clone group ms primitive; do
-    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /stonith|remote-|vip-/) {print \$2}"); do
+    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /galera|haproxy|stonith|remote-|vip-/) {print \$2}"); do
         log "Stopping resource $resource"
         crm --wait resource stop $resource
     done
@@ -53,7 +53,7 @@ log "Deleting pacemaker resources..."
 crm_cmd=""
 for type in location clone group ms primitive; do
     log "Looking at typ $type of resources..."
-    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /stonith|remote-|vip-/) {print \$2}"); do
+    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /galera|haproxy|stonith|remote-|vip-/) {print \$2}"); do
         printf -v crm_cmd "${crm_cmd}delete $resource\n"
     done
 done

--- a/chef/cookbooks/crowbar/templates/default/crowbar-migrate-keystone-and-start.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-migrate-keystone-and-start.sh.erb
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# This will execute the database schema migrations for keystone and start the
+# service by re-enabling the vhost config
+#
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-migrate-keystone-and-start-failed
+
+if [[ -f $UPGRADEDIR/crowbar-migrate-keystone-and-start-ok ]] ; then
+    log "database migration for keystone and restart of the vhost was already done."
+    exit 0
+fi
+
+# flush memcached caches
+systemctl restart memcached
+
+log "Running database migrations for keystone"
+keystone-manage db_sync
+log "Keystone database migrations completed"
+
+for vhost in admin public; do
+    log "Enabling apache vhost for keystone"
+    mv /etc/apache2/vhosts.d/keystone-$vhost.conf.disabled \
+       /etc/apache2/vhosts.d/keystone-$vhost.conf
+done
+
+log "Reloading apache2 service to start keystone vhosts"
+systemctl reload apache2
+
+touch $UPGRADEDIR/crowbar-migrate-keystone-and-start-ok
+log "$BASH_SOURCE is finished."

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-keystone.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-keystone.sh.erb
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# This makes sure that keystone is stopped by removing the vhost configuration
+# and shutting down the apache2 service. Addtionally it will restart memcached
+# to have its caches flushed,
+#
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-shutdown-keystone-failed
+
+if [[ -f $UPGRADEDIR/crowbar-shutdown-keystone-ok ]] ; then
+    log "Shut down of keystone was already done."
+    exit 0
+fi
+
+rm /etc/apache2/vhosts.d/keystone-*.conf
+systemctl stop apache2
+systemctl disable apache2
+
+# flush memcached caches
+systemctl restart memcached
+
+touch $UPGRADEDIR/crowbar-shutdown-keystone-ok
+log "$BASH_SOURCE is finished."

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-remaining-services.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-remaining-services.sh.erb
@@ -34,8 +34,14 @@ for i in $(systemctl list-units openstack* --no-legend | cut -d" " -f1) ; do
     systemctl stop $i
     systemctl disable $i
 done
-systemctl stop apache2
-systemctl disable apache2
+
+# Shutdown all apache vhost apart from keystone. Note: on the node that is
+# currently upgraded apache is being shutdown by the pre-upgrade script. So
+# this is here to ensure that the apache vhost for keystone keeps running for a
+# while on the non-upgraded nodes
+shopt -s extglob
+rm /etc/apache2/vhosts.d/!(keystone-admin|keystone-public).conf
+systemctl reload apache2
 
 touch $UPGRADEDIR/crowbar-shutdown-remaining-services-ok
 log "$BASH_SOURCE is finished."

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -972,10 +972,11 @@ module Api
         # After the cluster was upgraded, remove the temporary attribute from
         # the proposal role that was used for tracking the original (pre-upgrade)
         # value of "clone_stateless_services"
-        pacemaker_proposal = Proposal.where(barclamp: "pacemaker", name: cluster).first
-        role = pacemaker_proposal.role
-        role.default_attributes["pacemaker"].delete "clone_stateless_services_orig"
-        role.save
+        pacemaker_proposal_role = RoleObject.find_roles_by_name(cluster).first
+        pacemaker_proposal_role.default_attributes["pacemaker"].delete(
+          "clone_stateless_services_orig"
+        )
+        pacemaker_proposal_role.save
 
         Rails.logger.info("Nodes in cluster #{cluster} successfully upgraded")
       end
@@ -1006,24 +1007,31 @@ module Api
         delete_pacemaker_resources other_node
         shutdown_all_services_in_cluster node
 
-        # prevent first upgrade node to start keystone during the
-        # crowbar join call
-        node = ::Node.find_by_name(node.name)
-        node["keystone"]["disable_vhost"] = true
-        node.save
+        clone_stateless_pre_upgrade = node["pacemaker"]["clone_stateless_services_orig"].nil? ||
+          node["pacemaker"]["clone_stateless_services_orig"]
+
+        if !clone_stateless_pre_upgrade && node[:run_list_map].key?("keystone-server")
+          # prevent first upgrade node to start keystone during the
+          # crowbar join call
+          node = ::Node.find_by_name(node.name)
+          node["keystone"]["disable_vhost"] = true
+          node.save
+        end
 
         # start crowbar-join at the first node
         node_api.post_upgrade
         node_api.join_and_chef
 
-        # stop keystone on non-upgraded nodes, run db migrations
-        # and start on the upgrade node
-        keystone_migrate_and_restart node
+        if !clone_stateless_pre_upgrade && node[:run_list_map].key?("keystone-server")
+          # stop keystone on non-upgraded nodes, run db migrations
+          # and start on the upgrade node
+          keystone_migrate_and_restart node
 
-        # allow keystone to be handled by chef again
-        node = ::Node.find_by_name(node.name)
-        node["keystone"].delete "disable_vhost"
-        node.save
+          # allow keystone to be handled by chef again
+          node = ::Node.find_by_name(node.name)
+          node["keystone"].delete "disable_vhost"
+          node.save
+        end
 
         re_enable_network_agents(node, node)
         node_api.save_node_state("controller", "upgraded")

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1005,9 +1005,26 @@ module Api
         # delete old pacemaker resources (from the node where old pacemaker is running)
         delete_pacemaker_resources other_node
         shutdown_all_services_in_cluster node
+
+        # prevent first upgrade node to start keystone during the
+        # crowbar join call
+        node = ::Node.find_by_name(node.name)
+        node["keystone"]["disable_vhost"] = true
+        node.save
+
         # start crowbar-join at the first node
         node_api.post_upgrade
         node_api.join_and_chef
+
+        # stop keystone on non-upgraded nodes, run db migrations
+        # and start on the upgrade node
+        keystone_migrate_and_restart node
+
+        # allow keystone to be handled by chef again
+        node = ::Node.find_by_name(node.name)
+        node["keystone"].delete "disable_vhost"
+        node.save
+
         re_enable_network_agents(node, node)
         node_api.save_node_state("controller", "upgraded")
       end
@@ -1075,6 +1092,47 @@ module Api
         rescue StandardError => e
           raise_node_upgrade_error(
             "Error while shutting down ervices. " + e.message
+          )
+        end
+      end
+
+      # "shutdown_all_services_in_cluster" kept the keystone vhost running
+      # on the non-upgraded nodes. This method will stop the vhost on those
+      # nodes, run the db migrations and start the upgrade keystone instance
+      # on "node".
+      def keystone_migrate_and_restart(node)
+        save_node_action("Making sure that Keystone is stopped on non-upgraded nodes")
+
+        cluster = node[:pacemaker][:config][:environment]
+
+        cluster_nodes = ::Node.find(
+          "pacemaker_config_environment:#{cluster} AND " \
+          "run_list_map:pacemaker-cluster-member AND " \
+          "NOT fqdn:#{node[:fqdn]}"
+        )
+        begin
+          execute_scripts_and_wait_for_finish(
+            cluster_nodes,
+            "/usr/sbin/crowbar-shutdown-keystone.sh",
+            timeouts[:shutdown_remaining_services]
+          )
+          Rails.logger.info("All non-upgraded keystone instances were shut down.")
+        rescue StandardError => e
+          raise_node_upgrade_error(
+            "Error while shutting down keystone. " + e.message
+          )
+        end
+
+        save_node_action("Running keystone db migrations and starting keystone on upgraded node")
+        begin
+          node.wait_for_script_to_finish(
+            "/usr/sbin/crowbar-migrate-keystone-and-start.sh",
+            timeouts[:shutdown_remaining_services]
+          )
+          Rails.logger.info("Keystone DB migrated and service started.")
+        rescue StandardError => e
+          raise_node_upgrade_error(
+            "Error while migrating and restarting keystone. " + e.message
           )
         end
       end


### PR DESCRIPTION
This tries to reduce the required downtime of keystone during the upgrade. Basically we achieve this by keep keystone running on the non-upgraded nodes for a while longer and by preventing it from being started by crowbar_join on the 1st upgraded node. By doing this we have more control over when we actually run the db migrations for keystone and do the switchover. 

There's a couple of things missing for the PR to be ready for merge:

- [x] Currently this only works for setups not using cloned pacemaker resources for the stateless openstack services. Making this work with cloned resources is going to be complex as we switch from cloned to non-cloned during the upgrade (which means additional downtime)
- [x] This might need additional changes for the multicluster setups, which I completely ignored for now


There is some potential for reducing the downtime even more, by utilizing keystone's rolling upgrade features  (https://docs.openstack.org/keystone/pike/admin/identity-upgrading.html "upgrading without downtime" section). But it's uncertain that this actually works for a newton -> pike upgrade. (It would at least need increased db privileges for the keystone user to be able to install triggers).