### PR TITLE
upgrade: Ignore shut down nodes throughout the upgrade

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
@@ -56,15 +56,30 @@ openstack server list --insecure --all-projects --status active --host $host -f 
 i=0
 while [[ $i -lt 10 ]] && openstack --insecure compute service list --service nova-compute -f value -c State | grep down ; do
     log "Some nova-compute service is still down..."
+    # Find out hosts where nova-compute is down
+    hosts=$(openstack --insecure compute service list --service nova-compute -f value -c Host -c State | grep down | cut -f 1 -d " ")
+    some_host_is_up=0
+    for host_down in $hosts; do
+        # Check if hypervisor is down as well
+        if [ $(openstack --insecure hypervisor list --matching $host_down -f value -c State) = "up" ] ; then
+            some_host_is_up=1
+            break
+        fi
+    done
+    # Ignore cases where also the hosts (not just services) are down 
+    if [ "$some_host_is_up" = 0 ]; then
+        log "It appears that hypervisors are down as well."
+        break
+    fi
     sleep 6
     i=$(($i + 1))
+    # Give up after last cycle
+    if [[ $i -eq 10 ]]; then
+        log "Some nova-compute service is still down. Check the state of compute nodes before proceeding with the live-migration."
+        echo 4 > $UPGRADEDIR/crowbar-evacuate-host-failed
+        exit 4
+    fi
 done
-
-if openstack --insecure compute service list --service nova-compute -f value -c State | grep down ; then
-    log "Some nova-compute service is still down. Check the state of compute nodes before proceeding with the live-migration."
-    echo 4 > $UPGRADEDIR/crowbar-evacuate-host-failed
-    exit 4
-fi
 
 if ! nova --insecure host-evacuate-live "$host" $blockmigrate; then
     log "Live migration of instances from host $host has failed!"

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1250,7 +1250,7 @@ module Api
       # Prepare the compute nodes for upgrade by upgrading necessary packages
       def prepare_compute_nodes(virt)
         Rails.logger.info("Preparing #{virt} compute nodes for upgrade... ")
-        compute_nodes = ::Node.find("roles:nova-compute-#{virt}")
+        compute_nodes = ::Node.find("roles:nova-compute-#{virt} AND NOT state:shutdown")
         if compute_nodes.empty?
           Rails.logger.info("There are no compute nodes of #{virt} type.")
           return
@@ -1336,7 +1336,7 @@ module Api
 
       def upgrade_compute_nodes(virt)
         Rails.logger.info("Upgrading #{virt} compute nodes... ")
-        compute_nodes = ::Node.find("roles:nova-compute-#{virt}")
+        compute_nodes = ::Node.find("roles:nova-compute-#{virt} AND NOT state:shutdown")
         if compute_nodes.empty?
           Rails.logger.info("There are no compute nodes of #{virt} type.")
           return

--- a/crowbar_framework/app/models/node.rb
+++ b/crowbar_framework/app/models/node.rb
@@ -868,6 +868,7 @@ class Node < ChefObject
 
   def upgraded?
     upgrade_state = crowbar["node_upgrade_state"] || ""
+    return false if upgrade_state == "" && @node.state == "shutdown"
     if upgrade_state == "upgraded" ||
         (upgrade_state == "" && !crowbar.key?("crowbar_upgrade_step"))
       Rails.logger.info("Node #{@node.name} was already upgraded.")

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -504,7 +504,8 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to receive(:do_controllers_substep).and_return(true)
 
       allow(Node).to(
-        receive(:find).with("roles:nova-compute-*").and_return([node1, node2])
+        receive(:find).with("roles:nova-compute-* AND NOT state:shutdown")
+        .and_return([node1, node2])
       )
 
       # parallel_upgrade_compute_nodes:
@@ -572,7 +573,8 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to receive(:remaining_nodes).and_return(1)
       allow(Api::Upgrade).to receive(:do_controllers_substep).and_return(true)
       allow(Node).to(
-        receive(:find).with("roles:nova-compute-kvm").and_return([])
+        receive(:find).with("roles:nova-compute-kvm AND NOT state:shutdown")
+        .and_return([])
       )
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
         :start_step
@@ -606,8 +608,8 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to receive(:remaining_nodes).and_return(1)
       allow(Api::Upgrade).to receive(:do_controllers_substep).and_return(true)
       allow(Node).to(
-        receive(:find).with("roles:nova-compute-kvm").
-        and_return([Node.find_by_name("testing.crowbar.com")])
+        receive(:find).with("roles:nova-compute-kvm AND NOT state:shutdown")
+        .and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow_any_instance_of(Node).to receive(:upgraded?).and_return(false)
       allow(Node).to(
@@ -681,8 +683,8 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to receive(:remaining_nodes).and_return(1)
       allow(Api::Upgrade).to receive(:do_controllers_substep).and_return(true)
       allow(Node).to(
-        receive(:find).with("roles:nova-compute-kvm").
-        and_return([Node.find_by_name("testing.crowbar.com")])
+        receive(:find).with("roles:nova-compute-kvm AND NOT state:shutdown")
+        .and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow_any_instance_of(Node).to receive(:upgraded?).and_return(true)
       allow(Api::Upgrade).to receive(:upgrade_all_compute_nodes).and_return(true)
@@ -703,8 +705,8 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to receive(:do_controllers_substep).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(:save_substep).and_return(true)
       allow(Node).to(
-        receive(:find).with("roles:nova-compute-kvm").
-        and_return([Node.find_by_name("testing.crowbar.com")])
+        receive(:find).with("roles:nova-compute-kvm AND NOT state:shutdown")
+        .and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow_any_instance_of(Node).to receive(:upgraded?).and_return(true)
       allow_any_instance_of(Crowbar::UpgradeStatus).to receive(
@@ -720,8 +722,8 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to receive(:remaining_nodes).and_return(1)
       allow(Api::Upgrade).to receive(:do_controllers_substep).and_return(true)
       allow(Node).to(
-        receive(:find).with("roles:nova-compute-kvm").
-        and_return([Node.find_by_name("testing.crowbar.com")])
+        receive(:find).with("roles:nova-compute-kvm AND NOT state:shutdown")
+        .and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow(Node).to(
         receive(:find).with("roles:nova-controller").


### PR DESCRIPTION
During live migration, we have a check that makes sure all available
nova-compute services are up. This check has to exclude nodes that are shut down.

Originally https://github.com/crowbar/crowbar-core/pull/1697