### PR TITLE
ses: Configuration upload & SES cookbook

### DIFF
--- a/chef/cookbooks/ses/README.md
+++ b/chef/cookbooks/ses/README.md
@@ -1,0 +1,43 @@
+DESCRIPTION
+===========
+
+This cookbook contains providers and templates for integrating
+with SUSE Enterprise Storage (Ceph).
+
+Resources/Providers
+===================
+config
+----------
+Manages ceph configuration and keyring files based on information
+stored in crowbar-config/ses data bag.
+
+- `:create` creates the configuration and keyring files. The name 
+  of resource should point to the target service which will use
+  ceph configuration.
+
+### Examples
+``` ruby
+ses_config "cinder" do
+  action :create
+end
+```
+
+LICENSE AND AUTHORS
+--------
+
+* Author: Walter Boring <wboring@suse.com>
+* Author: Jacek Tomasiak <jtomasiak@suse.com>
+
+* Copyright 2018-2019 SUSE
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.

--- a/chef/cookbooks/ses/libraries/helpers.rb
+++ b/chef/cookbooks/ses/libraries/helpers.rb
@@ -1,0 +1,34 @@
+# Copyright 2019 SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module SesHelper
+  class << self
+    def ses_settings
+      BarclampLibrary::Barclamp::Config.load(
+        "ses",
+        "ses",
+        "default"
+      )
+    end
+
+    def ceph_conf_path
+      "/etc/ceph/ceph.conf"
+    end
+
+    def keyring_path(user)
+      "/etc/ceph/ceph.client.#{user}.keyring"
+    end
+  end
+end

--- a/chef/cookbooks/ses/metadata.rb
+++ b/chef/cookbooks/ses/metadata.rb
@@ -1,0 +1,24 @@
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "ses"
+maintainer "Crowbar project"
+maintainer_email "crowbar@googlegroups.com"
+license "Apache 2.0"
+description "Provides helpers for integrating with SUSE Enterprise Storage"
+long_description IO.read(File.join(File.dirname(__FILE__), "README.md"))
+version "0.1.0"
+
+depends "utils"

--- a/chef/cookbooks/ses/providers/config.rb
+++ b/chef/cookbooks/ses/providers/config.rb
@@ -1,0 +1,91 @@
+action :create do
+  create_configs(new_resource.name)
+end
+
+def supported_services
+  ["glance", "cinder", "nova"]
+end
+
+# TODO: do we need some service restarting/reloading logic here? maybe some
+# (smart) detection if configs were changed? or is this handled by template somehow?
+
+def write_keyring_file(client_name, keyring_path, key)
+  Chef::Log.info("SES create #{client_name} keyring #{keyring_path}")
+
+  template keyring_path do
+    cookbook "ses"
+    source "client.keyring.erb"
+    owner "root"
+    group "ceph"
+    mode "0640"
+    variables(client_name: client_name,
+              keyring_value: key)
+  end
+end
+
+def create_configs(ses_service)
+  # This function creates the /etc/ceph/ceph.conf
+  # and the keyring files needed by the services
+  # ses_service is the name of the service using ceph
+  # which should be nova, cinder, glance
+  Chef::Log.info("SES: create_configs for service #{ses_service}")
+
+  ses_config = SesHelper.ses_settings
+  Chef::Log.debug("SES config = #{ses_config}")
+
+  # No SES config found? Do nothing.
+  return if ses_config.nil? || ses_config.empty?
+
+  Chef::Log.info("External SES configuration found.")
+
+  # supported services on current node
+  local_services = supported_services.select { |service| node.key? service }
+  # ses configs matching local services
+  local_ses_services = ses_config.select { |key| local_services.include?(key) }
+
+  # First create a unique clients list, so we don't have dupes in
+  # the ceph.conf file. This could happen if multiple services use one user.
+  ses_clients = {}
+  local_ses_services.each do |service, service_config|
+    user = service_config["rbd_store_user"]
+    next if user.nil? || user.empty?
+    ses_clients[user] = {
+      keyring: SesHelper.keyring_path(user),
+      key: service_config["key"]
+    }
+  end
+
+  # Ensure ceph packages, user/group and config directories are available here
+  if node[:platform_family] == "suse"
+    package "ceph-common" do
+      action :install
+    end
+  end
+
+  # Add service user to ceph group to enable keyring access
+  group "ceph" do
+    action :modify
+    append true
+    members ses_service
+  end
+
+  Chef::Log.info("SES create #{SesHelper.ceph_conf_path}")
+  template SesHelper.ceph_conf_path do
+    cookbook "ses"
+    source "ceph.conf.erb"
+    owner "root"
+    group "ceph"
+    mode "0644"
+    variables(fsid: ses_config["ceph_conf"]["fsid"],
+              mon_initial_members: ses_config["ceph_conf"]["mon_initial_members"],
+              mon_host: ses_config["ceph_conf"]["mon_host"],
+              public_network: ses_config["ceph_conf"]["public_network"],
+              cluster_network: ses_config["ceph_conf"]["cluster_network"],
+              ses_clients: ses_clients)
+  end
+
+  # Create user keyring files
+  ses_clients.each do |user, values|
+    write_keyring_file(user, values[:keyring], values[:key])
+  end
+end

