### PR TITLE
keystone: delete old Member role before upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -105,6 +105,15 @@ template "/usr/sbin/crowbar-delete-cinder-services-before-upgrade.sh" do
   only_if { cinder_controller && (!use_ha || is_cluster_founder) }
 end
 
+template "/usr/sbin/crowbar-delete-Member-role-before-upgrade.sh" do
+  source "crowbar-delete-Member-role-before-upgrade.sh.erb"
+  mode "0775"
+  owner "root"
+  group "root"
+  action :create
+  only_if { roles.include?("keystone-server") && (!use_ha || is_cluster_founder) }
+end
+
 controller_nodes = search(:node, "run_list_map:nova-controller").map { |n| n["hostname"] }
 compute_nodes = search(:node, "run_list_map:nova-compute-*").map { |n| n["hostname"] }
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-delete-Member-role-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-delete-Member-role-before-upgrade.sh.erb
@@ -1,0 +1,47 @@
+#!/bin/bash
+#
+# This script deletes the Member role as part of the upgrade from Cloud 8 to
+# Cloud 9. This is necessary because the "Member" role was renamed to "member"
+# in Cloud 9 and the attempt to create the "member" role will fail if "Member"
+# exists already (Keystone is case-insensitive).
+#
+# The script should be run only on the controller (first controller/cluster
+# founder in an HA cloud).
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+STATEFILE=${UPGRADEDIR}/crowbar-delete-Member-role-before-upgrade-ok
+
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+source /root/.openrc
+set -x
+
+mkdir -p $UPGRADEDIR
+
+if [[ -f $STATEFILE ]] ; then
+    log "Member role was already deleted"
+    exit 0
+fi
+
+if openstack role list | grep -q ' Member '; then
+  openstack role delete Member
+  ret=$?
+  if [ $ret != 0 ]; then
+    log "Failed to delete Member role."
+    exit $ret
+  fi
+fi
+
+touch $STATEFILE
+log "$BASH_SOURCE is finished."


### PR DESCRIPTION
Until Cloud 8, the default keystone role for simple membership
in a tenant was named "Member". It got renamed to "member" as
of Cloud 9. Since Keystone ignores case, Crowbar will attempt
to create a "member" role and fail since "Member" exists
already. Deleting the old "Member" role first fixes this
problem.