### PR TITLE
[5.0] upgrade: Block access to crowbar UI for both upgrade paths

### DIFF
--- a/crowbar_framework/app/controllers/application_controller.rb
+++ b/crowbar_framework/app/controllers/application_controller.rb
@@ -38,7 +38,7 @@ class ApplicationController < ActionController::Base
       flash[:warning] = "Some nodes are not upgraded yet. " \
         "Continue to <a href='/upgrade'>upgrade wizard</a> to complete the upgrade."
     end
-    File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-running") &&
+    Dir.glob("/var/lib/crowbar/upgrade/*-upgrade-running").any? &&
       !File.exist?("/var/lib/crowbar/upgrade/7-to-8-upgrade-compute-nodes-postponed")
   }
   before_filter :sanity_checks, unless: proc {


### PR DESCRIPTION
This code needs to cover 2 different upgrade paths:
 - end of 7-8 upgrade
 - start of 8-9 upgrade
So we should not check for just one "running upgrade" indication.