### PR TITLE
[4.0] upgrade: Map jsonapi for respond_to

### DIFF
--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -203,7 +203,7 @@ class ApplicationController < ActionController::Base
 
   def upgrade
     respond_to do |format|
-      format.json do
+      format.any(:json, :jsonapi) do
         if request.post?
           render json: { error: I18n.t("error.during_upgrade") }, status: :service_unavailable
         else

--- a/crowbar_framework/config/initializers/mime_types.rb
+++ b/crowbar_framework/config/initializers/mime_types.rb
@@ -1,0 +1,2 @@
+# map jsonapi type to enable it inside respond_to
+Mime::Type.register "application/vnd.crowbar.v2.0+json", :jsonapi


### PR DESCRIPTION
JSONAPI MimeTypes (e.g. application/vnd.crowbar.v2.0+json) are not mapped to symbols in rails by default. This is required to handle JSONAPI requests properly inside code like `respond_to ... format....`.
    
The case where this was mostly visible is GET requests which should be enabled during upgrade but were mostly returning 406 NotAcceptable.

Better solution to problem from #1774

Before:
```
root@crowbar:~ # crowbarctl backup list

root@crowbar:~ # crowbarctl backup create test

root@crowbar:~ # crowbarctl backup download non-existing-name
Crowbar::Client::SimpleCatchableError
```

After:
```
root@crowbar:~ # crowbarctl backup list
+-------------------------------+--------------------------+--------+---------+
| Name                          | Created                  | Size   | Version |
+-------------------------------+--------------------------+--------+---------+
| upgrade-backup-20190118200052 | 2019-01-18T19:01:00.364Z | 253 KB | 4.0     |
+-------------------------------+--------------------------+--------+---------+
root@crowbar:~ # crowbarctl backup create test
{"error":"This API is not available during upgrade"}

root@crowbar:~ # crowbarctl backup download non-existing-name
Backup does not exist
```