### PR TITLE
provisioner: enabled tuned profiles

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -414,3 +414,22 @@ elsif !is_admin
     mode "0o600"
   end
 end
+
+if node.roles.include?("nova-compute-kvm") || node.roles.include?("database-server")
+  package "tuned"
+
+  service "tuned" do
+    action [:enable, :start]
+  end
+
+  if node.roles.include?("nova-compute-kvm")
+    profile = "virtual-host"
+  elsif node.roles.include?("database-server")
+    profile = "throughput-performance"
+  end
+
+  execute "Set proper tuned profile to #{profile}" do
+    command "tuned-adm profile #{profile}"
+    not_if "tuned-adm active|grep -q '#{profile}'"
+  end
+end


### PR DESCRIPTION
Enable the tuned profiles virtual-host or throughput-performance based
on the current role of the node to get better sysctl settings