### PR TITLE
Added ability to include recipes smartly

### DIFF
--- a/chef/cookbooks/barclamp/libraries/smartroles.rb
+++ b/chef/cookbooks/barclamp/libraries/smartroles.rb
@@ -1,0 +1,24 @@
+require 'chef/mixin/language_include_recipe'
+
+class Chef
+  module Mixin
+    module LanguageIncludeRecipe
+      def include_recipe_smartly(*list_of_recipes)
+        for recipe in list_of_recipes
+          included=false
+          for dependency in BarclampLibrary::Barclamp::DependsOn.get(recipe)
+            if BarclampLibrary::Barclamp::Config.has_changes_to_apply(dependency)
+              Chef::Log.info("smart including recipe: #{recipe}")
+              Chef::Log.debug("due to change in: #{dependency}")
+              include_recipe recipe
+              included=true
+              break
+            end # if
+          end # for
+          Chef::Log.info("recipe excluded: #{recipe}") unless included
+        end # for
+      end # def include_recipe_smartly
+    end
+  end
+end
+


### PR DESCRIPTION
Roles can get smart by making recipe inform the role about its dependencies
across the proposal.

So a recipe will be included by the role only if the attributes
registered by the recipe are actually changed in current chef-client
run.

a recipe can register its dependencies as
```
mydependson = {
    "horizon::server" => [
        ['glance','api','bind_port']
    ]
}

BarclampLibrary::Barclamp::DependsOn.add(mydependson)
```
So here the "horizon::server"  is informing about its
dependencies.

This is accomplished by comparing the value of the current attributes of node
against the one already stored in the databag after the previous successful
chef-client run.

BarclampLibrary::Barclamp::DependsOn.add:
takes in a map:
```
     recipe_name => [
                [barclampname,drill,down,till,value],
                [otherbarclampname,onlyhere],
               ]
```
This map is flushed and recreated only everyrun, however like resources
this could also be cached.

this behaviour can be altered by adding flag to config and using it
'include_recipe_smartly', however that is an extension to this behavior
and can be addressed in subsequent commits