### PR TITLE
crowbar: Give more time for reboot for physical hardware reboots

### DIFF
--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -127,7 +127,7 @@ module Api
     end
 
     def wait_for_ssh_state(desired_state, action)
-      Timeout.timeout(400) do
+      Timeout.timeout(800) do
         loop do
           ssh_status = @node.ssh_cmd("").first
           break if desired_state == :up ? ssh_status == 200 : ssh_status != 200


### PR DESCRIPTION
Some more enterprisy physical servers take a little bit more time
to reboot than just the 5-6 minutes. Wait at least 10 minutes
to be compatible with those vendors.