### PR TITLE
[5.0] upgrade: Restart nova-compute instead of relaoding via SIGHUP

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
@@ -35,7 +35,9 @@ for service in conductor consoleauth scheduler novncproxy serialproxy api; do
     fi
 done
 <% else %>
-systemctl kill --signal HUP --kill-who main openstack-nova-compute
+# As nova-compute on Pike doesn't handle SIGHUPs correctly currently we
+# need to restart it until https://launchpad.net/bugs/1715374 is fixed
+systemctl restart openstack-nova-compute
 <% end %>
 
 touch $UPGRADEDIR/crowbar-reload-nova-after-upgrade-ok


### PR DESCRIPTION
To workaround a bug in nova-compute, we need to restart the server after
the upgrade instead of just sending a SIGHUP until a fix for
https://launchpad.net/bugs/1715374 is available.