### PR TITLE
Allow restricted API access during upgrade

### DIFF
--- a/crowbar_framework/app/controllers/restricted_controller.rb
+++ b/crowbar_framework/app/controllers/restricted_controller.rb
@@ -133,4 +133,15 @@ class RestrictedController < ApplicationController
   def load_node
     @node = Node.find_node_by_name_or_alias(params[:id])
   end
+
+  def upgrade
+    respond_to do |format|
+      format.any(:json, :jsonapi) do
+        return
+      end
+      format.html do
+        render "errors/during_upgrade", status: :service_unavailable
+      end
+    end
+  end
 end


### PR DESCRIPTION
The upgrade uses the restricted API to transition nodes from
state "readying" to state "ready" in the course of the
upgrade. Since RestrictedController inherits the update()
method from ApplicationController this is not possible due to
ApplicationController disallowing all POST requests during
API. This commit fixes the problem by giving the restricted
controller an update() method of its own which does allow
them.

Setting to WIP for now - currently testing. I will clear the flag once my test cloud has (hopefully) finished upgrading.