### PR TITLE
crowbar: Start/stop crowbar-init to restore backups

### DIFF
--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -265,10 +265,20 @@ module Crowbar
       end
 
       def run_installer
+        # Start crowbar-init.service so that the installer can run.
+        # See c99b83262936e4bccb832a47f921c5c66a7b6a1f for details.
+        Rails.logger.debug "Starting crowbar-init.service"
+        system("sudo systemctl start crowbar-init.service")
+
         Rails.logger.debug "Starting Crowbar installation"
         Crowbar::Installer.install!
         Rails.logger.debug "Waiting for installation to be successful"
         sleep(1) until Crowbar::Installer.successful? || Crowbar::Installer.failed?
+
+        # Start crowbar-init.service so that the installer can run.
+        # See c99b83262936e4bccb832a47f921c5c66a7b6a1f for details.
+        Rails.logger.debug "Stopping crowbar-init.service"
+        system("sudo systemctl stop crowbar-init.service")
 
         if Crowbar::Installer.failed?
           Rails.logger.error "Crowbar Installation Failed"


### PR DESCRIPTION
[SCRD-8330] When the `install-chef-suse.sh` script is initiated, the
`crowbar-init.service` is typically not running and the script
fails (c.f. c99b83262936e4bccb832a47f921c5c66a7b6a1f for details).
This change starts and later stops the `crowbar-init.service` before
and after calling the installer.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>