### PR TITLE
[5.0] dns: fix migration for designate

### DIFF
--- a/chef/data_bags/crowbar/migrate/dns/103_add_rndckey.rb
+++ b/chef/data_bags/crowbar/migrate/dns/103_add_rndckey.rb
@@ -4,7 +4,7 @@ def upgrade(template_attrs, template_deployment, attrs, deployment)
     @@dns_designate_rndc_key = service.random_password
   end
   attrs["designate_rndc_key"] = @@dns_designate_rndc_key
-  attrs["enable_designate"] = template_deployment["enable_designate"]
+  attrs["enable_designate"] = template_attrs["enable_designate"]
   return attrs, deployment
 end
 


### PR DESCRIPTION
(cherry picked from commit 38580808e1b8a4a43ae40a4ec0bcfc7352156db2)