### PR TITLE
upgrade: Increase delayed_job time limit

### DIFF
--- a/crowbar_framework/config/initializers/delayed_job_config.rb
+++ b/crowbar_framework/config/initializers/delayed_job_config.rb
@@ -35,3 +35,4 @@ else
   File.join(Rails.root, "log", "background_jobs.log")
 end
 Delayed::Worker.logger = Logger.new(log_file)
+Delayed::Worker.max_run_time = 7.days


### PR DESCRIPTION
The longest method started in the background seems to be Api::Upgrade.nodes.
Assuming 1h per node we could upgrade 168 nodes with 7 days limit.
Default limit is 4 hours which is way too low for this task.