### PR TITLE
upgrade: Revert "upgrade: Deleting cinder services from database no longer needed

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -101,6 +101,17 @@ template "/usr/sbin/crowbar-shutdown-services-before-upgrade.sh" do
   )
 end
 
+cinder_controller = roles.include? "cinder-controller"
+
+template "/usr/sbin/crowbar-delete-cinder-services-before-upgrade.sh" do
+  source "crowbar-delete-cinder-services-before-upgrade.sh.erb"
+  mode "0755"
+  owner "root"
+  group "root"
+  action :create
+  only_if { cinder_controller && (!use_ha || is_cluster_founder) }
+end
+
 nova = search(:node, "run_list_map:nova-controller").first
 
 template "/usr/sbin/crowbar-evacuate-host.sh" do

--- a/chef/cookbooks/crowbar/templates/default/crowbar-delete-cinder-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-delete-cinder-services-before-upgrade.sh.erb
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# This script deletes existing cinder services from the database. This is necessary when upgrading to Newton.
+# They will be recreated automatically once upgraded and started.
+#
+# The script should be run only from cinder-controller.
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+
+if [[ -f $UPGRADEDIR/crowbar-delete-cinder-services-before-upgrade-ok ]] ; then
+    log "Services shutdown was already successfully executed"
+    exit 0
+fi
+
+# all cinder services must be stopped before deleting
+while cinder-manage service list 2>/dev/null | grep -q ":-)"; do
+  log "Some cinder services are still running"
+  sleep 5
+done
+
+for service in cinder-volume cinder-scheduler; do
+    hosts=$(cinder-manage service list | grep $service | tr -s ' ' | cut -d ' ' -f 2)
+    for host in $hosts; do
+        log "Removing service $service from host $host"
+        cinder-manage service remove $service $host 2>/dev/null
+    done
+done
+
+touch $UPGRADEDIR/crowbar-delete-cinder-services-before-upgrade-ok
+log "$BASH_SOURCE is finished."

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -435,8 +435,14 @@ module Api
 
         # For all nodes in cluster, set the pre-upgrade attribute
         upgrade_nodes = ::Node.find("state:crowbar_upgrade")
+        cinder_node = nil
         upgrade_nodes.each do |node|
           node.set_pre_upgrade_attribute
+          if node.roles.include?("cinder-controller") &&
+              (!node.roles.include?("pacemaker-cluster-member") ||
+                  node["pacemaker"]["founder"] == node[:fqdn])
+            cinder_node = node
+          end
         end
 
         # Initiate the services shutdown for all nodes
@@ -446,6 +452,26 @@ module Api
           timeouts[:shutdown_services]
         )
         Rails.logger.info("Services were shut down on all nodes.")
+
+        begin
+          unless cinder_node.nil?
+            cinder_node.wait_for_script_to_finish(
+              "/usr/sbin/crowbar-delete-cinder-services-before-upgrade.sh",
+              timeouts[:delete_cinder_services]
+            )
+            Rails.logger.info("Deleting of cinder services was successful.")
+          end
+        rescue StandardError => e
+          ::Crowbar::UpgradeStatus.new.end_step(
+            false,
+            services: {
+              data: "Problem while deleting cinder services: " + e.message,
+              help: "Check /var/log/crowbar/production.log at admin server. " \
+                "If the action failed at a specific node, " \
+                "check /var/log/crowbar/node-upgrade.log at the node."
+            }
+          )
+        end
 
         # Remove the temporary key from the role object
         pacemaker_proposals = Proposal.all.where(barclamp: "pacemaker")


### PR DESCRIPTION
This reverts commit b27b6d72a56bf7e9a22a4d7d93ce6df6f22db8ba and PR https://github.com/crowbar/crowbar-core/pull/1600

Turns out, it is still correct to delete those services before the upgrade.

Note that this was not clean revert, the code in `upgrade.rb` has changed a bit since the time of the original commit.