### PR TITLE
travis: pin sexp_processor to 4.12.0

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -65,6 +65,7 @@ gem "activeresource", "~> 4.0.0",
 
 unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
   group :development, :test do
+    gem "sexp_processor", "<= 4.12.0" # remove when moving to newer brakeman
     gem "brakeman", "~> 2.6.3"
     gem "rspec-rails", "~> 3.3.0"
     gem "byebug", "~> 8.2.2"


### PR DESCRIPTION
we use brakeman during our travis run. It has a dependency
sexp_processor (deep buried). This gem got a new commit[1] which is not
compatible with brakeman.

The best case would be to fix brakeman and backport it to v2.6.3 (also
pinned) which had a last commit in 2014.  So pinning the dependency is
the easier fix

1 - https://github.com/seattlerb/sexp_processor/commit/ce284487f057203360c41b14d2b25f8c5453fbb9