### PR TITLE
crowbar: Move crowbarrc mgmt into crowbar cookbook (SCRD-8330)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -355,48 +355,7 @@ verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
 
 package "ruby2.1-rubygem-crowbar-client"
 
-if is_admin && ::File.exist?("/etc/crowbarrc")
-  # On admin server, only make sure the address and verify_ssl options are
-  # correct; the admin is the one controlling the username & password
-
-  # After installation of a gem, we have a new path for the new gem, so we
-  # need to reset the paths if we can't load the gem
-  begin
-    require "inifile"
-  rescue LoadError
-    Gem.clear_paths
-  end
-
-  begin
-    crowbarrc = IniFile.load("/etc/crowbarrc")
-
-    crowbarrc_config = crowbarrc["default"]
-
-    if server != crowbarrc_config["server"]
-      crowbarrc_config["server"] = server
-      Chef::Log.info("Will update \"server\" option in /etc/crowbarrc to \"#{server}\"")
-      do_save = true
-    end
-
-    crowbarrc_verify_ssl = crowbarrc_config["verify_ssl"].nil? ||
-      ![false, 0, "0", "f", "F", "false", "FALSE"].include?(crowbarrc_config["verify_ssl"])
-
-    if protocol == "http" && crowbarrc_config.key?("verify_ssl")
-      crowbarrc_config.delete("verify_ssl")
-      Chef::Log.info("Will remove \"verify_ssl\" option in /etc/crowbarrc")
-      do_save = true
-    elsif protocol == "https" && verify_ssl != crowbarrc_verify_ssl
-      crowbarrc_config["verify_ssl"] = verify_ssl ? 1 : 0
-      Chef::Log.info("Will update \"verify_ssl\" option in /etc/crowbarrc to " \
-          "\"#{crowbarrc_config["verify_ssl"]}\"")
-      do_save = true
-    end
-
-    crowbarrc.save if do_save
-  rescue IniFile::Error
-    Chef::Log.warn("Could not parse/update config file /etc/crowbarrc")
-  end
-elsif !is_admin
+unless is_admin
   # On non-admin nodes, setup /etc/crowbarrc with the restricted client
   username = crowbar_node["crowbar"]["client_user"]["username"]
   password = crowbar_node["crowbar"]["client_user"]["password"]

--- a/crowbar_framework/lib/crowbar/backup/restore.rb
+++ b/crowbar_framework/lib/crowbar/backup/restore.rb
@@ -187,6 +187,7 @@ module Crowbar
 
         begin
           [:nodes, :roles, :clients, :databags].each do |type|
+            Rails.logger.debug("Restoring #{type}")
             Dir.glob(@data.join("knife", type.to_s, "**", "*")).each do |file|
               file = Pathname.new(file)
               next unless file.extname == ".json"
@@ -207,8 +208,8 @@ module Crowbar
           @status[:restore_chef] ||= { status: :ok, msg: "" }
         rescue Errno::ECONNREFUSED
           raise Crowbar::Error::ChefOffline.new
-        rescue Net::HTTPServerException
-          raise "Restore failed"
+        rescue Net::HTTPServerException => exception
+          raise "Restore failed: #{exception.message}"
         end
 
         # now that restore is done, dns server can answer requests from other nodes.


### PR DESCRIPTION
In the case of a restoration from backup, /etc/crowbarrc will already
have been modified by the last installation. During the restore, the
install-suse-chef.sh script runs chef on the admin node, but only with a
select set of roles which at certain points does not include the
provisioner role. The result is that from crowbar's point of view at
that point in time this is a new installation and the proposal values,
including whether to use SSL, are set to default values. However, the
crowbarrc file may already have been modified to use SSL. In this case,
trying to use crowbarctl will fail because the crowbar server is not yet
configured for SSL.

This patch addresses the problem by moving the management of the
crowbarrc file into the crowbar cookbook for the admin node. This way,
if only the crowbar role is included, it can still properly manage the
crowbarrc file so that the server and verify_ssl parameters are correct
for the stage it is running in.