### PR TITLE
dns: fix designate migration

### DIFF
--- a/chef/data_bags/crowbar/migrate/dns/301_add_rndckey.rb
+++ b/chef/data_bags/crowbar/migrate/dns/301_add_rndckey.rb
@@ -3,13 +3,13 @@ def upgrade(template_attrs, template_deployment, attrs, deployment)
     service = ServiceObject.new "fake-logger"
     @@dns_designate_rndc_key = service.random_password
   end
-  deployment["designate_rndc_key"] = @@dns_designate_rndc_key
-  deployment["enable_designate"] = template_deployment["enable_designate"]
+  attrs["designate_rndc_key"] = @@dns_designate_rndc_key
+  attrs["enable_designate"] = template_deployment["enable_designate"]
   return attrs, deployment
 end
 
 def downgrade(template_attrs, template_deployment, attrs, deployment)
-  attr.delete("designate_rndc_key") unless template_attrs.key("designate_rndc_key")
-  attr.delete("enable_designate") unless template_attrs.key("enable_designate")
+  attrs.delete("designate_rndc_key") unless template_attrs.key("designate_rndc_key")
+  attrs.delete("enable_designate") unless template_attrs.key("enable_designate")
   return attrs, deployment
 end


### PR DESCRIPTION
This commit fixes the Designate migration which added the
Designate related keys to deployment rather than attrs.

Without this, the migration will fail upon upgrade from Cloud 8.