### PR TITLE
upgrade: reduce keystone downtime 

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -238,6 +238,22 @@ template "/usr/sbin/crowbar-post-upgrade.sh" do
   action :create
 end
 
+template "/usr/sbin/crowbar-shutdown-keystone.sh" do
+  source "crowbar-shutdown-keystone.sh.erb"
+  mode "0775"
+  owner "root"
+  group "root"
+  action :create
+end
+
+template "/usr/sbin/crowbar-migrate-keystone-and-start.sh" do
+  source "crowbar-migrate-keystone-and-start.sh.erb"
+  mode "0775"
+  owner "root"
+  group "root"
+  action :create
+end
+
 template "/usr/sbin/crowbar-chef-upgraded.sh" do
   source "crowbar-chef-upgraded.sh.erb"
   mode "0775"

--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -244,6 +244,7 @@ template "/usr/sbin/crowbar-shutdown-keystone.sh" do
   owner "root"
   group "root"
   action :create
+  only_if { roles.include? "keystone-server" }
 end
 
 template "/usr/sbin/crowbar-migrate-keystone-and-start.sh" do
@@ -252,6 +253,7 @@ template "/usr/sbin/crowbar-migrate-keystone-and-start.sh" do
   owner "root"
   group "root"
   action :create
+  only_if { roles.include? "keystone-server" }
 end
 
 template "/usr/sbin/crowbar-chef-upgraded.sh" do

--- a/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
@@ -35,7 +35,7 @@ log "Stopping pacemaker resources..."
 # Otherwise we could have services starting up in unwanted locations while deleting constraints.
 
 for type in clone group ms primitive; do
-    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /drbd|stonith|remote-|vip-/) {print \$2}"); do
+    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /galera|haproxy|stonith|remote-|vip-/) {print \$2}"); do
         log "Stopping resource $resource"
         crm --wait resource stop $resource
     done
@@ -53,7 +53,7 @@ log "Deleting pacemaker resources..."
 crm_cmd=""
 for type in location clone group ms primitive; do
     log "Looking at typ $type of resources..."
-    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /drbd|stonith|remote-|vip-/) {print \$2}"); do
+    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /galera|haproxy|stonith|remote-|vip-/) {print \$2}"); do
         printf -v crm_cmd "${crm_cmd}delete $resource\n"
     done
 done

--- a/chef/cookbooks/crowbar/templates/default/crowbar-migrate-keystone-and-start.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-migrate-keystone-and-start.sh.erb
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# This will execute the database schema migrations for keystone and start the
+# service by re-enabling the vhost config
+#
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-migrate-keystone-and-start-failed
+
+if [[ -f $UPGRADEDIR/crowbar-migrate-keystone-and-start-ok ]] ; then
+    log "database migration for keystone and restart of the vhost was already done."
+    exit 0
+fi
+
+# flush memcached caches
+systemctl restart memcached
+
+log "Running database migrations for keystone"
+keystone-manage db_sync
+log "Keystone database migrations completed"
+
+for vhost in admin public; do
+    log "Enabling apache vhost for keystone"
+    mv /etc/apache2/vhosts.d/keystone-$vhost.conf.disabled \
+       /etc/apache2/vhosts.d/keystone-$vhost.conf
+done
+
+log "Reloading apache2 service to start keystone vhosts"
+systemctl reload apache2
+
+touch $UPGRADEDIR/crowbar-migrate-keystone-and-start-ok
+log "$BASH_SOURCE is finished."

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-keystone.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-keystone.sh.erb
@@ -1,0 +1,40 @@
+#!/bin/bash
+#
+# This makes sure that keystone is stopped by removing the vhost configuration
+# and shutting down the apache2 service. Addtionally it will restart memcached
+# to have its caches flushed,
+#
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-shutdown-keystone-failed
+
+if [[ -f $UPGRADEDIR/crowbar-shutdown-keystone-ok ]] ; then
+    log "Shut down of keystone was already done."
+    exit 0
+fi
+
+rm /etc/apache2/vhosts.d/keystone-*.conf
+systemctl stop apache2
+systemctl disable apache2
+
+# flush memcached caches
+systemctl restart memcached
+
+touch $UPGRADEDIR/crowbar-shutdown-keystone-ok
+log "$BASH_SOURCE is finished."

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-remaining-services.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-remaining-services.sh.erb
@@ -34,8 +34,14 @@ for i in $(systemctl list-units openstack* --no-legend | cut -d" " -f1) ; do
     systemctl stop $i
     systemctl disable $i
 done
-systemctl stop apache2
-systemctl disable apache2
+
+# Shutdown all apache vhost apart from keystone. Note: on the node that is
+# currently upgraded apache is being shutdown by the pre-upgrade script. So
+# this is here to ensure that the apache vhost for keystone keeps running for a
+# while on the non-upgraded nodes
+shopt -s extglob
+rm /etc/apache2/vhosts.d/!(keystone-admin|keystone-public).conf
+systemctl reload apache2
 
 touch $UPGRADEDIR/crowbar-shutdown-remaining-services-ok
 log "$BASH_SOURCE is finished."

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -478,15 +478,6 @@ module Api
             }
           )
         end
-
-        # Remove the temporary key from the role object
-        pacemaker_proposals = Proposal.all.where(barclamp: "pacemaker")
-        pacemaker_proposals.each do |proposal|
-          role = proposal.role
-          role.default_attributes["pacemaker"].delete "clone_stateless_services_orig"
-          role.save
-        end
-
         ::Crowbar::UpgradeStatus.new.end_step
       rescue ::Crowbar::Error::Upgrade::ServicesError => e
         ::Crowbar::UpgradeStatus.new.end_step(
@@ -980,6 +971,14 @@ module Api
         non_founder_nodes.each do |node|
           upgrade_next_cluster_node node, founder
         end
+
+        # After the cluster was upgraded, remove the temporary attribute from
+        # the proposal role that was used for tracking the original (pre-upgrade)
+        # value of "clone_stateless_services"
+        pacemaker_proposal = Proposal.where(barclamp: "pacemaker", name: cluster).first
+        role = pacemaker_proposal.role
+        role.default_attributes["pacemaker"].delete "clone_stateless_services_orig"
+        role.save
 
         Rails.logger.info("Nodes in cluster #{cluster} successfully upgraded")
       end


### PR DESCRIPTION
This tries to reduce the required downtime of keystone during the upgrade. Basically we achieve this by keep keystone running on the non-upgraded nodes for a while longer and by preventing it from being started by crowbar_join on the 1st upgraded node. By doing this we have more control over when we actually run the db migrations for keystone and do the switchover.

Forward port of #1715