### PR TITLE
Revert "upgrade: Remove manipulation with ceph nodes from upgrade wor…

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -79,7 +79,7 @@ module Api
 
       def addons
         [].tap do |list|
-          ["ha"].each do |addon|
+          ["ceph", "ha"].each do |addon|
             list.push(addon) if addon_installed?(addon) && addon_deployed?(addon)
           end
         end
@@ -89,7 +89,8 @@ module Api
       def health_check
         ret = {}
         unready = []
-        NodeObject.all.each do |node|
+        # We are ignoring the ceph nodes, as they should already be in crowbar_upgrade state
+        NodeObject.find("NOT roles:ceph-*").each do |node|
           unready << node.name unless node.ready?
         end
         ret[:nodes_not_ready] = unready unless unready.empty?
@@ -305,6 +306,8 @@ module Api
 
       def addon_installed?(addon)
         case addon
+        when "ceph"
+          CephService
         when "ha"
           PacemakerService
         else
@@ -317,6 +320,8 @@ module Api
 
       def addon_deployed?(addon)
         case addon
+        when "ceph"
+          ::Node.find("roles:ceph-* AND ceph_config_environment:*").any?
         when "ha"
           ::Node.find("pacemaker_config_environment:*").any?
         end

--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -279,8 +279,13 @@ module Api
             ret["os"] ||= []
             ret["os"].push(arch) unless ret["os"].include?(arch)
 
-            ret["openstack"] ||= []
-            ret["openstack"].push(arch) unless ret["openstack"].include?(arch)
+            if ceph_node?(node)
+              ret["ceph"] ||= []
+              ret["ceph"].push(arch) unless ret["ceph"].include?(arch)
+            else
+              ret["openstack"] ||= []
+              ret["openstack"].push(arch) unless ret["openstack"].include?(arch)
+            end
 
             if pacemaker_node?(node)
               ret["ha"] ||= []
@@ -288,6 +293,10 @@ module Api
             end
           end
         end
+      end
+
+      def ceph_node?(node)
+        node.roles.include?("ceph-config-default")
       end
 
       def pacemaker_node?(node)

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -440,7 +440,7 @@ module Api
         check_for_running_instances if upgrade_mode == :normal
 
         # For all nodes in cluster, set the pre-upgrade attribute
-        upgrade_nodes = ::Node.find("state:crowbar_upgrade")
+        upgrade_nodes = ::Node.find("state:crowbar_upgrade AND NOT roles:ceph-*")
         cinder_node = nil
         upgrade_nodes.each do |node|
           node.set_pre_upgrade_attribute
@@ -714,6 +714,10 @@ module Api
       end
 
       def do_controllers_substep(substep)
+        if substep == :ceph_nodes
+          join_ceph_nodes
+          substep = :controller_nodes
+        end
         if substep == :controller_nodes
           upgrade_controller_clusters
           upgrade_non_compute_nodes
@@ -749,6 +753,10 @@ module Api
         end
 
         if substep.nil? || substep.empty?
+          substep = :ceph_nodes
+        end
+
+        if substep == :ceph_nodes && substep_status == :finished
           substep = :controller_nodes
         end
 
@@ -932,6 +940,23 @@ module Api
         ].map { |f| "/usr/sbin/crowbar-#{f}.sh" }.join(" ")
         scripts_to_delete << " /etc/neutron/lbaas-connection.conf"
         node.run_ssh_cmd("rm -f #{scripts_to_delete}")
+      end
+
+      # Ceph nodes were upgraded independently, we only need to make them ready again
+      def join_ceph_nodes
+        ceph_nodes = ::Node.find("roles:ceph-*")
+        ceph_nodes.sort! { |n| n.upgrading? ? -1 : 1 }
+
+        ceph_nodes.each do |node|
+          return true if node.upgraded?
+          Rails.logger.info("Joining ceph node #{node.name}")
+          node_api = Api::Node.new node.name
+          node_api.save_node_state("ceph", "upgrading")
+          node_api.join_and_chef
+          node_api.save_node_state("ceph", "upgraded")
+        end
+        ::Crowbar::UpgradeStatus.new.save_substep(:ceph_nodes, :finished)
+        save_nodes_state([], "", "")
       end
 
       def finalize_nodes_upgrade

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -92,7 +92,7 @@ describe Api::Crowbar do
 
   context "with addons enabled" do
     it "lists the enabled addons" do
-      ["ha"].each do |addon|
+      ["ceph", "ha"].each do |addon|
         allow(Api::Crowbar).to(
           receive(:addon_installed?).with(addon).
           and_return(true)
@@ -108,7 +108,7 @@ describe Api::Crowbar do
         )
       end
 
-      expect(subject.class.addons).to eq(["ha"])
+      expect(subject.class.addons).to eq(["ceph", "ha"])
     end
   end
 
@@ -132,9 +132,8 @@ describe Api::Crowbar do
   context "with cloud not healthy" do
     it "finds a node that is not ready" do
       allow(NodeObject).to(
-        receive(:find_all_nodes).and_return(
-          [NodeObject.find_node_by_name("testing.crowbar.com")]
-        )
+        receive(:find).with("NOT roles:ceph-*").
+        and_return([NodeObject.find_node_by_name("testing.crowbar.com")])
       )
       allow_any_instance_of(NodeObject).to(receive(:ready?).and_return(false))
 

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -164,9 +164,8 @@ describe Api::Upgrade do
         :prepare_nodes_for_os_upgrade
       ).and_return(true)
       allow(Node).to(
-        receive(:find).with("state:crowbar_upgrade").and_return(
-          [Node.find_by_name("testing.crowbar.com")]
-        )
+        receive(:find).with("state:crowbar_upgrade AND NOT roles:ceph-*").
+        and_return([Node.find_by_name("testing.crowbar.com")])
       )
       allow_any_instance_of(Node).to(
         receive(:set_pre_upgrade_attribute).and_return([200, ""])
@@ -461,6 +460,7 @@ describe Api::Upgrade do
   context "upgrading the nodes in normal mode" do
     it "successfully upgrades controller nodes" do
       allow(Api::Upgrade).to receive(:remaining_nodes).and_return(1)
+      allow(Api::Upgrade).to receive(:join_ceph_nodes).and_return(true)
 
       allow(Api::Upgrade).to receive(:upgrade_mode).and_return(:normal)
 
@@ -543,6 +543,7 @@ describe Api::Upgrade do
       testing = Node.find_by_name("testing.crowbar.com")
 
       allow(Node).to(receive(:find).with("state:crowbar_upgrade").and_return([testing]))
+      allow(Api::Upgrade).to receive(:join_ceph_nodes).and_return(true)
       allow(Api::Upgrade).to receive(:upgrade_controller_clusters).and_return(true)
 
       # upgrade_non_compute_nodes:
@@ -641,6 +642,7 @@ describe Api::Upgrade do
         :start_step
       ).with(:nodes).and_return(true)
       allow(Api::Upgrade).to receive(:remaining_nodes).and_return(1)
+      allow(Api::Upgrade).to receive(:join_ceph_nodes).and_return(true)
       allow(Node).to(
         receive(:find).
         with(


### PR DESCRIPTION
…flow"

This reverts commit cfb0aabb046f492ab82b565915e6cd797870c537.

Originally https://github.com/crowbar/crowbar-core/pull/1694 . Not into product, just to archive the work