--- a/chef/cookbooks/ses/resources/config.rb
+++ b/chef/cookbooks/ses/resources/config.rb
@@ -1,0 +1,22 @@
+#
+# Cookbook Name:: ses
+# Resource:: config
+#
+# Copyright:: 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+actions :create
+
+attribute :service_name, kind_of: String

--- a/chef/cookbooks/ses/templates/default/ceph.conf.erb
+++ b/chef/cookbooks/ses/templates/default/ceph.conf.erb
@@ -1,0 +1,23 @@
+[global]
+fsid = <%= @fsid %>
+mon_initial_members = <%= @mon_initial_members %>
+mon_host = <%= @mon_host %>
+auth_cluster_required = cephx
+auth_service_required = cephx
+auth_client_required = cephx
+filestore_xattr_use_omap = true
+public_network = <%= @public_network %>
+cluster_network = <%= @cluster_network %>
+
+# enable old ceph health format in the json output. This fixes the
+# ceph_exporter. This option will only stay until the prometheus plugin takes
+# over
+mon_health_preluminous_compat = true
+mon health preluminous compat warning = false
+
+rbd default features = 3
+
+<% @ses_clients.each do |user, values| %>
+[client.<%= user %>]
+keyring=<%= values[:keyring] %>
+<% end %>

--- a/chef/cookbooks/ses/templates/default/client.keyring.erb
+++ b/chef/cookbooks/ses/templates/default/client.keyring.erb
@@ -1,0 +1,2 @@
+[client.<%= @client_name %>]
+key = <%= @keyring_value %>

--- a/crowbar_framework/app/assets/javascripts/application.js
+++ b/crowbar_framework/app/assets/javascripts/application.js
@@ -285,6 +285,16 @@ jQuery(document).ready(function($) {
     location.reload();
   });
 
