### PR TITLE
salt: Make the barclamp visible in the UI and adjust order

### DIFF
--- a/salt.yml
+++ b/salt.yml
@@ -19,13 +19,13 @@ barclamp:
   display: 'Salt'
   description: 'Salt Management'
   version: 0
-  user_managed: false
+  user_managed: true
   member:
     - 'crowbar'
 
 crowbar:
   layout: 1
-  order: 30
-  run_order: 30
-  chef_order: 30
-  proposal_schema_version: 1
+  order: 99
+  run_order: 99
+  chef_order: 99
+  proposal_schema_version: 3


### PR DESCRIPTION
To be able to deploy salt on the admin node (and use it via salt-ssh),
the baclamp must be visible. That's done now.
Also move the barclamp in the list down (given that it is not that
important and more an optional feature).
Also change the "proposal_schema_version" to 3 which seems to be the
default in other barclamps.