### PR TITLE
[5.0] upgrade: Update the repository names required for SOC9

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -219,7 +219,6 @@ module Api
       def adminrepocheck
         upgrade_status = ::Crowbar::UpgradeStatus.new
         upgrade_status.start_step(:repocheck_crowbar)
-        # FIXME: once we start working on 7 to 8 upgrade we have to adapt the sles version
         zypper_stream = Hash.from_xml(
           `sudo /usr/bin/zypper-retry --xmlout products`
         )["stream"]
@@ -270,12 +269,12 @@ module Api
 
           products = zypper_stream["product_list"]["product"]
 
-          os_available = repo_version_available?(products, "SLES", "12.3")
+          os_available = repo_version_available?(products, "SLES", "12.4")
           ret[:os] = {
             available: os_available,
             repos: [
-              "SLES12-SP3-Pool",
-              "SLES12-SP3-Updates"
+              "SLES12-SP4-Pool",
+              "SLES12-SP4-Updates"
             ],
             errors: {}
           }
@@ -285,12 +284,12 @@ module Api
             }
           end
 
-          cloud_available = repo_version_available?(products, "suse-openstack-cloud-crowbar", "8")
+          cloud_available = repo_version_available?(products, "suse-openstack-cloud-crowbar", "9")
           ret[:openstack] = {
             available: cloud_available,
             repos: [
-              "SUSE-OpenStack-Cloud-Crowbar-8-Pool",
-              "SUSE-OpenStack-Cloud-Crowbar-8-Updates"
+              "SUSE-OpenStack-Cloud-Crowbar-9-Pool",
+              "SUSE-OpenStack-Cloud-Crowbar-9-Updates"
             ],
             errors: {}
           }

--- a/crowbar_framework/spec/fixtures/crowbar_repocheck.json
+++ b/crowbar_framework/spec/fixtures/crowbar_repocheck.json
@@ -2,16 +2,16 @@
   "os":{
     "available":true,
     "repos":[
-      "SLES12-SP3-Pool",
-      "SLES12-SP3-Updates"
+      "SLES12-SP4-Pool",
+      "SLES12-SP4-Updates"
     ],
     "errors":{}
   },
   "openstack":{
     "available":true,
     "repos":[
-      "SUSE-OpenStack-Cloud-Crowbar-8-Pool",
-      "SUSE-OpenStack-Cloud-Crowbar-8-Updates"
+      "SUSE-OpenStack-Cloud-Crowbar-9-Pool",
+      "SUSE-OpenStack-Cloud-Crowbar-9-Updates"
     ],
     "errors":{}
   }

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -272,14 +272,14 @@ describe Api::Upgrade do
         receive(:repo_version_available?).with(
           Hash.from_xml(crowbar_repocheck_zypper)["stream"]["product_list"]["product"],
           "SLES",
-          "12.3"
+          "12.4"
         ).and_return(false)
       )
       allow(Api::Upgrade).to(
         receive(:repo_version_available?).with(
           Hash.from_xml(crowbar_repocheck_zypper)["stream"]["product_list"]["product"],
           "suse-openstack-cloud-crowbar",
-          "8"
+          "9"
         ).and_return(true)
       )
       allow(Api::Upgrade).to(


### PR DESCRIPTION
When upgrading from SOC8 to SOC9, we need to check if admin server
has SOC9 and SLE12SP4 repositories prepared.