### PR TITLE
[5.0] upgrade: Only SIGHUP the main nova processes

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
@@ -31,11 +31,11 @@ fi
 for service in conductor consoleauth scheduler novncproxy serialproxy api; do
     fullname="openstack-nova-$service"
     if systemctl --quiet is-active $fullname 2>/dev/null ; then
-        systemctl kill -s HUP $fullname
+        systemctl kill --signal HUP --kill-who main $fullname
     fi
 done
 <% else %>
-systemctl kill -s HUP openstack-nova-compute
+systemctl kill --signal HUP --kill-who main openstack-nova-compute
 <% end %>
 
 touch $UPGRADEDIR/crowbar-reload-nova-after-upgrade-ok


### PR DESCRIPTION
Sending the signal to all processes of the unit will have unwanted
site-effects. E.g. in the case of nova-compute it might cause the
privsep helper to terminate which brings down the whole service.