### PR TITLE
[5.0] upgrade: Mark correctly the set of nodes that was selected for upgrade

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -221,6 +221,7 @@ class Api::UpgradeController < ApiController
           Rails.logger.info("Restarting the 'nodes' step after previous failure")
           ::Crowbar::UpgradeStatus.new.start_step(:nodes)
         end
+        ::Crowbar::UpgradeStatus.new.save_nodes_selected_for_upgrade("compute")
       end
       Api::Upgrade.nodes component
       head :ok


### PR DESCRIPTION
Do it also for the cases when subset of compute nodes was selected.