### PR TITLE
upgrade: Map jsonapi for respond_to

### DIFF
--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -208,7 +208,7 @@ class ApplicationController < ActionController::Base
 
   def upgrade
     respond_to do |format|
-      format.json do
+      format.any(:json, :jsonapi) do
         if request.post?
           render json: { error: I18n.t("error.during_upgrade") }, status: :service_unavailable
         else

--- a/crowbar_framework/config/initializers/mime_types.rb
+++ b/crowbar_framework/config/initializers/mime_types.rb
@@ -1,0 +1,2 @@
+# map jsonapi type to enable it inside respond_to
+Mime::Type.register "application/vnd.crowbar.v2.0+json", :jsonapi


### PR DESCRIPTION
JSONAPI MimeTypes (e.g. application/vnd.crowbar.v2.0+json) are not mapped to
symbols in rails by default. This is required to handle JSONAPI requests properly
inside code like `respond_to ... format....`.

The case where this was mostly visible is GET requests which should be enabled
during upgrade but were mostly returning 406 NotAcceptable.

(cherry picked from commit 3c6f3d82c95bf346ceece3e88948cfc7ae3239c5)

port of #1775 