### PR TITLE
upgrade: Skip already upgraded nodes+fail with no upgradeable nodes

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1520,6 +1520,12 @@ module Api
           ::Node.find_node_by_name_or_alias(name)
         end
 
+        # make sure we upgrade each node only once
+        compute_nodes.uniq!(&:name)
+
+        # remove nodes which were already upgraded
+        compute_nodes.reject!(&:upgraded?)
+
         controller = fetch_nova_controller
 
         # If there's a compute node which we already started to upgrade,

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -964,7 +964,7 @@ module Api
           "run_list_map:pacemaker-cluster-member AND " \
           "NOT fqdn:#{founder[:fqdn]}"
         )
-        non_founder_nodes.select! { |n| !n.upgraded? }
+        non_founder_nodes.reject!(&:upgraded?)
 
         if founder.upgraded? && non_founder_nodes.empty?
           Rails.logger.info("All nodes in cluster #{cluster} have already been upgraded.")
@@ -1365,7 +1365,7 @@ module Api
         end
 
         # remove upgraded compute nodes
-        compute_nodes.select! { |n| !n.upgraded? }
+        compute_nodes.reject!(&:upgraded?)
         if compute_nodes.empty?
           Rails.logger.info(
             "All compute nodes of #{virt} type are already upgraded."
@@ -1489,7 +1489,7 @@ module Api
         end
 
         # remove upgraded compute nodes
-        compute_nodes.select! { |n| !n.upgraded? }
+        compute_nodes.reject!(&:upgraded?)
         if compute_nodes.empty?
           Rails.logger.info(
             "All compute nodes of #{virt} type are already upgraded."

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1557,6 +1557,13 @@ module Api
               break
             end
           end
+          if nodes_to_upgrade.empty?
+            raise_node_upgrade_error(
+              "There was a problem during live evacuation of #{compute_nodes.first[:name]}. " \
+              "Cannot proceed with upgrade of compute nodes. " \
+              "Check /var/log/crowbar/production.log and nova logs for details."
+            )
+          end
           compute_nodes -= nodes_to_upgrade
           save_nodes_state(nodes_to_upgrade, "compute", "upgrading")
 


### PR DESCRIPTION
**Skip already upgraded nodes**
If list of nodes is requested for upgrade, already upgraded nodes will be
skipped. Re-running upgrade procedure on an already upgraded node could
trigger various problems.
+
**Fail if no nodes can be upgraded**
This can happen e.g. if some live evacuation doesn't succeed.
The added condition should ensure non_disruptive_upgrade_compute_nodes()
will not loop forever.

port of #1741