### PR TITLE
[5.0] upgrade: Check for the correct file indicating postponed upgrade

### DIFF
--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -425,7 +425,7 @@ module Crowbar
     end
 
     def postponed_file
-      "/var/lib/crowbar/upgrade/8-to-9-upgrade-compute-nodes-postponed"
+      "/var/lib/crowbar/upgrade/7-to-8-upgrade-compute-nodes-postponed"
     end
 
     def running_file_7_8


### PR DESCRIPTION
In SOC8 we have to check for 7-8 file, since postponed/resume actions
are in the 2nd part of the upgrade.