### PR TITLE
Use same line-height for all buttons (SCRD-8582)

### DIFF
--- a/crowbar_framework/app/assets/stylesheets/content/content.scss
+++ b/crowbar_framework/app/assets/stylesheets/content/content.scss
@@ -132,10 +132,6 @@ h3.modal-title {
   }
 }
 
-.btn-group > .btn.cancel {
-  line-height: 13px;
-}
-
 ul li {
   line-height: 17px;
 }


### PR DESCRIPTION
Button groups can contain inputs and anchor tags that should be styled similar. Removing this over-ride because they are consistent with out it. This is especially true on barclamp edit pages.