### PR TITLE
[5.0] upgrade: Signal all nova services after the upgrade is complete 

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -307,3 +307,11 @@ template "/usr/sbin/crowbar-reload-nova-after-upgrade.sh" do
   )
   only_if { nova_node }
 end
+
+template "/usr/sbin/crowbar-run-nova-online-migrations.sh" do
+  source "crowbar-run-nova-online-migrations.sh.erb"
+  mode "0775"
+  owner "root"
+  group "root"
+  only_if { roles.include?("nova-controller") }
+end

--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -145,6 +145,7 @@ template "/usr/sbin/crowbar-evacuate-host.sh" do
 end
 
 compute_node = roles.include? "nova-compute-kvm"
+nova_node = compute_node || roles.include?("nova-controller")
 cinder_volume = roles.include? "cinder-volume"
 neutron = search(:node, "run_list_map:neutron-server").first
 
@@ -294,4 +295,15 @@ template "/usr/sbin/crowbar-chef-upgraded.sh" do
     crowbar_join: "#{web_path}/crowbar_join.sh",
     nova_controller: roles.include?("nova-controller")
   )
+end
+
+template "/usr/sbin/crowbar-reload-nova-after-upgrade.sh" do
+  source "crowbar-reload-nova-after-upgrade.sh.erb"
+  mode "0775"
+  owner "root"
+  group "root"
+  variables(
+    nova_controller: roles.include?("nova-controller")
+  )
+  only_if { nova_node }
 end

--- a/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# After the upgrade of all services on all nodes is finished, it's
+# necessary to signal all nova services so that they start using latest RPC API version.
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-reload-nova-after-upgrade-failed
+
+if [[ -f $UPGRADEDIR/crowbar-reload-nova-after-upgrade-ok ]] ; then
+    log "Reload nova script was already successfully executed"
+    exit 0
+fi
+
+<% if @nova_controller %>
+for service in conductor consoleauth scheduler novncproxy serialproxy api; do
+    fullname="openstack-nova-$service"
+    if systemctl --quiet is-active $fullname 2>/dev/null ; then
+        systemctl kill -s HUP $fullname
+    fi
+done
+<% else %>
+systemctl kill -s HUP openstack-nova-compute
+<% end %>
+
+touch $UPGRADEDIR/crowbar-reload-nova-after-upgrade-ok
+log "$BASH_SOURCE is finished."

--- a/chef/cookbooks/crowbar/templates/default/crowbar-run-nova-online-migrations.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-run-nova-online-migrations.sh.erb
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# After the upgrade of all services on all nodes is finished and all nova services
+# run the new version, it's recommended to run nova online data migrations
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-run-nova-online-migrations-failed
+
+if [[ -f $UPGRADEDIR/crowbar-run-nova-online-migrations-ok ]] ; then
+    log "Nova migrations were already executed"
+    exit 0
+fi
+
+nova-manage db online_data_migrations
+
+# From the manual:
+# "Returns exit code 0 if migrations were successful or exit code 1 for partial updates.
+# If the command exits with partial updates (exit code 1) the command will need to be called again."
+
+# So let's call it again right away. If it fails for second time, throw an error and give
+# control to user.
+
+nova-manage db online_data_migrations
+
+ret=$?
+if [ $ret != 0 ] ; then
+    log "Error occured during online_data_migrations run"
+    echo $ret > $UPGRADEDIR/crowbar-run-nova-online-migrations-failed
+    exit $ret
+fi
+
+
+touch $UPGRADEDIR/crowbar-run-nova-online-migrations-ok
+log "$BASH_SOURCE is finished."

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -203,8 +203,7 @@ class Api::UpgradeController < ApiController
           raise ::Crowbar::Error::UpgradeError,
             "All requested nodes are already upgraded."
         end
-
-        if substep != :compute_nodes && status != :finished
+        if substep == :controller_nodes && status != :finished
           raise ::Crowbar::Error::UpgradeError.new(
             "Controller nodes must be upgraded first!"
           )

--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -225,7 +225,8 @@ class Api::UpgradeController < ApiController
         end
         # If the 'nodes' step did not fail, it is still running and user can continue
         # with upgrading single compute node.
-        if substep == :compute_nodes && status == :failed
+        if [:compute_nodes, :reload_nova, :run_online_migrations].include?(substep) &&
+            status == :failed
           Rails.logger.info("Restarting the 'nodes' step after previous failure")
           ::Crowbar::UpgradeStatus.new.start_step(:nodes)
         end

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -817,6 +817,10 @@ module Api
           reload_nova_services
           status.save_substep(:reload_nova, :finished)
 
+          status.save_substep(:run_online_migrations, :running)
+          run_online_migrations
+          status.save_substep(:run_online_migrations, :finished)
+
           finalize_nodes_upgrade
           unlock_crowbar_ui_package
           status.end_step
@@ -968,6 +972,31 @@ module Api
           Rails.logger.info("Nova services reloaded at #{node.name}.")
           save_node_action("Nova services reload finished.")
         end
