### PR TITLE
[4.0] upgrade: Allow backup list and download during upgrade

### DIFF
--- a/crowbar_framework/app/controllers/api/backups_controller.rb
+++ b/crowbar_framework/app/controllers/api/backups_controller.rb
@@ -17,6 +17,7 @@
 class Api::BackupsController < ApiController
   skip_before_filter :enforce_installer
   before_action :set_backup, only: [:destroy, :show, :restore, :download]
+  skip_before_action :upgrade, only: [:index, :download]
 
   api :GET, "/api/crowbar/backups", "Returns a list of available backups"
   header "Accept", "application/vnd.crowbar.v2.0+json", required: true

--- a/crowbar_framework/app/controllers/backups_controller.rb
+++ b/crowbar_framework/app/controllers/backups_controller.rb
@@ -17,6 +17,7 @@
 class BackupsController < ApplicationController
   skip_before_filter :enforce_installer
   before_action :set_backup, only: [:destroy, :restore, :download]
+  skip_before_action :upgrade, only: [:index, :download]
 
   api :GET, "/utils/backups", "Returns a list of available backups"
   def index


### PR DESCRIPTION
When upgrade is active user should still be able to list and download
crowbar/admin server backups.