### PR TITLE
utils: Avoid creating restart resource twice

### DIFF
--- a/chef/cookbooks/utils/providers/systemd_service_restart.rb
+++ b/chef/cookbooks/utils/providers/systemd_service_restart.rb
@@ -53,6 +53,7 @@ def write_conf_snippet(new_resource, snippet_variables)
     cookbook "utils"
     source "systemd_service_restart.conf.erb"
     variables snippet_variables
+    action :nothing
     notifies :run, "bash[#{systemd_reload_resource_name}]", :immediately
   end
   template_resource.run_action(:create)


### PR DESCRIPTION
The default action is create, but we forcefully run it afterwards
so we could just skip it by setting it to :nothing. this removes
running it twice for every resource, which seems to save ~ 10-20s
on evry proposal run