### PR TITLE
[5.0] Ignore CVE-2019-11068 during Travis (SOC-9262)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
        - bundle exec rake spec brakeman:run
        # ignore rest-client issues, chef 10 requires that
        - bin/bundle exec bundle-audit update
-       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 OSVDB-117461
+       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 OSVDB-117461 CVE-2019-11068
     - gemfile: chef/cookbooks/barclamp/Gemfile
       script:
        - cd chef/cookbooks/barclamp && bundle exec rake


### PR DESCRIPTION
SLES 12 only ships Ruby 2.1.9 but nokogiri 1.10.3 requires ruby >=
2.3.0. As we can't update to this version we will ignore the CVE during
travis but we will add a patch to the current SLES 12 nokogiri to fix
the CVE.

(cherry picked from commit e7b9585dc330ed4753119d301c36a16bbcee3c1b)