+  $('body.ses input[name="sesconfig[file]"]').fileinput({
+    uploadUrl: Routes.ses_settings_upload_path(),
+    uploadAsync: true,
+    allowedFileExtensions: ['yml', 'yaml'],
+    dropZoneEnabled: false
+  })
+  .on('fileuploaded', function() {
+    location.reload();
+  });
+
   $('body.installer-upgrades input[name="file"]').fileinput({
     showPreview: false,
     showUpload: false,

--- a/crowbar_framework/app/controllers/ses_controller.rb
+++ b/crowbar_framework/app/controllers/ses_controller.rb
@@ -1,0 +1,54 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class SesController < ApplicationController
+  # Render the settings page, where currently stored settings are visible
+  # and yaml file with configuration can be uploaded.
+  def settings
+    @ses_settings = SES.load
+  end
+
+  def upload
+    data = upload_params[:file].read
+    begin
+      config = YAML.safe_load(data)
+    rescue YAML::SyntaxError => e
+      return render json: { error: "YAML parsing failed: #{e.problem}" }, status: :unprocessable_entity
+    end
+    if validate(config)
+      SES.save(config)
+      render json: config, status: :ok
+    else
+      render json: { error: "validation error" }, status: :unprocessable_entity
+    end
+  end
+
+  def delete
+    SES.save nil
+    redirect_to ses_settings_path
+  end
+
+  private
+
+  def validate(config)
+    # TODO: validate structure
+    true
+  end
+
+  def upload_params
+    params.require(:sesconfig).permit(:file)
+  end
+end

--- a/crowbar_framework/app/models/ses.rb
+++ b/crowbar_framework/app/models/ses.rb
@@ -1,0 +1,30 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class SES
+  def self.load
+    Crowbar::DataBagConfig.load("ses", "default", "ses")
+  end
+
+  def self.save(config)
+    Crowbar::DataBagConfig.save("ses", "default", "ses", config)
+  end
+
+  def self.configured?
+    config = self.load
+    !config.nil? && !config.empty?
+  end
+end

--- a/crowbar_framework/app/views/ses/settings.html.haml
+++ b/crowbar_framework/app/views/ses/settings.html.haml
@@ -1,0 +1,66 @@
+.row
+  .col-xs-12
+    %h2.page-header
+      = t(".title")
+      .btn-group.pull-right
+        .btn.btn-default{ data: { toggle: "modal", target: "#upload_ses_config_modal" } }
+          = t(".upload_config")
+        - if @ses_settings.empty?
+          .btn.btn-danger{ disabled: true }
+            = t(".delete_config")
+        - else
+          .btn.btn-danger{ data: { toggle: "modal", target: "#delete_ses_config_modal" } }
+            = t(".delete_config")
+
+    - @ses_settings.each do |group_name, group_values|
+      %fieldset
+        %legend
+          = t(".parameters.#{group_name}_info")
+        - if group_values.kind_of?(Hash)
+          - group_values.each do |name, value|
+            .form-group
+              %label{ :for => name }
+                = t(".#{group_name}.#{name}")
+              - if name == 'key'
+                = password_field_tag name, value, :class => "form-control", :readonly => true
+              - else
+                = text_field_tag name, value, :class => "form-control", :readonly => true
+        - if group_values.kind_of?(Array)
+          - group_values.each do |value|
+            .form-group
+              = text_field_tag :url, value, :class => "form-control", :readonly => true
+
+    - if @ses_settings.empty?
+      .alert.alert-info
+        = t(".no_config")
+
+.modal.fade{ id: "upload_ses_config_modal" }
+  .modal-dialog
+    .modal-content
+      .modal-header
+        .btn.close{ data: { dismiss: "modal" } }
+          &times
+        %h2
+          = t(".upload_config")
+      .modal-body
+        %input{ name: "sesconfig[file]", type: "file" }
+      .modal-footer
+        .btn.btn-default{ data: { dismiss: "modal" } }
+          = t("cancel")
+
+.modal.fade{ id: "delete_ses_config_modal" }
+  .modal-dialog
+    .modal-content
+      .modal-header
+        .btn.close{ data: { dismiss: "modal" } }
+          &times
+        %h2
+          = t(".delete_config")
+      = form_for :delete, url: ses_settings_delete_path do |f|
+        .modal-body
+          = t(".confirm_delete")
+        .modal-footer
+          .row
+            .btn.btn-default{ data: { dismiss: "modal" } }
+              = t("cancel")
+            = f.submit(t("delete"), class: "btn btn-danger")

--- a/crowbar_framework/config/locales/ses/en.yml
+++ b/crowbar_framework/config/locales/ses/en.yml
@@ -1,0 +1,54 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+en:
+  nav:
+    utils:
+      ses: 'SUSE Enterprise Storage'
+  ses:
+    settings:
+      title: 'SUSE Enterprise Storage Configuration'
+      upload_config: 'Upload Configuration'
+      delete_config: 'Delete Configuration'
+      confirm_delete: 'Are you sure you want to delete SES configuration from Crowbar?'
+      no_config: 'No configuration found. Please import SES configuration file.'
+      parameters:
+        ceph_conf_info: 'Ceph Config'
+        cinder_info: 'Cinder'
+        cinder-backup_info: 'Cinder Backup'
+        glance_info: 'Glance'
+        nova_info: 'Nova'
+        radosgw_urls_info: 'RADOSGW URLs'
+      ceph_conf:
+        cluster_network: 'Cluster Network'
+        fsid: 'FSID'
+        mon_host: 'Monitor Hosts'
+        mon_initial_members: 'Initial Monitor Members'
+        public_network: 'Public Network'
+      cinder:
+        key: 'Key'
+        rbd_store_pool: 'RBD Store Pool'
+        rbd_store_user: 'RBD Store User'
+      cinder-backup:
+        key: 'Key'
+        rbd_store_pool: 'RBD Store Pool'
+        rbd_store_user: 'RBD Store User'
+      glance:
+        key: 'Key'
+        rbd_store_pool: 'RBD Store Pool'
+        rbd_store_user: 'RBD Store User'
+      nova:
+        rbd_store_pool: 'RBD Store Pool'

--- a/crowbar_framework/config/routes.d/ses.routes
+++ b/crowbar_framework/config/routes.d/ses.routes
@@ -1,0 +1,19 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+get 'ses/settings' => 'ses#settings', as: 'ses_settings'
+post 'ses/settings/upload' => 'ses#upload', as: 'ses_settings_upload'
+post 'ses/settings/delete' => 'ses#delete', as: 'ses_settings_delete'

--- a/ses.yml
+++ b/ses.yml
@@ -1,0 +1,37 @@
+#
+# Copyright 2019, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+barclamp:
+  name: ses
+  display: SES
+  description: Integration with SUSE Enterprise Storage
+  version: 1
+  user_managed: false
+  member:
+    - crowbar
+
+crowbar:
+  layout: 1
+  order: 20
+  run_order: 20
+  chef_order: 20
+  proposal_schema_version: 3
+
+nav:
+  utils:
+    ses:
+      order: 91
+      route: 'ses_settings_path'


### PR DESCRIPTION
Added Crowbar UI part for uploading and viewing SES settings based on
yaml file exported from SES cluster.
Settings are saved in a data bag for future use.

This change is a base for: https://github.com/crowbar/crowbar-openstack/pull/2035
and alternative to: https://github.com/crowbar/crowbar-openstack/pull/1977

TODO:
- [ ] validation of uploaded yaml (beyond yaml syntax check). Currently everything is stored in the data bag "as is".
- [ ] CLI interface to upload yaml configs (good for CI)
- [ ] add some service restart logic after the ceph config/keyring files are modified (?)

Some screenshots:
Menu entry:
![zrzut ekranu z 2019-02-19 22-46-19](https://user-images.githubusercontent.com/2458112/53049923-670ba300-3498-11e9-90a0-1c4dd6f8056d.png)

Empty settings view:
![zrzut ekranu z 2019-02-19 22-44-28](https://user-images.githubusercontent.com/2458112/53049913-62df8580-3498-11e9-81d7-472b87b50d48.png)

Upload modal (similar to backup upload):
![zrzut ekranu z 2019-02-19 22-44-11](https://user-images.githubusercontent.com/2458112/53049902-5eb36800-3498-11e9-9e15-f1af7fcd5ae4.png)

Part of uploaded settings:
![zrzut ekranu z 2019-02-19 22-43-50](https://user-images.githubusercontent.com/2458112/53049858-4b080180-3498-11e9-850a-c20d17e7a3b0.png)
