### PR TITLE
[4.0] network: run wicked ifdown for interface cleanup (bsc#1063535)

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -151,6 +151,7 @@ def kill_nic(nic)
 
   Chef::Log.info("Interface #{nic.name} is no longer being used, deconfiguring it.")
   nic.destroy
+  ::Kernel.system("wicked ifdown #{nic.name}")
 
   kill_nic_files(nic)
 end


### PR DESCRIPTION
#1441 backport

When cleaning up vlan interfaces, simply running 'vconfig rem'
doesn't have any effect for interfaces that are already managed
by wicked. Only running 'wicked ifdown' properly cleans up these
interfaces.

Instead of patching only the vlan interfaces in the nic.rb library,
all interfaces are brought down with 'wicked ifdown' in the network
barclamp when removed.

(cherry picked from commit 8f15749f2834f3c490358a59f44278d79078996f)