### PR TITLE
[5.0] upgrade: Do not mark nodes as upgraded before the last action

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1337,7 +1337,7 @@ module Api
         upgrade_compute_nodes type
       end
 
-      def parallel_upgrade_compute_nodes(compute_nodes)
+      def parallel_upgrade_compute_nodes(compute_nodes, controller = nil)
         Rails.logger.info("Entering parallel upgrade of compute nodes, #{upgrade_mode} mode")
         Rails.logger.info("Nodes for upgrade: #{compute_nodes.map(&:name).join(', ')}")
         save_nodes_state(compute_nodes, "compute", "upgrading")
@@ -1392,6 +1392,13 @@ module Api
           next if node.upgraded?
           node_api = Api::Node.new node.name
           node_api.post_join_cleanup
+        end
+        # enable nova-compute services for upgraded nodes.
+        unless controller.nil?
+          compute_nodes.each do |node|
+            next if node.upgraded?
+            enable_compute_service(controller, node)
+          end
         end
         # mark the finish states
         compute_nodes.each do |node|
@@ -1477,12 +1484,7 @@ module Api
           save_nodes_state(nodes_to_upgrade, "compute", "upgrading")
 
           # 2. Use original parallel upgrade method for nodes that are free of instances.
-          parallel_upgrade_compute_nodes(nodes_to_upgrade)
-
-          # 3. Enable nova-compute services for upgraded nodes.
-          nodes_to_upgrade.each do |node|
-            enable_compute_service(controller, node)
-          end
+          parallel_upgrade_compute_nodes(nodes_to_upgrade, controller)
         end
         save_nodes_state([], "", "")
       end
@@ -1523,7 +1525,7 @@ module Api
           "--host #{hostname} -f value -c Status",
           "60s"
         )
-        unless out[:stdout].chomp == "enabled"
+        if out[:stdout].nil? || out[:stdout].chomp != "enabled"
           raise_node_upgrade_error(
             "Enabling nova-compute service for '#{hostname}' has failed. " \
             "Check nova log files at '#{controller.name}' and '#{hostname}'."


### PR DESCRIPTION
Last action for compute nodes is re-enabling the compute service.
If it fails, there should be an option to run the step again, but
that is not possible if the nodes are already marked as upgraded.

Additionally, make the check for ssh command run a bit more robust.

~~Not yet tested~~