### PR TITLE
[5.0] crowbar: Save sync_mark attributes in databag

### DIFF
--- a/chef/data_bags/crowbar/migrate/crowbar/201_add_sync_mark.rb
+++ b/chef/data_bags/crowbar/migrate/crowbar/201_add_sync_mark.rb
@@ -1,0 +1,9 @@
+def upgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs["sync_mark"] = template_attrs["sync_mark"] unless attrs.key?("sync_mark")
+  return attrs, deployment
+end
+
+def downgrade(template_attrs, template_deployment, attrs, deployment)
+  attrs.delete("sync_mark")
+  return attrs, deployment
+end

--- a/chef/data_bags/crowbar/template-crowbar.json
+++ b/chef/data_bags/crowbar/template-crowbar.json
@@ -20,6 +20,10 @@
         "machine-install": { "password": "machine_password" },
         "crowbar": { "password": "crowbar" }
       },
+      "sync_mark": {
+        "default_timeout": 60,
+        "timeout_multiplier": 1.0
+      },
       "simple_proposal_ui": true,
       "upgrade": {
         "db_dump_location": "/var/lib/pgsql/openstack-db-before-upgrade.dump"
@@ -42,7 +46,7 @@
     "crowbar": {
       "crowbar-revision": 0,
       "crowbar-applied": false,
-      "schema-revision": 200,
+      "schema-revision": 201,
       "element_states": {
         "crowbar": [ "all" ],
         "crowbar-upgrade": [ "readying", "ready", "applying", "crowbar_upgrade" ]

--- a/chef/data_bags/crowbar/template-crowbar.schema
+++ b/chef/data_bags/crowbar/template-crowbar.schema
@@ -50,6 +50,14 @@
                 "ssl_crt_chain_file": { "type": "str" }
               }
             },
+            "sync_mark": {
+              "type": "map",
+              "required": true,
+              "mapping": {
+                "default_timeout": { "type": "int", "required": true },
+                "timeout_multiplier": { "type": "float", "required": true }
+              }
+            },
             "simple_proposal_ui": { "type": "bool", "required": false },
 	    "bios-settings": { "type": "map", "required": false, "mapping": {
 		    = : { "type": "str", "required": true }

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -452,6 +452,11 @@ class CrowbarService < ServiceObject
         node.set_state("crowbar_upgrade")
       end
     end
+
+    # save sync_mark attributes in config databag for the sync_mark provider to fetch
+    item = Crowbar::DataBagConfig.get_or_create_databag_item("crowbar-config", "sync_mark")
+    item.update(role.default_attributes["crowbar"]["sync_mark"])
+    item.save
   end
 
   def apply_role(role, inst, in_queue, bootstrap = false)

--- a/crowbar_framework/spec/fixtures/data_bags/template-crowbar.json
+++ b/crowbar_framework/spec/fixtures/data_bags/template-crowbar.json
@@ -21,6 +21,10 @@
         "machine-install": { "password": "machine_password" },
         "crowbar": { "password": "crowbar" }
       },
+      "sync_mark": {
+        "default_timeout": 60,
+        "timeout_multiplier": 1.0
+      },
       "simple_proposal_ui": true,
       "upgrade": {
         "db_dump_location" : "/var/lib/pgsql/db-before-cloud6.dump"


### PR DESCRIPTION
sync_mark provider from crowbar-ha is using sync_mark attributes from
crowbar-config databag so they need to be transferred from proposal to
this databag.

(cherry picked from commit 429a51bf11e174901266e898139d06bca916cb39)

port of #1863 