### PR TITLE
crowbar: Restrict admin access (bsc#1117080) 

### DIFF
--- a/bin/gather_logs.sh
+++ b/bin/gather_logs.sh
@@ -18,7 +18,8 @@
 
 if [[ -f /etc/crowbar.install.key ]]; then
     export CROWBAR_KEY=$(cat /etc/crowbar.install.key)
-    export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
+    export CROWBAR_USER="$(sed -e 's/:[^:]*$//' <<< $CROWBAR_KEY)"
+    export CROWBAR_PASS="$(sed -e 's/^.*://' <<< $CROWBAR_KEY)"
 fi
 mkdir -p /tmp/crowbar-logs
 tarname="${1-$(date '+%Y%m%d-%H%M%S')}"
@@ -48,10 +49,10 @@ sort_by_last() {
 	-o 'UserKnownHostsFile /dev/null')
     logs=(/var/log /etc)
     logs+=(/var/chef/cache /var/cache/chef /opt/dell/crowbar_framework/db)
-    crowbarctl node list -U machine-install -P $CROWBAR_PASS --no-verify-ssl
+    crowbarctl node list -U $CROWBAR_USER -P $CROWBAR_PASS --no-verify-ssl
 
     for to_get in proposals roles; do
-        crowbarctl $to_get proposal list crowbar -U machine-install -P $CROWBAR_PASS --no-verify-ssl
+        crowbarctl $to_get proposal list crowbar -U $CROWBAR_USER -P $CROWBAR_PASS --no-verify-ssl
     done
     for node in $(sudo -H knife node list); do
 	tarfile="${node%%.*}-${tarname}.tar.gz"

--- a/bin/transition.sh
+++ b/bin/transition.sh
@@ -22,7 +22,8 @@ if [[ $(cat /proc/cmdline) =~ $key_re ]]; then
 elif [[ -f /etc/crowbar.install.key ]]; then
     export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
 fi
-export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
+export CROWBAR_USER="$(sed -e 's/:[^:]*$//' <<< $CROWBAR_KEY)"
+export CROWBAR_PASS="$(sed -e 's/^.*://' <<< $CROWBAR_KEY)"
 
 if [ "$1" == "" ]
 then
@@ -41,7 +42,7 @@ do
   if [ $1 == $line ]
   then
     echo "Transitioning node $1 to state $2"
-    crowbarctl node transition $1 $2 -U machine-install -P $CROWBAR_PASS --no-verify-ssl
+    crowbarctl node transition $1 $2 -U $CROWBAR_USER -P $CROWBAR_PASS --no-verify-ssl
     break
   fi
 done

--- a/chef/cookbooks/crowbar/files/default/crowbar
+++ b/chef/cookbooks/crowbar/files/default/crowbar
@@ -23,7 +23,8 @@ IP="127.0.0.1"
 
 if [[ -f /etc/crowbar.install.key ]]; then
     export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
-    export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
+    export CROWBAR_USER="$(sed -e 's/:[^:]*$//' <<< $CROWBAR_KEY)"
+    export CROWBAR_PASS="$(sed -e 's/^.*://' <<< $CROWBAR_KEY)"
 fi
 
 case $1 in
@@ -32,12 +33,12 @@ case $1 in
         rm -rf /var/run/crowbar/looper-chef-client.lock /var/run/crowbar/chef-client.run /var/run/crowbar/chef-client.lock
 
         # Mark us as readying, and get our cert.
-	crowbarctl node transition $HOSTNAME "readying" -U machine-install -P $CROWBAR_PASS --no-verify-ssl
+	crowbarctl node transition $HOSTNAME "readying" -U $CROWBAR_USER -P $CROWBAR_PASS --no-verify-ssl
         if [ -f /etc/default/tftpd-hpa ] ; then
           service tftpd-hpa stop
           service tftpd-hpa start
         fi
-	crowbarctl node transition $HOSTNAME "ready" -U machine-install -P $CROWBAR_PASS --no-verify-ssl
+	crowbarctl node transition $HOSTNAME "ready" -U $CROWBAR_USER -P $CROWBAR_PASS --no-verify-ssl
 
 	echo "Done";;
     stop) bluepill crowbar-webserver stop;;

--- a/chef/cookbooks/crowbar/templates/default/apache.conf.erb
+++ b/chef/cookbooks/crowbar/templates/default/apache.conf.erb
@@ -28,6 +28,24 @@
         <%- end %>
         <%- end %>
     </Location>
