### PR TITLE
cisco-ucs: Hide menu item for Cisco UCS

### DIFF
--- a/cisco_ucs.yml
+++ b/cisco_ucs.yml
@@ -30,9 +30,3 @@ crowbar:
   run_order: 20
   chef_order: 20
   proposal_schema_version: 3
-
-nav:
-  utils:
-    ucs:
-      order: 90
-      route: 'ucs_edit_path'


### PR DESCRIPTION
It's not tested, and is not used. So hide it.