+      end
+
+      # Once all nova services are running Pike, it's possible to execute
+      # online db migrations
+      def run_online_migrations
+        nova_controllers = ::Node.find("roles:nova-controller")
+        return if nova_controllers.empty?
+
+        if nova_controllers.size > 1
+          nova_controllers.select! { |n| n[:fqdn] == n[:pacemaker][:founder] }
+        end
+        node = nova_controllers.first
+
+        save_node_action("Executing nova online migrations on #{node.name}...")
+        node.wait_for_script_to_finish(
+          "/usr/sbin/crowbar-run-nova-online-migrations.sh",
+          timeouts[:nova_online_migrations]
+        )
+        Rails.logger.info("Nova online migrations finished.")
+        save_node_action("Nova online migrations finished.")
+      rescue StandardError => e
+        raise_node_upgrade_error(
+          "Problem while running nova online migrations on node #{node.name}: " \
+          "#{e.message} Check /var/log/crowbar/node-upgrade.log for details."
+        )
       end
 
       def delete_upgrade_scripts(node)

--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -36,7 +36,8 @@ module Crowbar
         delete_pacemaker_resources: @timeouts_config[:delete_pacemaker_resources] || 600,
         delete_cinder_services: @timeouts_config[:delete_cinder_services] || 300,
         delete_nova_services: @timeouts_config[:delete_nova_services] || 300,
-        wait_until_compute_started: @timeouts_config[:wait_until_compute_started] || 60
+        wait_until_compute_started: @timeouts_config[:wait_until_compute_started] || 60,
+        reload_nova_services: @timeouts_config[:reload_nova_services] || 120
       }
     end
   end

--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -37,7 +37,8 @@ module Crowbar
         delete_cinder_services: @timeouts_config[:delete_cinder_services] || 300,
         delete_nova_services: @timeouts_config[:delete_nova_services] || 300,
         wait_until_compute_started: @timeouts_config[:wait_until_compute_started] || 60,
-        reload_nova_services: @timeouts_config[:reload_nova_services] || 120
+        reload_nova_services: @timeouts_config[:reload_nova_services] || 120,
+        nova_online_migrations: @timeouts_config[:nova_online_migrations] || 1800
       }
     end
   end

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -566,6 +566,8 @@ describe Api::Upgrade do
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :progress
       ).and_return(remaining_nodes: 0)
+      allow(Api::Upgrade).to receive(:reload_nova_services).and_return(true)
+      allow(Api::Upgrade).to receive(:run_online_migrations).and_return(true)
       allow(Api::Upgrade).to receive(:finalize_nodes_upgrade).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
@@ -584,6 +586,8 @@ describe Api::Upgrade do
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :progress
       ).and_return(remaining_nodes: 0)
+      allow(Api::Upgrade).to receive(:reload_nova_services).and_return(true)
+      allow(Api::Upgrade).to receive(:run_online_migrations).and_return(true)
       allow(Api::Upgrade).to receive(:finalize_nodes_upgrade).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
@@ -672,6 +676,8 @@ describe Api::Upgrade do
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :progress
       ).and_return(remaining_nodes: 0)
+      allow(Api::Upgrade).to receive(:reload_nova_services).and_return(true)
+      allow(Api::Upgrade).to receive(:run_online_migrations).and_return(true)
       allow(Api::Upgrade).to receive(:finalize_nodes_upgrade).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
@@ -693,6 +699,8 @@ describe Api::Upgrade do
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :progress
       ).and_return(remaining_nodes: 0)
+      allow(Api::Upgrade).to receive(:reload_nova_services).and_return(true)
+      allow(Api::Upgrade).to receive(:run_online_migrations).and_return(true)
       allow(Api::Upgrade).to receive(:finalize_nodes_upgrade).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
@@ -714,6 +722,8 @@ describe Api::Upgrade do
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :progress
       ).and_return(remaining_nodes: 0)
+      allow(Api::Upgrade).to receive(:reload_nova_services).and_return(true)
+      allow(Api::Upgrade).to receive(:run_online_migrations).and_return(true)
       allow(Api::Upgrade).to receive(:finalize_nodes_upgrade).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 
@@ -749,6 +759,8 @@ describe Api::Upgrade do
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :progress
       ).and_return(remaining_nodes: 0)
+      allow(Api::Upgrade).to receive(:reload_nova_services).and_return(true)
+      allow(Api::Upgrade).to receive(:run_online_migrations).and_return(true)
       allow(Api::Upgrade).to receive(:finalize_nodes_upgrade).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:end_step).and_return(true)
 


### PR DESCRIPTION
There are operations (like attaching volume using reserve_block_device_name
method) that cannot be performed with mixed nova setup. So we pin the RPC
version to the latest one that works for Newton. That is achieved with https://github.com/crowbar/crowbar-openstack/pull/1941

After the upgrade, we need to reload (and restart?) the services so they can switch to the latest RPC version.