### PR TITLE
Delete controller on ovs bridge for admin net at boot (bsc#1141124)

### DIFF
--- a/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
+++ b/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
@@ -4,9 +4,12 @@ ovs-vsctl br-exists <%= @bridgename %> || exit 0
 <%
   # remove the "secure" fail-mode for bridges that share an interface
   # with the "admin" network, otherwise the admin network will be offline
-  # during boot and until the neutron OVS agent wakes up
+  # during boot and until the neutron OVS agent wakes up. Also delete any
+  # controller to prevent an outage when the agent starts and the bridge
+  # leaves fail open mode.
   if @is_admin_nwk
 -%>
+ovs-vsctl get-controller <%= @bridgename %> && ovs-vsctl del-controller <%= @bridgename %> || true
 ovs-vsctl del-fail-mode <%= @bridgename %>
 <%
   end


### PR DESCRIPTION
Wicked deletes any ovs bridges it manages on a clean shutdown and recreates them
at boot time. These bridges won't have a controller until the ovs agent adds one
later. But on an unclean shutdown the bridges don't get deleted and ovs recreates
them on the next boot, but now with a controller defined. When the ovs agent
starts, the bridge will connect immediately and leave fail open mode, so
forwarding stops until the agent adds new flows. But if the agent requires the
bridge for the admin network to reach rabbitmq server, then it will never get to
install the flows.

To avoid this, delete the controller in the pre-up script - the agent will be
replacing anyway.