### PR TITLE
crowbar: show upgraded nodes in the blue'ish upgrade color in pie chart

### DIFF
--- a/crowbar_framework/app/assets/javascripts/application.js
+++ b/crowbar_framework/app/assets/javascripts/application.js
@@ -74,7 +74,8 @@ jQuery(document).ready(function($) {
       '#0f0',
       '#f00',
       '#999',
-      '#ff0'
+      '#ff0',
+      '#39f'
     ]
   });
 

--- a/crowbar_framework/vendor/assets/javascripts/jquery/ledUpdate.js
+++ b/crowbar_framework/vendor/assets/javascripts/jquery/ledUpdate.js
@@ -70,8 +70,8 @@
             val.status.ready,
             val.status.failed,
             val.status.unknown,
-            val.status.crowbar_upgrade,
-            val.status.unready + val.status.pending
+            val.status.unready + val.status.pending,
+            val.status.crowbar_upgrade
           ];
 
           current.attr('title', val.tooltip).tooltip('destroy').tooltip({
@@ -89,7 +89,8 @@
                 '#0f0',
                 '#f00',
                 '#999',
-                '#ff0'
+                '#ff0',
+                '#39f',
               ]
             }
           );


### PR DESCRIPTION
Currently upgraded nodes are counted as not ready (yellow) while
they're actually very much ready. this seems to be because we're missing
a color for the associated state in the pie definition.