### PR TITLE
[4.0] deployer: Use dhcp on crowbar_register only when enable_pxe is set (bsc#1132654)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -24,6 +24,7 @@ domain_name = node[:dns].nil? ? node[:domain] : (node[:dns][:domain] || node[:do
 web_port = node[:provisioner][:web_port]
 provisioner_web="http://#{admin_ip}:#{web_port}"
 append_line = node[:provisioner][:discovery][:append].dup # We'll modify it inline
+enable_pxe = node[:provisioner][:enable_pxe]
 
 crowbar_node = node_search_with_cache("roles:crowbar").first
 crowbar_protocol = crowbar_node[:crowbar][:apache][:ssl] ? "https" : "http"
@@ -533,6 +534,7 @@ node[:provisioner][:supported_oses].each do |os, arches|
                   admin_broadcast: admin_net.broadcast,
                   crowbar_protocol: crowbar_protocol,
                   crowbar_verify_ssl: crowbar_verify_ssl,
+                  enable_pxe: enable_pxe,
                   web_port: web_port,
                   ntp_servers_ips: ntp_servers,
                   os: os,

--- a/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
+++ b/chef/cookbooks/provisioner/templates/suse/crowbar_register.erb
@@ -435,6 +435,7 @@ crowbarctl node transition $HOSTNAME "installed"
 # Wait for DHCP to update
 sleep 30
 
+<% if @enable_pxe -%>
 # Make sure we can always resolve our hostname; we use DHCP to find what's our
 # admin IP
 DHCP_VARS=$(mktemp)
@@ -445,5 +446,6 @@ if test $? -eq 0; then
     echo "$ADMIN_IP $HOSTNAME ${HOSTNAME%%.*}" >> /etc/hosts
 fi
 rm -f "$DHCP_VARS"
+<% end -%>
 
 /usr/sbin/crowbar_join --setup --verbose


### PR DESCRIPTION
Backport #1852 

(cherry picked from commit 80db03a430713debf395b676564f4446aaf6fc50)