### PR TITLE
bin: Read /etc/crowbarrc instead of /etc/crowbar.install.key

### DIFF
--- a/bin/crowbar_machines
+++ b/bin/crowbar_machines
@@ -22,6 +22,7 @@ require "rubygems"
 require "net/http"
 require "net/http/digest_auth"
 require "uri"
+require "inifile"
 require "json"
 require "getoptlong"
 require "utils/extended_hash"
@@ -33,7 +34,6 @@ require "utils/extended_hash"
 @allow_zero_args = false
 @timeout = 500
 @barclamp = "machines"
-@crowbar_key_file = "/etc/crowbar.install.key"
 
 @hostname = "127.0.0.1" unless @hostname
 @port = 80 unless @port
@@ -402,19 +402,30 @@ def api_help
   end
 end
 
-def opt_parse
-  key = ENV["CROWBAR_KEY"]
-  if key.nil? and ::File.exists?(@crowbar_key_file) and ::File.readable?(@crowbar_key_file)
+def get_user_password
+  @username = ENV["CROWBAR_USERNAME"]
+  @password = ENV["CROWBAR_PASSWORD"]
+
+  return unless @username.nil?
+
+  [
+    File.join(ENV["HOME"], ".crowbarrc"),
+    File.join("/etc", "crowbarrc")
+  ].each do |file|
+    next unless File.exist?(file)
     begin
-      key = File.read(@crowbar_key_file).strip
-    rescue => e
-      warn "Unable to read crowbar key from #{@crowbar_key_file}: #{e}"
+      site = ENV["CROWBAR_ALIAS"] || "default"
+      config = IniFile.load(file).to_h[site]
+      @username = config["username"]
+      @password = config["password"]
+    rescue IniFile::Error
+      STDERR.puts "Could not parse config file \"#{file}\""
     end
   end
+end
 
-  if key
-    @username, @password = key.split(":",2)
-  end
+def opt_parse
+  get_user_password
 
   sub_options = @options.map { |x| x[0] }
   lsub_options = @options.map { |x| [x[0][0], x[2]] }
@@ -452,8 +463,9 @@ def opt_parse
   end
 
   if @username.nil? or @password.nil?
-    STDERR.puts "CROWBAR_KEY not set, will not be able to authenticate!"
-    STDERR.puts "Please set CROWBAR_KEY or use -U and -P"
+    STDERR.puts "Incomplete credentials, will not be able to authenticate!"
+    STDERR.puts "Please a crowbarrc configuration file, " \
+        "set CROWBAR_USERNAME and CROWBAR_PASSWORD, or use -U and -P"
     exit 1
   end
 end

--- a/bin/crowbar_node_state
+++ b/bin/crowbar_node_state
@@ -20,6 +20,7 @@ require "rubygems"
 require "net/http"
 require "net/http/digest_auth"
 require "uri"
+require "inifile"
 require "json"
 require "getoptlong"
 
@@ -35,7 +36,6 @@ require "getoptlong"
 @allow_zero_args = false
 @timeout = 500
 @barclamp="machines"
-@crowbar_key_file = "/etc/crowbar.install.key"
 @noready = false
 
 #
@@ -168,19 +168,30 @@ def status()
   end
 end
 
-def opt_parse()
-  key = ENV["CROWBAR_KEY"]
-  if key.nil? and ::File.exists?(@crowbar_key_file) and ::File.readable?(@crowbar_key_file)
+def get_user_password
+  @username = ENV["CROWBAR_USERNAME"]
+  @password = ENV["CROWBAR_PASSWORD"]
+
+  return unless @username.nil?
+
+  [
+    File.join(ENV["HOME"], ".crowbarrc"),
+    File.join("/etc", "crowbarrc")
+  ].each do |file|
+    next unless File.exist?(file)
     begin
-      key = File.read(@crowbar_key_file).strip
-    rescue => e
-      warn "Unable to read crowbar key from #{@crowbar_key_file}: #{e}"
+      site = ENV["CROWBAR_ALIAS"] || "default"
+      config = IniFile.load(file).to_h[site]
+      @username = config["username"]
+      @password = config["password"]
+    rescue IniFile::Error
+      STDERR.puts "Could not parse config file \"#{file}\""
     end
   end
+end
 
-  if key
-    @username, @password = key.split(":",2)
-  end
+def opt_parse()
+  get_user_password
 
   sub_options = @options.map { |x| x[0] }
   lsub_options = @options.map { |x| [x[0][0], x[2]] }
@@ -224,8 +235,9 @@ def opt_parse()
   end
 
   if @username.nil? or @password.nil?
-    STDERR.puts "CROWBAR_KEY not set, will not be able to authenticate!"
-    STDERR.puts "Please set CROWBAR_KEY or use -U and -P"
+    STDERR.puts "Incomplete credentials, will not be able to authenticate!"
+    STDERR.puts "Please a crowbarrc configuration file, " \
+        "set CROWBAR_USERNAME and CROWBAR_PASSWORD, or use -U and -P"
     exit 1
   end
 end


### PR DESCRIPTION
We also stop using the CROWBAR_KEY environment variable and use
CROWBAR_USERNAME and CROWBAR_PASSWORD, like crowbarctl.

This depends on https://github.com/crowbar/crowbar/pull/2379 (which creates /etc/crowbarrc during install-chef-suse, and also removes the use of the crowbar CLI in that script).

This removes a good part of the use of the machine-install user.