### PR TITLE
network: Don't set datapath-ids on ovs-bridges anymore

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -820,22 +820,6 @@ class ::Nic
       ::Kernel.system("ovs-vsctl add-port #{@nic} #{slave}")
     end
 
-    def datapath_id
-      res = ""
-      ::IO.popen("ovs-vsctl get Bridge #{@nic} datapath-id 2> /dev/null") do |f|
-        f.each do |line|
-          # There should only be one line of output, the double quoted
-          # datapath-id
-          res = line.strip.tr('"', '')
-        end
-      end
-      res
-    end
-
-    def datapath_id=(id)
-      ::Kernel.system("ovs-vsctl set Bridge #{@nic} other-config:datapath-id=#{id}")
-    end
-
     def self.create(nic, slaves = [])
       Chef::Log.info("Creating new OVS bridge #{nic}")
       if self.exists?(nic)

--- a/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
+++ b/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
@@ -1,7 +1,6 @@
 #! /bin/bash
 
 ovs-vsctl br-exists <%= @bridgename %> || exit 0
-ovs-vsctl set Bridge <%= @bridgename %> other-config:datapath-id=<%= @datapath_id %>
 <%
   # remove the "secure" fail-mode for bridges that share an interface
   # with the "admin" network, otherwise the admin network will be offline


### PR DESCRIPTION
Neutron is now taking care of setting a unique datapath-id. So we don't
need this anymore. See:

https://review.opendev.org/#/c/587244/