### PR TITLE
upgrade: Mark correctly the set of nodes that was selected for upgrade

### DIFF
--- a/crowbar_framework/app/controllers/api/upgrade_controller.rb
+++ b/crowbar_framework/app/controllers/api/upgrade_controller.rb
@@ -216,6 +216,7 @@ class Api::UpgradeController < ApiController
           Rails.logger.info("Restarting the 'nodes' step after previous failure")
           ::Crowbar::UpgradeStatus.new.start_step(:nodes)
         end
+        ::Crowbar::UpgradeStatus.new.save_nodes_selected_for_upgrade("compute")
       end
       Api::Upgrade.nodes component
       head :ok


### PR DESCRIPTION
Do it also for the cases when subset of compute nodes was selected.

(cherry picked from commit a21566ff56533ff55d8bc3cff9923c0a2e32ac73)

Port of https://github.com/crowbar/crowbar-core/pull/1731