### PR TITLE
ipv6: Add a wrap_ip helper to NetworkHelper

### DIFF
--- a/chef/cookbooks/network/libraries/helpers.rb
+++ b/chef/cookbooks/network/libraries/helpers.rb
@@ -1,0 +1,10 @@
+module NetworkHelper
+  def self.wrap_ip(address)
+    require "ipaddr"
+    if IPAddr.new(address).ipv6?
+      "[#{address}]"
+    else
+      address.to_s
+    end
+  end
+end

--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -350,7 +350,7 @@ is_admin = CrowbarHelper.is_admin?(node)
 crowbar_node = node_search_with_cache("roles:crowbar").first
 address = crowbar_node["crowbar"]["network"]["admin"]["address"]
 protocol = crowbar_node["crowbar"]["apache"]["ssl"] ? "https" : "http"
-server = "#{protocol}://#{address}"
+server = "#{protocol}://#{NetworkHelper.wrap_ip(address)}"
 verify_ssl = !crowbar_node["crowbar"]["apache"]["insecure"]
 
 package "ruby2.1-rubygem-crowbar-client"


### PR DESCRIPTION
To make it easier to write out IP addresses which may be v6, introduce a
wrap_ip method to NetworkHelper. Make use of it in the provisioner
barclamp when writing out the crowbar rc file.

Co-Authored-By: Matthew Oliver <matt@oliver.net.au>