### PR TITLE
allow skip_unready_nodes for network barclamp

### DIFF
--- a/crowbar_framework/config/crowbar.yml
+++ b/crowbar_framework/config/crowbar.yml
@@ -18,6 +18,7 @@ default: &default
     - nova-compute-vmware
     - nova-compute-xen
     - nova-compute-zvm
+    - network
     - ntp-client
     - provisioner-base
     - suse-manager-client


### PR DESCRIPTION
It is pretty tiresome to fixup bus_order when it blocks on unready
nodes. Allow skipping of unready nodes. the network barclamp will
always be executed by crowbar_join (both in --setup and --start) so
skipping it if the node isn't ready should be safe.