### PR TITLE
upgrade: Skip powered off compute nodes during the upgrade prechecks

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -91,7 +91,12 @@ module Api
         unready = []
         # We are ignoring the ceph nodes, as they should already be in crowbar_upgrade state
         NodeObject.find("NOT roles:ceph-*").each do |node|
-          unready << node.name unless node.ready?
+          next if node.ready?
+          if node.state == "shutdown" && node.roles.include?("nova-compute-kvm")
+            Rails.logger.info("ignoring powered off compute node...")
+            next
+          end
+          unready << node.name
         end
         ret[:nodes_not_ready] = unready unless unready.empty?
         failed = Proposal.all.select { |p| p.active? && p.failed? }

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -240,7 +240,7 @@ class CrowbarService < ServiceObject
     admin_with_dns_server_role = false
     all_nodes = Node.all
     all_nodes.each do |n|
-      not_ready_for_upgrade.push n.name if !n.admin? && !%w(ready crowbar_upgrade).include?(n.state)
+      not_ready_for_upgrade.push n.name if !n.admin? && !%w(ready crowbar_upgrade shutdown).include?(n.state)
       admin_with_dns_server_role = true if n.admin? && n.role?("dns-server")
     end
 
@@ -256,6 +256,7 @@ class CrowbarService < ServiceObject
 
     all_nodes.each do |node|
       next if node.admin?
+      next if node.state == "shutdown"
 
       if node[:platform] == "windows"
         # for Hyper-V nodes, only change the state, but do not run chef-client


### PR DESCRIPTION
Originally https://github.com/crowbar/crowbar-core/pull/1695

Targeting specific branch to keep the work somewhere