+
+    <%- unless @realm.nil? %>
+    <Location /crowbar/crowbar/1.0/transition/>
+        AuthType Digest
+        AuthName "<%= @realm %>"
+        AuthDigestProvider file
+        AuthUserFile /opt/dell/crowbar_framework/htdigest-clients
+        Require valid-user
+    </Location>
+
+    <Location /nodes/status >
+        AuthType Digest
+        AuthName "<%= @realm %>"
+        AuthDigestProvider file
+        AuthUserFile /opt/dell/crowbar_framework/htdigest-clients
+        Require valid-user
+    </Location>
+    <%- end %>
 </VirtualHost>
 
 <% if @use_ssl %>

--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -350,7 +350,14 @@ crowbar_node = node_search_with_cache("roles:crowbar").first
 address = crowbar_node["crowbar"]["network"]["admin"]["address"]
 protocol = crowbar_node["crowbar"]["apache"]["ssl"] ? "https" : "http"
 server = "#{protocol}://#{address}"
-password = crowbar_node["crowbar"]["users"]["crowbar"]["password"]
+is_admin = CrowbarHelper.is_admin?(node)
+if is_admin
+  username = "crowbar"
+  password = crowbar_node["crowbar"]["users"][username]["password"]
+else
+  username = crowbar_node["crowbar"]["client_user"]["username"]
+  password = crowbar_node["crowbar"]["client_user"]["password"]
+end
 verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
 
 package "ruby2.1-rubygem-crowbar-client"
@@ -359,6 +366,7 @@ template "/etc/crowbarrc" do
   source "crowbarrc.erb"
   variables(
     server: server,
+    username: username,
     password: password,
     verify_ssl: verify_ssl
   )

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -63,6 +63,8 @@ virtual_intfs = ["tap", "qbr", "qvo", "qvb", "brq", "ovs", "vxl"]
 crowbar_node = node_search_with_cache("roles:crowbar").first
 crowbar_protocol = crowbar_node[:crowbar][:apache][:ssl] ? "https" : "http"
 crowbar_verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
+crowbar_client_username = crowbar_node["crowbar"]["client_user"]["username"]
+crowbar_client_password = crowbar_node["crowbar"]["client_user"]["password"]
 
 discovery_dir = "#{tftproot}/discovery"
 pxecfg_subdir = "bios/pxelinux.cfg"
@@ -392,6 +394,8 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
           admin_node_ip: admin_ip,
           crowbar_protocol: crowbar_protocol,
           crowbar_verify_ssl: crowbar_verify_ssl,
+          crowbar_client_username: crowbar_client_username,
+          crowbar_client_password: crowbar_client_password,
           web_port: web_port,
           packages: packages,
           repos: repos,

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -65,6 +65,7 @@ crowbar_protocol = crowbar_node[:crowbar][:apache][:ssl] ? "https" : "http"
 crowbar_verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
 crowbar_client_username = crowbar_node["crowbar"]["client_user"]["username"]
 crowbar_client_password = crowbar_node["crowbar"]["client_user"]["password"]
+restricted_install_key = "#{crowbar_client_username}:#{crowbar_client_password}"
 
 discovery_dir = "#{tftproot}/discovery"
 pxecfg_subdir = "bios/pxelinux.cfg"
@@ -422,7 +423,6 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
 
     when /^(hyperv|windows)/
       os_dir_win = "#{tftproot}/#{os}"
-      crowbar_key = ::File.read("/etc/crowbar.install.key").chomp.strip
 
       case os
       when "windows-6.3"
@@ -455,7 +455,7 @@ filename = \"discovery/x86_64/bios/pxelinux.0\";
                   image_name: image_name,
                   admin_ip: admin_ip,
                   admin_name: node[:hostname],
-                  crowbar_key: crowbar_key,
+                  crowbar_key: restricted_install_key,
                   admin_password: node[:provisioner][:windows][:admin_password],
                   domain_name: node.fetch(:dns, {})[:domain] || node[:domain])
       end

