### PR TITLE
[5.0] upgrade: Create update repositories with refresh enabled

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-prepare-repositories.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-prepare-repositories.sh.erb
@@ -31,7 +31,11 @@ rm -f /etc/zypp/repos.d/*.repo
 
 log "Adding new repositories..."
 <% @new_repos.each do |name, attrs| %>
+    <% if name =~ /-Updates/ -%>
+zypper --non-interactive addrepo -f <%= attrs[:url] %> <%= name %>
+    <% else -%>
 zypper --non-interactive addrepo <%= attrs[:url] %> <%= name %>
+    <% end -%>
 <% end %>
 zypper --non-interactive addrepo <%= @new_base_repo %> <%= @new_alias %>
 


### PR DESCRIPTION
We want the Update repositories to autorefresh because
they frequently change, and it is convenient if zypper
does the check for us rather than having to manually
"zypper ref -f" all the time.

backport of #1793 
(cherry picked from commit 6d3b3549e73a43f233b18344f4e26033a09bc7da)