### PR TITLE
crowbar: avoid nil crash when provisioner attributes are not set

### DIFF
--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -316,8 +316,12 @@ class Node < ChefObject
     return "unknown" if (@node.nil? or @role.nil?)
     if self.crowbar["state"] === "ready" and @node["ohai_time"]
       since_last = Time.now.to_i-@node["ohai_time"].to_i
-      max_last = @node.default_attrs["provisioner"]["chef_client_runs"] || 900
-      max_last += @node.default_attrs["provisioner"]["chef_splay"] || 900
+      if @node.default_attrs["provisioner"]
+        max_last = @node.default_attrs["provisioner"]["chef_client_runs"] || 900
+        max_last += @node.default_attrs["provisioner"]["chef_splay"] || 900
+      else
+        max_last = 900 + 900
+      end
       max_last += 300 # time + 5 min buffer time
       return "noupdate" if since_last > max_last
     end


### PR DESCRIPTION
The crowbar ui is currently going down when there is a node whithout
provisioner proposal:

FATAL -- NoMethodError (undefined method `[]' for nil:NilClass):
  app/models/node.rb:319:in `state'
  app/models/node.rb:285:in `status'
  app/controllers/nodes_controller.rb:606:in `block in get_nodes_and_groups'
  app/controllers/nodes_controller.rb:604:in `each'
  app/controllers/nodes_controller.rb:604:in `get_nodes_and_groups'
  app/controllers/nodes_controller.rb:59:in `index'