### PR TITLE
crowbar: Add rake task to set the schema-revision

### DIFF
--- a/crowbar_framework/lib/schema_migration.rb
+++ b/crowbar_framework/lib/schema_migration.rb
@@ -64,6 +64,14 @@ module SchemaMigration
     end
   end
 
+  # set the schema revision number to revision
+  # This is useful to rerun migration scripts
+  def self.set_proposal_schema_revision(bc_name, revision)
+    proposal = Proposal.where(barclamp: bc_name).limit(1)[0]
+    proposal.properties["deployment"][bc_name]["schema-revision"] = revision.to_i
+    proposal.save
+  end
+
   def self.migrate_proposal_from_json(bc_name, json)
     template = get_template_for_barclamp bc_name
     return if template.nil?

--- a/crowbar_framework/lib/tasks/crowbar.rake
+++ b/crowbar_framework/lib/tasks/crowbar.rake
@@ -16,6 +16,13 @@
 #
 
 namespace :crowbar do
+  desc "Set the schema-revision for a given barclmap"
+  task :set_schema_revision, [:barclamp, :schema_revision] => :environment do |t, args|
+
+    require "schema_migration"
+    SchemaMigration.set_proposal_schema_revision(args[:barclamp], args[:schema_revision])
+  end
+
   desc "Run schema migration on proposals"
   task :schema_migrate, [:barclamps] => :environment do |t, args|
     args.with_defaults(barclamps: "all")


### PR DESCRIPTION
When working with migrations, it's useful to be able to set the schema
revision to a lower value to rerun the latest migration.
With this change, there is a new rake task called
"set_schema_revision". This can be used like:

- get the current revision status for the available proposals
$ RAILS_ENV=production ./bin/rake crowbar:schema_migrate_status

- set the schema-revision to a lower number (in this case 299)
$ RAILS_ENV=production ./bin/rake \
  crowbar:set_schema_revision[crowbar,299]

- Now run the migration for the crowbar barclamp again
$ RAILS_ENV=production ./bin/rake crowbar:schema_migrate[crowbar]