### PR TITLE
upgrade: Delete nova services that are registered to unknown nodes

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -105,6 +105,22 @@ template "/usr/sbin/crowbar-delete-cinder-services-before-upgrade.sh" do
   only_if { cinder_controller && (!use_ha || is_cluster_founder) }
 end
 
+controller_nodes = search(:node, "run_list_map:nova-controller").map { |n| n["hostname"] }
+compute_nodes = search(:node, "run_list_map:nova-compute-*").map { |n| n["hostname"] }
+
+template "/usr/sbin/crowbar-delete-unknown-nova-services.sh" do
+  source "crowbar-delete-unknown-nova-services.sh.erb"
+  mode "0755"
+  owner "root"
+  group "root"
+  action :create
+  variables(
+    controller_nodes: controller_nodes.join(","),
+    compute_nodes: compute_nodes.join(",")
+  )
+  only_if { roles.include?("nova-controller") }
+end
+
 nova = search(:node, "run_list_map:nova-controller").first
 
 template "/usr/sbin/crowbar-evacuate-host.sh" do

--- a/chef/cookbooks/crowbar/templates/default/crowbar-delete-unknown-nova-services.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-delete-unknown-nova-services.sh.erb
@@ -1,0 +1,62 @@
+#!/bin/bash
+#
+# Before the nodes upgrade, we should delete nova services
+# that are supposed to run on the nodes that are not known to crowbar.
+#
+# If such old services would stay in database, it would not be possible
+# to convince fully upgraded nova to use the latest RPC API.
+#
+# The script should be run only from nova controller.
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+
+if [[ -f $UPGRADEDIR/crowbar-delete-unknown-nova-services-ok ]] ; then
+    log "Unknown services were was already deleted"
+    exit 0
+fi
+
+set +x
+source /root/.openrc
+set -x
+
+# Delete all nova-compute services that are registered to a node
+# that does not have nova-compute crowbar role
+for host in $(openstack compute service list --service nova-compute -f value -c Host | sort | uniq); do
+    # @compute_nodes is comma separated string like "node1,node2,node3"
+    if [[ ! ",<%=@compute_nodes%>," =~ ",$host," ]]; then
+        for service in $(openstack compute service list --service nova-compute --host "$host" -f value -c ID); do
+            openstack compute service delete $service
+        done
+    fi
+
+# Delete all controller based nova services that are registered to a node
+# that does not have nova-controller crowbar role
+for s in cert conductor consoleauth scheduler; do
+    for host in $(openstack compute service list --service "nova-$s" -f value -c Host | sort | uniq); do
+        # @controller_nodes is comma separated string like "node1,node2,node3"
+        if [[ ! ",<%=@controller_nodes%>," =~ ",$host," ]]; then
+            for service in $(openstack compute service list --service "nova-$s" --host "$host" -f value -c ID); do
+                openstack compute service delete $service
+            done
+        fi
+    done
+done
+
+touch $UPGRADEDIR/crowbar-delete-unknown-nova-services-ok
+log "$BASH_SOURCE is finished."

--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -35,6 +35,7 @@ module Crowbar
         set_network_agents_state: @timeouts_config[:set_network_agents_state] || 300,
         delete_pacemaker_resources: @timeouts_config[:delete_pacemaker_resources] || 600,
         delete_cinder_services: @timeouts_config[:delete_cinder_services] || 300,
+        delete_nova_services: @timeouts_config[:delete_nova_services] || 300,
         wait_until_compute_started: @timeouts_config[:wait_until_compute_started] || 60
       }
     end


### PR DESCRIPTION
If such (presumably old) services would stay in database, it would not be possible
to convince fully upgraded nova to use the latest RPC API.

(cherry picked from commit d7d9214088a4873a05e207d51ab2af5f2f70e4e8)

Port of https://github.com/crowbar/crowbar-core/pull/1754