### PR TITLE
Remove dubious uses of machine-install user

### DIFF
--- a/bin/gather_logs.sh
+++ b/bin/gather_logs.sh
@@ -16,10 +16,6 @@
 # limitations under the License.
 #
 
-if [[ -f /etc/crowbar.install.key ]]; then
-    export CROWBAR_KEY=$(cat /etc/crowbar.install.key)
-    export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
-fi
 mkdir -p /tmp/crowbar-logs
 tarname="${1-$(date '+%Y%m%d-%H%M%S')}"
 targetdir="/opt/dell/crowbar_framework/public/export"
@@ -48,10 +44,10 @@ sort_by_last() {
 	-o 'UserKnownHostsFile /dev/null')
     logs=(/var/log /etc)
     logs+=(/var/chef/cache /var/cache/chef /opt/dell/crowbar_framework/db)
-    crowbarctl node list -U machine-install -P $CROWBAR_PASS --no-verify-ssl
+    crowbarctl node list --no-verify-ssl
 
     for to_get in proposals roles; do
-        crowbarctl $to_get proposal list crowbar -U machine-install -P $CROWBAR_PASS --no-verify-ssl
+        crowbarctl $to_get proposal list crowbar --no-verify-ssl
     done
     for node in $(sudo -H knife node list); do
 	tarfile="${node%%.*}-${tarname}.tar.gz"

--- a/bin/gather_logs.sh
+++ b/bin/gather_logs.sh
@@ -44,11 +44,24 @@ sort_by_last() {
 	-o 'UserKnownHostsFile /dev/null')
     logs=(/var/log /etc)
     logs+=(/var/chef/cache /var/cache/chef /opt/dell/crowbar_framework/db)
-    crowbarctl node list --no-verify-ssl
 
-    for to_get in proposals roles; do
-        crowbarctl $to_get proposal list crowbar --no-verify-ssl
+    mkdir nodes
+    for node in $(crowbarctl node list --no-verify-ssl --no-meta --plain); do
+        crowbarctl node show $node --no-verify-ssl --json > nodes/$node.json
     done
+
+    mkdir proposals
+    for barclamp in $(crowbarctl barclamp list --no-verify-ssl --plain); do
+        for proposal in $(crowbarctl proposal list $barclamp --no-verify-ssl --plain); do
+            crowbarctl proposal show $barclamp $proposal --no-verify-ssl --json > proposals/$barclamp-$proposal.json
+        done
+    done
+
+    mkdir roles
+    for role in $(sudo -H knife role list | grep '\-config-'); do
+        knife role show -F json $role > roles/$role.json
+    done
+
     for node in $(sudo -H knife node list); do
 	tarfile="${node%%.*}-${tarname}.tar.gz"
 	(   sudo ssh "${sshopts[@]}" "${node}" \

--- a/bin/transition.sh
+++ b/bin/transition.sh
@@ -16,14 +16,6 @@
 # limitations under the License.
 #
 
-key_re='crowbar\.install\.key=([^ ]+)'
-if [[ $(cat /proc/cmdline) =~ $key_re ]]; then
-    export CROWBAR_KEY="${BASH_REMATCH[1]}"
-elif [[ -f /etc/crowbar.install.key ]]; then
-    export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
-fi
-export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
-
 if [ "$1" == "" ]
 then
   echo "Please specify a node to transition"
@@ -41,7 +33,7 @@ do
   if [ $1 == $line ]
   then
     echo "Transitioning node $1 to state $2"
-    crowbarctl node transition $1 $2 -U machine-install -P $CROWBAR_PASS --no-verify-ssl
+    crowbarctl node transition $1 $2 --no-verify-ssl
     break
   fi
 done

--- a/chef/cookbooks/crowbar/files/default/crowbar
+++ b/chef/cookbooks/crowbar/files/default/crowbar
@@ -21,23 +21,18 @@
 
 IP="127.0.0.1"
 
-if [[ -f /etc/crowbar.install.key ]]; then
-    export CROWBAR_KEY="$(cat /etc/crowbar.install.key)"
-    export CROWBAR_PASS="$(sed -e 's/^machine-install://' <<< $CROWBAR_KEY)"
-fi
-
 case $1 in
     start|'')
         # clean up files just in case
         rm -rf /var/run/crowbar/looper-chef-client.lock /var/run/crowbar/chef-client.run /var/run/crowbar/chef-client.lock
 
         # Mark us as readying, and get our cert.
-	crowbarctl node transition $HOSTNAME "readying" -U machine-install -P $CROWBAR_PASS --no-verify-ssl
+	crowbarctl node transition $HOSTNAME "readying" --no-verify-ssl
         if [ -f /etc/default/tftpd-hpa ] ; then
           service tftpd-hpa stop
           service tftpd-hpa start
         fi
-	crowbarctl node transition $HOSTNAME "ready" -U machine-install -P $CROWBAR_PASS --no-verify-ssl
+	crowbarctl node transition $HOSTNAME "ready" --no-verify-ssl
 
 	echo "Done";;
     stop) bluepill crowbar-webserver stop;;


### PR DESCRIPTION
Both gather_logs.sh and transition.sh seem to use it, for no good reason.