### PR TITLE
provisioner: Remove references to windows admin password (bsc#1123640)

### DIFF
--- a/crowbar_framework/app/views/barclamp/provisioner/_edit_attributes.html.haml
+++ b/crowbar_framework/app/views/barclamp/provisioner/_edit_attributes.html.haml
@@ -11,10 +11,6 @@
     %span.help-block
       = t(".shell_prompt_hint")
 
-    = password_field %w(windows admin_password)
-    %span.help-block
-      = t(".windows.admin_password_hint")
-
     %fieldset
       %legend
         = t(".serial_console")

--- a/crowbar_framework/config/locales/provisioner/en.yml
+++ b/crowbar_framework/config/locales/provisioner/en.yml
@@ -26,6 +26,3 @@ en:
         serial_console: 'Serial Console'
         use_serial_console: 'Enable Serial Console'
         serial_tty: 'Serial Console Device'
-        windows:
-          admin_password: 'Windows Administrator Password'
-          admin_password_hint: 'This password is only set on initial installation of Windows Server and Hyper-V Server, and any subsequent changes here will not be propagated to the nodes.'


### PR DESCRIPTION
Hyper-V hosts are no longer supported, so we don't need to expose
this to the UI. with out this patch the occassional user might
be feeling confused.