--- a/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
@@ -57,19 +57,7 @@
         <source>
           <![CDATA[
           export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
-          HTTP_SERVER="<%= @admin_node_ip %>:<%= @web_port %>"
-          IP="<%= @admin_node_ip %>"
           HOSTNAME="<%= @node_fqdn %>"
-
-          key_re='crowbar\.install\.key=([^ ]+)'
-          if [[ $(cat /proc/cmdline) =~ $key_re ]]; then
-              export CROWBAR_KEY="${BASH_REMATCH[1]}"
-              echo "$CROWBAR_KEY" >/etc/crowbar.install.key
-          elif [[ -f /etc/crowbar.install.key ]]; then
-              export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
-          fi
-
-          export CROWBAR_PASS="$(sed -e 's/^.*://' <<< $CROWBAR_KEY)"
 
           cat <<EOF > /etc/crowbarrc
 [default]

--- a/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
@@ -69,7 +69,7 @@
               export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
           fi
 
-          export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
+          export CROWBAR_PASS="$(sed -e 's/^.*://' <<< $CROWBAR_KEY)"
 
           cat <<EOF > /etc/crowbarrc
 [default]

--- a/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast-upgrade.xml.erb
@@ -74,8 +74,8 @@
           cat <<EOF > /etc/crowbarrc
 [default]
 server = <%= @crowbar_protocol %>://<%= @admin_node_ip %>
-username = machine-install
-password = $CROWBAR_PASS
+username = <%= @crowbar_client_username %>
+password = <%= @crowbar_client_password %>
 <% unless @crowbar_verify_ssl %>
 verify_ssl = 0
 <% end %>

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -293,7 +293,7 @@ elif [[ -f /etc/crowbar.install.key ]]; then
 export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
 fi
 
-export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
+export CROWBAR_PASS="$(sed -e 's/^.*://' <<< $CROWBAR_KEY)"
 
 cat <<EOF > /etc/crowbarrc
 [default]

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -298,8 +298,8 @@ export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
 cat <<EOF > /etc/crowbarrc
 [default]
 server = <%= @crowbar_protocol %>://<%= @admin_node_ip %>
-username = machine-install
-password = $CROWBAR_PASS
+username = <%= @crowbar_client_username %>
+password = <%= @crowbar_client_password %>
 <% unless @crowbar_verify_ssl %>
 verify_ssl = 0
 <% end %>

--- a/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
+++ b/chef/cookbooks/provisioner/templates/default/autoyast.xml.erb
@@ -282,18 +282,7 @@ sed -i s/"^[[:space:]]*DEFAULT_FS=.*"/DEFAULT_FS=\"<%= @default_fs %>\"/ /etc/sy
 <![CDATA[
 export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
 HTTP_SERVER="<%= @admin_node_ip %>:<%= @web_port %>"
-IP="<%= @admin_node_ip %>"
 HOSTNAME="<%= @node_fqdn %>"
-
-key_re='crowbar\.install\.key=([^ ]+)'
-if [[ $(cat /proc/cmdline) =~ $key_re ]]; then
-export CROWBAR_KEY="${BASH_REMATCH[1]}"
-echo "$CROWBAR_KEY" >/etc/crowbar.install.key
-elif [[ -f /etc/crowbar.install.key ]]; then
-export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
-fi
-
-export CROWBAR_PASS="$(sed -e 's/^.*://' <<< $CROWBAR_KEY)"
 
 cat <<EOF > /etc/crowbarrc
 [default]

--- a/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbar_join.suse.sh.erb
@@ -402,10 +402,6 @@ HTTP_SERVER="<%= @admin_ip %>:<%= @web_port %>"
 NTP_SERVERS="<%= @ntp_servers_ips.join(" ") %>"
 VALID_NTP_SERVERS=""
 
-if [[ -f /etc/crowbar.install.key ]]; then
-    export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
-fi
-
 CHEF_CLIENT_OPTIONS=
 if [ "$DEBUG" -ne 0 ]; then
     CHEF_CLIENT_OPTIONS="-l debug"

--- a/chef/cookbooks/provisioner/templates/default/crowbarrc.erb
+++ b/chef/cookbooks/provisioner/templates/default/crowbarrc.erb
@@ -1,6 +1,6 @@
 [default]
 server = <%= @server %>
-username = crowbar
+username = <%= @username %>
 password = <%= @password %>
 <% unless @verify_ssl %>
 verify_ssl = 0

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -277,7 +277,7 @@ fi
 
 # Set up /etc/crowbarrc with crowbarctl credentials
 # -------------------------------------------
-export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
+export CROWBAR_PASS="$(sed -e 's/^.*://' <<< $CROWBAR_KEY)"
 
 cat <<EOF > /etc/crowbarrc
 [default]

--- a/chef/data_bags/crowbar/migrate/crowbar/301_add_client_password.rb
+++ b/chef/data_bags/crowbar/migrate/crowbar/301_add_client_password.rb
@@ -1,0 +1,13 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  unless attrs.key?("client_user")
+    attrs["client_user"] = template_attrs["client_user"]
+    service = ServiceObject.new "fake-logger"
+    attrs["client_user"]["password"] = service.random_password
+  end
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs.delete("client_user") if attrs.key?("client_user")
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-crowbar.json
+++ b/chef/data_bags/crowbar/template-crowbar.json
@@ -20,6 +20,10 @@
         "machine-install": { "password": "machine_password" },
         "crowbar": { "password": "crowbar" }
       },
+      "client_user": {
+        "username": "client",
+        "password": "client_password"
+      },
       "simple_proposal_ui": true,
       "upgrade": {
         "db_dump_location": "/var/lib/pgsql/openstack-db-before-upgrade.dump"
@@ -42,7 +46,7 @@
     "crowbar": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 300,
+      "schema-revision": 301,
       "element_states": {
         "crowbar": [ "all" ],
         "crowbar-upgrade": [ "readying", "ready", "applying", "crowbar_upgrade" ]

--- a/chef/data_bags/crowbar/template-crowbar.schema
+++ b/chef/data_bags/crowbar/template-crowbar.schema
@@ -23,6 +23,12 @@
                 }
               }
             },
+            "client_user": { "type": "map", "required": true,
+              "mapping": {
+                "username": { "type": "str"},
+                "password": { "type": "str" }
+              }
+            },
             "upgrade": {
               "type": "map",
               "required": true,

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -37,6 +37,12 @@ class CrowbarService < ServiceObject
     end
   end
 
+  def create_proposal
+    base = super
+    base["attributes"]["crowbar"]["client_user"]["password"] = random_password
+    base
+  end
+
   # This is relevant to upgrade process only.
   #
   # Commit current proposal of crowbar barclamp and check if the commit doesn't

--- a/crowbar_framework/spec/fixtures/data_bags/template-crowbar.json
+++ b/crowbar_framework/spec/fixtures/data_bags/template-crowbar.json
@@ -21,6 +21,10 @@
         "machine-install": { "password": "machine_password" },
         "crowbar": { "password": "crowbar" }
       },
+      "client_user": {
+        "username": "client",
+        "password": "client_password"
+      },
       "simple_proposal_ui": true,
       "upgrade": {
         "db_dump_location" : "/var/lib/pgsql/db-before-cloud6.dump"

--- a/updates/control_lib.sh
+++ b/updates/control_lib.sh
@@ -77,8 +77,9 @@ try_to() {
 
 __post_state() {
   # $1 = hostname, $2 = target state
-  PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
-  crowbarctl node transition "$1" "$2" -s "http://$ADMIN_IP" -U machine-install -P $PASS --no-verify-ssl
+  USER="$(sed -e 's/:[^:]*$//' <<< $CROWBAR_KEY)"
+  PASS="$(sed -e 's/^.*://' <<< $CROWBAR_KEY)"
+  crowbarctl node transition "$1" "$2" -s "http://$ADMIN_IP" -U $USER -P $PASS --no-verify-ssl
   local RET=$?
   __get_state "$1"
   return $RET
@@ -86,8 +87,9 @@ __post_state() {
 
 __get_state() {
   # $1 = hostname
-  PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
-  parse_node_data < <(crowbarctl node show $1 -s "http://$ADMIN_IP" -U machine-install -P $PASS --no-verify-ssl --json)
+  USER="$(sed -e 's/:[^:]*$//' <<< $CROWBAR_KEY)"
+  PASS="$(sed -e 's/^.*://' <<< $CROWBAR_KEY)"
+  parse_node_data < <(crowbarctl node show $1 -s "http://$ADMIN_IP" -U $USER -P $PASS --no-verify-ssl --json)
 }
 
 post_state() { try_to "$MAXTRIES" 15 __post_state "$@"; }


### PR DESCRIPTION
Without this patch, crowbar-managed nodes have full admin access to the
crowbar API via both /etc/crowbarrc and /etc/crowbar.install.key. This
means users with root access on a crowbar-managed machine can modify
crowbar proposals and gain access to the crowbar node itself, if they
didn't already have access. This patch creates a special client user
that can only access the crowbar transition and node status APIs and
cannot modify proposals or other node attributes. This means that
crowbar-managed nodes can still change the transition state of other
nodes, which is unavoidable as long as the crowbar server is limited to
using digest auth, but at least this way they cannot change proposals or
do other destructive actions.

This change also changes the machine-install user's password once the
initial deployment is completed. This means that the password found in
/etc/crowbar.install.key as well as in the grub config and all over the
logs will no longer be able to be used to gain access to the crowbar
admin server. When the password is changed, new node deployments will
have the new key injected into their grub configs during provisioning,
and the key will be changed again on the next chef run.

Co-authored-by: Sumit Jamgade <sjamgade@suse.com>