### PR TITLE
[5.0] upgrade: Fix check for ceph presence

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -101,7 +101,7 @@ module Api
       def ceph_status
         ret = {}
         ceph_nodes = ::Node.find("roles:ceph-* AND ceph_config_environment:*")
-        ret[:crowbar_ceph_nodes] = ceph_nodes.any?
+        ret[:crowbar_ceph_nodes] = true if ceph_nodes.any?
         ret
       end
 


### PR DESCRIPTION
We're checking the return hash for empty? so we want it empty
when the test passes.

(cherry picked from commit 0f2bc24088010000a14573cd92747d52dd56ea61)

port of https://github.com/crowbar/crowbar-core/pull/1589