### PR TITLE
[5.0] upgrade: Let the upgrade library work with both 7-8 and 8-9 upgrades.

### DIFF
--- a/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/upgrade_status_spec.rb
@@ -33,11 +33,16 @@ describe Crowbar::UpgradeStatus do
   let(:crowbar_backup) { "/var/lib/crowbar.tgz" }
   let(:openstack_backup) { "/var/lib/openstack.tgz" }
   let(:all_nodes) { "all" }
+  let(:running_8_9) { "/var/lib/crowbar/upgrade/8-to-9-upgrade-running" }
 
   context "with a status file that does not exist" do
     it "ensures the default initial values are correct" do
       expect(subject.current_substep).to be_nil
       expect(subject.finished?).to be false
+    end
+
+    it "starts with default upgrade path" do
+      expect(subject.running_file_location).to eq running_8_9
     end
 
     it "ensures that the defaults are saved" do


### PR DESCRIPTION
Upgrade library that is part of this version of crowbar-core package
can be used by

a) 7-8 upgrade: when executing the later steps that are done after
upgrading all crowbar packages at admin server to next product

b) 8-9 upgrade: when executing the initial steps on SOC8 before
upgrading crowbar packages at admin server to next product

So we need to distinguish these two cases.

(cherry picked from commit cfbdd72914f22f9b2a005420d90b595d6a887dec)

(Original commit was handling 6-7 & 7-8 combination)

Based on https://github.com/crowbar/crowbar-core/pull/1444