### PR TITLE
[5.0] Migrations after upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -308,10 +308,18 @@ template "/usr/sbin/crowbar-reload-nova-after-upgrade.sh" do
   only_if { nova_node }
 end
 
-template "/usr/sbin/crowbar-run-nova-online-migrations.sh" do
-  source "crowbar-run-nova-online-migrations.sh.erb"
+template "/usr/sbin/crowbar-nova-migrations-after-upgrade.sh" do
+  source "crowbar-nova-migrations-after-upgrade.sh.erb"
   mode "0775"
   owner "root"
   group "root"
   only_if { roles.include?("nova-controller") }
+end
+
+template "/usr/sbin/crowbar-heat-migrations-after-upgrade.sh" do
+  source "crowbar-heat-migrations-after-upgrade.sh.erb"
+  mode "0775"
+  owner "root"
+  group "root"
+  only_if { roles.include?("heat-server") }
 end

--- a/chef/cookbooks/crowbar/templates/default/crowbar-heat-migrations-after-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-heat-migrations-after-upgrade.sh.erb
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# After the upgrade of all services on all nodes is finished update legacy heat properties
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-heat-migrations-after-upgrade-failed
+
+if [[ -f $UPGRADEDIR/crowbar-heat-migrations-after-upgrade-ok ]] ; then
+    log "Heat migrations were already executed"
+    exit 0
+fi
+
+# According to documentation:
+# "Migrates properties data from the legacy locations in the db
+# (resource.properties_data and event.resource_properties) to the modern location, the resource_properties_data table."
+heat-manage migrate_properties_data
+ret=$?
+if [ $ret != 0 ] ; then
+    log "Error occured during heat properties migration"
+    echo $ret > $UPGRADEDIR/crowbar-heat-migrations-after-upgrade-failed
+    exit $ret
+fi
+
+touch $UPGRADEDIR/crowbar-heat-migrations-after-upgrade-ok
+log "$BASH_SOURCE is finished."

--- a/chef/cookbooks/crowbar/templates/default/crowbar-nova-migrations-after-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-nova-migrations-after-upgrade.sh.erb
@@ -20,9 +20,9 @@ log "Executing $BASH_SOURCE"
 set -x
 
 mkdir -p $UPGRADEDIR
-rm -f $UPGRADEDIR/crowbar-run-nova-online-migrations-failed
+rm -f $UPGRADEDIR/crowbar-nova-migrations-after-upgrade-failed
 
-if [[ -f $UPGRADEDIR/crowbar-run-nova-online-migrations-ok ]] ; then
+if [[ -f $UPGRADEDIR/crowbar-nova-migrations-after-upgrade-ok ]] ; then
     log "Nova migrations were already executed"
     exit 0
 fi
@@ -40,10 +40,9 @@ done
 
 if [ $ret -gt 1 ] ; then
     log "Error occured during online_data_migrations run"
-    echo $ret > $UPGRADEDIR/crowbar-run-nova-online-migrations-failed
+    echo $ret > $UPGRADEDIR/crowbar-nova-migrations-after-upgrade-failed
     exit $ret
 fi
 
-
-touch $UPGRADEDIR/crowbar-run-nova-online-migrations-ok
+touch $UPGRADEDIR/crowbar-nova-migrations-after-upgrade-ok
 log "$BASH_SOURCE is finished."

--- a/chef/cookbooks/crowbar/templates/default/crowbar-run-nova-online-migrations.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-run-nova-online-migrations.sh.erb
@@ -27,19 +27,18 @@ if [[ -f $UPGRADEDIR/crowbar-run-nova-online-migrations-ok ]] ; then
     exit 0
 fi
 
-nova-manage db online_data_migrations
-
 # From the manual:
 # "Returns exit code 0 if migrations were successful or exit code 1 for partial updates.
 # If the command exits with partial updates (exit code 1) the command will need to be called again."
 
-# So let's call it again right away. If it fails for second time, throw an error and give
-# control to user.
+ret=1
 
-nova-manage db online_data_migrations
+while [[ $ret = 1 ]] ; do
+  nova-manage db online_data_migrations --max-count 200
+  ret=$?
+done
 
-ret=$?
-if [ $ret != 0 ] ; then
+if [ $ret -gt 1 ] ; then
     log "Error occured during online_data_migrations run"
     echo $ret > $UPGRADEDIR/crowbar-run-nova-online-migrations-failed
     exit $ret

--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -38,7 +38,7 @@ module Crowbar
         delete_nova_services: @timeouts_config[:delete_nova_services] || 300,
         wait_until_compute_started: @timeouts_config[:wait_until_compute_started] || 60,
         reload_nova_services: @timeouts_config[:reload_nova_services] || 120,
-        nova_online_migrations: @timeouts_config[:nova_online_migrations] || 1800
+        online_migrations: @timeouts_config[:online_migrations] || 1800
       }
     end
   end


### PR DESCRIPTION
This is how it went during my test:
```
+ nova-manage db online_data_migrations --max-count 200
3 rows matched query populate_missing_availability_zones, 3 migrated
+---------------------------------------------+--------------+-----------+
|                  Migration                  | Total Needed | Completed |
+---------------------------------------------+--------------+-----------+
| delete_build_requests_with_no_instance_uuid |      0       |     0     |
|    migrate_aggregate_reset_autoincrement    |      0       |     0     |
|              migrate_aggregates             |      0       |     0     |
|      migrate_flavor_reset_autoincrement     |      0       |     0     |
|               migrate_flavors               |      0       |     0     |
|      migrate_instance_groups_to_api_db      |      0       |     0     |
|          migrate_instance_keypairs          |      0       |     0     |
|      migrate_instances_add_request_spec     |      0       |     0     |
|          migrate_keypairs_to_api_db         |      0       |     0     |
|       migrate_quota_classes_to_api_db       |      0       |     0     |
|        migrate_quota_limits_to_api_db       |      0       |     0     |
|     populate_missing_availability_zones     |      3       |     3     |
|     service_uuids_online_data_migration     |      0       |     0     |
+---------------------------------------------+--------------+-----------+
+ ret=1
+ [[ 1 = 1 ]]
+ nova-manage db online_data_migrations --max-count 200
+---------------------------------------------+--------------+-----------+
|                  Migration                  | Total Needed | Completed |
+---------------------------------------------+--------------+-----------+
| delete_build_requests_with_no_instance_uuid |      0       |     0     |
|    migrate_aggregate_reset_autoincrement    |      0       |     0     |
|              migrate_aggregates             |      0       |     0     |
|      migrate_flavor_reset_autoincrement     |      0       |     0     |
|               migrate_flavors               |      0       |     0     |
|      migrate_instance_groups_to_api_db      |      0       |     0     |
|          migrate_instance_keypairs          |      0       |     0     |
|      migrate_instances_add_request_spec     |      0       |     0     |
|          migrate_keypairs_to_api_db         |      0       |     0     |
|       migrate_quota_classes_to_api_db       |      0       |     0     |
|        migrate_quota_limits_to_api_db       |      0       |     0     |
|     populate_missing_availability_zones     |      0       |     0     |
|     service_uuids_online_data_migration     |      0       |     0     |
+---------------------------------------------+--------------+-----------+
+ ret=0
```