### PR TITLE
crowbar: Modify regex of group names to forbid dots (SOC-8011)

### DIFF
--- a/crowbar_framework/app/assets/javascripts/barclamps/crowbar/application.js
+++ b/crowbar_framework/app/assets/javascripts/barclamps/crowbar/application.js
@@ -30,7 +30,7 @@ jQuery(document).ready(function($) {
       $('#group-invalid').html()
     );
 
-    if ($input.val().match(/^[a-zA-Z][a-zA-Z0-9._:-]+$/)) {
+    if ($input.val().match(/^[a-zA-Z][a-zA-Z0-9_:-]+$/)) {
       $('#nodegroups').append(
         groupTemplate({
           group: $input.val()


### PR DESCRIPTION
Group names cannot contain dots because it conflicts with
the url route

/nodes/groups/1.0/:id/:group(.:format)

Now JS doesn't allow dots in the group names

More info at https://jira.suse.com/browse/SOC-8011