### PR TITLE
upgrade: Make sure all compute nodes get compute related scripts

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -137,7 +137,7 @@ template "/usr/sbin/crowbar-evacuate-host.sh" do
   only_if { roles.include? "nova-controller" }
 end
 
-compute_node = roles.include? "nova-compute-kvm"
+compute_node = compute_nodes.include? node["hostname"]
 nova_node = compute_node || roles.include?("nova-controller")
 cinder_volume = roles.include? "cinder-volume"
 neutron = search(:node, "run_list_map:neutron-server").first


### PR DESCRIPTION
There may be also other compute nodes than just kvm one (bsc#1127129)

(cherry picked from commit 00835eec6bc31512161843b48a46f76e6e23148e)

Port of https://github.com/crowbar/crowbar-core/pull/1800