### PR TITLE
network: add IPv6 and CIDR support

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -513,8 +513,15 @@ end
 if provisioner_address
   Chef::Log.info("Checking we can ping #{provisioner_address}; " \
                  "will wait up to 60 seconds")
+  require "ipaddr"
+  ping_cmd = if IPAddr.new(provisioner_address).ipv6?
+    "ping6"
+  else
+    "ping"
+  end
+
   60.times do
-    break if ::Kernel.system("ping -c 1 -w 1 -q #{provisioner_address} > /dev/null")
+    break if ::Kernel.system("#{ping_cmd} -c 1 -w 1 -q #{provisioner_address} > /dev/null")
     sleep 1
   end
 end


### PR DESCRIPTION
The 'network:default' chef recipe attempts to ping the
the admin IP address but fails when the admin node is using
an IPv6 address. It fails because SLE12.* ships an older version
of iputils, whose ping only supports IPv4 addresses and requires
the use of ping6 for IPv6 addresses.
This patch checks the admin ip version and uses the correct ping
binary.

This patch also adds CIDR support to
`crowbar_framework/app/models/network_service.rb`. As without it
it fails to find the admin IP to apply to the chef node causing
the admin node's eth0 interface to be de-configured.

CIDR notation is most common in IPv6 as the writing it as a full
IPv6 mask is alot more work. This patch detects whether the netmask
is in CIDR notation, if it is it'll convert it to the full notation
so it can be used in the all the IPAddr bitwise checks.