### PR TITLE
upgrade: Improve handling of zypper prompts (bsc#1116853)

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -242,14 +242,18 @@ module Api
           end
 
           prompt = zypper_stream["prompt"]
+
           unless prompt.nil?
             # keep only first prompt for easier formatting
             prompt = prompt.first if prompt.is_a?(Array)
 
+            message_text = zypper_stream["message"]
+            message_text = message_text.join("\n") if message_text.is_a?(Array)
+
             upgrade_status.end_step(
               false,
               repocheck_crowbar: {
-                data: prompt["text"],
+                data: [message_text, prompt["text"]].join("\n"),
                 help: "Make sure you complete the required action and try again."
               }
             )
@@ -257,7 +261,9 @@ module Api
             return {
               status: :service_unavailable,
               error: I18n.t(
-                "api.crowbar.zypper_prompt", zypper_prompt_text: prompt["text"]
+                "api.crowbar.zypper_prompt",
+                zypper_prompt_text: prompt["text"],
+                zypper_message: message_text
               )
             }
           end

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -782,7 +782,7 @@ en:
       disallow_chef_restart_disabled: 'This API is currently disabled in crowbar.yml config file (%{option} option).'
       upgrade_ongoing: 'Upgrade is already ongoing. Please wait.'
       zypper_locked: '%{zypper_locked_message}'
-      zypper_prompt: '%{zypper_prompt_text}'
+      zypper_prompt: "Zypper requires user interaction.\n\nMessage: %{zypper_message}\nPrompt: %{zypper_prompt_text}"
       upgrade_script_path: 'Could not find %{path}'
       upgrade:
         help:

--- a/crowbar_framework/spec/fixtures/crowbar_repocheck_zypper_prompt.xml
+++ b/crowbar_framework/spec/fixtures/crowbar_repocheck_zypper_prompt.xml
@@ -1,5 +1,6 @@
 <?xml version='1.0'?>
 <stream>
+<message type="info">Repository &apos;Cloud&apos; is up to date.</message>
 <prompt id="14">
 <text>
 New repository or package signing key received:

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -345,6 +345,10 @@ describe Api::Upgrade do
       check = subject.class.adminrepocheck
       expect(check[:status]).to eq(:service_unavailable)
       expect(check[:error]).to eq(
+        "Zypper requires user interaction.\n" \
+        "\nMessage: " +
+        Hash.from_xml(crowbar_repocheck_zypper_prompt)["stream"]["message"] +
+        "\nPrompt: " +
         Hash.from_xml(crowbar_repocheck_zypper_prompt)["stream"]["prompt"]["text"]
       )
     end


### PR DESCRIPTION
Some zypper prompts include important information in <text> while
others also need <message> items to give proper feedback to the
user.

(cherry picked from commit 41c39ae58b4c2546c80b7809f4d07df714992487)

forward port of #1714 