### PR TITLE
monasca: remove Java persister (SOC-9482)

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -105,6 +105,15 @@ template "/usr/sbin/crowbar-delete-cinder-services-before-upgrade.sh" do
   only_if { cinder_controller && (!use_ha || is_cluster_founder) }
 end
 
+template "/usr/sbin/crowbar-monasca-cleanups.sh" do
+  source "crowbar-monasca-cleanups.sh.erb"
+  mode "0775"
+  owner "root"
+  group "root"
+  action :create
+  only_if { roles.include?("monasca-server") }
+end
+
 controller_nodes = search(:node, "run_list_map:nova-controller").map { |n| n["hostname"] }
 compute_nodes = search(:node, "run_list_map:nova-compute-*").map { |n| n["hostname"] }
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-monasca-cleanups.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-monasca-cleanups.sh.erb
@@ -1,0 +1,72 @@
+#!/bin/bash
+#
+# This script performs various Monasca cleanups required before
+# the Cloud 8 to Cloud 9 upgrade.
+#
+# The script should be run only on the monasca-server node.
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+STATEFILE=${UPGRADEDIR}/crowbar-monasca-cleanups-ok
+
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+install_new_persister()
+{
+    # Do nothing if java persister is not installed
+    rpm -q openstack-monasca-persister-java || return
+
+    zypper --non-interactive remove openstack-monasca-persister-java
+    local ret=$?
+
+    if [ $ret != 0 ]; then
+      log "Failed to remove Java based Monasca persister."
+      exit $ret
+    fi
+
+    zypper --non-interactive install openstack-monasca-persister
+    local ret=$?
+
+    if [ $ret != 0 ]; then
+      log "Failed to install Python based Monasca persister."
+      exit $ret
+    fi
+
+    # This is required because persister deinstallation will perform a userdel on
+    # the monasca-persister user which may then get recreated with a different user
+    # ID by the Python persister package.
+    chown monasca-persister /var/log/monasca-persister/monasca-persister.log
+}
+
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+
+if [[ -f $STATEFILE ]] ; then
+    log "Monasca cleanup already ran."
+    exit 0
+fi
+
+# Replace Java persister by Python persister
+
+install_new_persister
+
+# Clear old VHost definitions. Without this, apache2 will fail to start due to
+# duplicate VHost definitions for monasca{-log,}-api
+rm -vf /etc/apache2/vhosts.d/wsgi-monasca-*
+
+###
+
+touch $STATEFILE
+log "$BASH_SOURCE is finished."


### PR DESCRIPTION
Until Cloud 8 we used the Java based Monasca Persister. As of
Cloud 9 we use the Python based Monasca Persister
implementation. Since the two packages conflict, we need to
uninstall the Java based persister when preparing for the
Cloud 8 to Cloud 9 upgrade.