### PR TITLE
[5.0] travis fix for bundler problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,7 @@ addons:
   apt:
     packages:
       - libarchive-dev
+
+# pin bundler to avoid problems with old ruby and new deps
+before_install:
+  - rvm @global do gem install bundler -v '< 2.0.0'


### PR DESCRIPTION
Bundler version >= 2.0.0 requires rubygems >= 3.0.
There seems to be no simple way to upgrade rubygems with ruby2.1.
Pinning bundler to older version solves the problem.

see:
https://travis-ci.community/t/bundle-is-not-installed-for-ruby-2-3/1641
https://github.com/travis-ci/travis-ci/issues/5290

port of #1755