### PR TITLE
[5.0] Fix order of values in nodes piechart

### DIFF
--- a/crowbar_framework/vendor/assets/javascripts/jquery/ledUpdate.js
+++ b/crowbar_framework/vendor/assets/javascripts/jquery/ledUpdate.js
@@ -70,8 +70,8 @@
             val.status.ready,
             val.status.failed,
             val.status.unknown,
-            val.status.crowbar_upgrade,
-            val.status.unready + val.status.pending
+            val.status.unready + val.status.pending,
+            val.status.crowbar_upgrade
           ];
 
           current.attr('title', val.tooltip).tooltip('destroy').tooltip({


### PR DESCRIPTION
JavaScript part of piecharts expected [ready,failed,unknown,upgrade,pending]
but backend was providing [ready,failed,unknown,pending,upgrade].
Backend code is in NodesHelper.piechart_values().

(cherry picked from commit 5c78f9d872a6b07c92efc61cc4f265a4b408c758)

backport of #1816 