### PR TITLE
[5.0] upgrade: Fix condition for setting clone_stateless value

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -82,7 +82,8 @@ remote_node = roles.include? "pacemaker-remote"
 is_cluster_founder = use_ha && node["pacemaker"]["founder"] == node[:fqdn]
 
 clone_stateless = if node["pacemaker"]
-  node["pacemaker"]["clone_stateless_services_orig"] || true
+  node["pacemaker"]["clone_stateless_services_orig"].nil? ||
+    node["pacemaker"]["clone_stateless_services_orig"]
 else
   true
 end


### PR DESCRIPTION
The original condition ( "something" || true ) always evaluates to true.
Checking for node["pacemaker"]["clone_stateless_services_orig"] being
nil or true should give the desired result. (clone_stateless=false only
if node["pacemaker"]["clone_stateless_services_orig"] is present and
explicitly set to false.

(this doesn't need any forward or backport)