### PR TITLE
barclamp: Fix setting MTU on networks using a bridge

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -712,6 +712,13 @@ class ::Nic
       self
     end
 
+    def mtu=(mtu)
+      slaves.each do |slave|
+        slave.mtu = mtu
+      end
+      super
+    end
+
     def up
       slaves.each(&:up)
       super


### PR DESCRIPTION
When add_bridge is set to true, we set the MTU on the bridge interface,
but nothing sets it on the slave interface, so it doesn't work.

So whenever we set the MTU on a bridge, also set it on the slave
interface.