### PR TITLE
Lock sexp_parser version to make travis happy

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -66,6 +66,7 @@ gem "activeresource", "~> 4.0.0",
 unless ENV["PACKAGING"] && ENV["PACKAGING"] == "yes"
   group :development, :test do
     gem "brakeman", "~> 2.6.3"
+    gem "sexp_processor", "~> 4.10.0"
     gem "rspec-rails", "~> 3.3.0"
     gem "byebug", "~> 8.2.2"
     gem "derailed_benchmarks", "~> 1.3.0"


### PR DESCRIPTION
sexp_parser added a new check in the line() function [1] which breaks
the version of brakeman we have locked currently (2.6.3). Upstream
brakeman includes a fix [2] but it is not released yet and we would
need to upgrade to latest version (4.5.x).

Locking sexp_parser before the check was added seems to be the easiest
quick-fix.

[1] https://github.com/seattlerb/sexp_processor/commit/ce284487f057203360c41b14d2b25f8c5453fbb9
[2] https://github.com/presidentbeef/brakeman/blob/master/lib/ruby_parser/bm_sexp.rb#L43