### PR TITLE
[5.0] upgrade: Reset the current nodes list before new set of nodes

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1449,6 +1449,10 @@ module Api
         # continue with that one.
         compute_nodes.sort! { |n| n.upgrading? ? -1 : 1 }
 
+        # before the upgrade starts, reset the current nodes list
+        # (so it does not show possibly old situation from previous run)
+        save_nodes_state([], "", "")
+
         while compute_nodes.any?
           # 1. Evacuate as many as possible, create a subset of nodes without instances.
           nodes_to_upgrade = []


### PR DESCRIPTION
I want to prevent situations like this one:

```:current_step: :nodes
:current_substep: :compute_nodes
:current_substep_status: :running
:current_nodes:
- :name: d8c-dc-d4-0d-59-48.ecp1.cloud.suse.de
  :alias: compute21
  :ip: 10.86.32.36
  :state: upgraded
  :role: compute
:current_node_action: live-migrating nova instances from d5c-b9-01-89-b9-08
:remaining_nodes: 73
:upgraded_nodes: 102
```