### PR TITLE
[5.0] Fix cloud-mkcloud9-job-backup-restore (SCRD-7126)

### DIFF
--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -222,6 +222,13 @@ module Crowbar
           "-L",
           "#{ENV["CROWBAR_LOG_DIR"]}/chef-client/#{Node.admin_node.name}.log"
         )
+        Rails.logger.info("Updating admin node log file ownership")
+        system(
+          "sudo",
+          "chown",
+          "crowbar:",
+          "#{ENV["CROWBAR_LOG_DIR"]}/chef-client/#{Node.admin_node.name}.log"
+        )
       end
 
       def restore_files(source, destination)


### PR DESCRIPTION
Added code to fix the ownership of admin node log file to
crowbar:crowbar after restore since it run chef-client as root and
creates the log file with ownership root:root

(cherry picked from commit 117d21c372617a98a2157429b07d0ddd27af0d85)

Backport of https://github.com/crowbar/crowbar-core/pull/1822