### PR TITLE
Cleanup clone_stateless_services leftovers (SOC-9842)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -61,7 +61,6 @@ if [ $ret != 0 ] ; then
 fi
 
 # Make sure services are shut down - they may not have to be managed by pacemaker
-# (if clone_stateless_services is set to false)
 for i in $(systemctl list-units openstack-* --no-legend | cut -d" " -f1) ; do
     log "Stopping service $i"
     systemctl stop $i

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-remaining-services.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-remaining-services.sh.erb
@@ -1,8 +1,8 @@
 #!/bin/bash
 #
 # This makes sure openstack related services are really shut down
-# We intend to do this by shutting down pacemaker resources, but if
-# clone_stateless_services is set to false, some services are not managed by pacemaker.
+# We used to do this by shutting down pacemaker resources, but now
+# some services are managed by systemd instead.
 
 LOGFILE=/var/log/crowbar/node-upgrade.log
 UPGRADEDIR=/var/lib/crowbar/upgrade

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -70,8 +70,8 @@ done
 
 <% end %>
 
-# It's possible services are not managed by pacemaker (if clone_stateless_services was not set),
-# so to make sure that services are stopped, use additional systemctl commands.
+# Some services are not managed by pacemaker, so to make sure that services are stopped,
+# use additional systemctl commands.
 log "Stopping OpenStack services..."
 
 # We do not want to stop neutron services just yet, they are needed in later upgrade stage

--- a/crowbar_framework/app/models/crowbar_service.rb
+++ b/crowbar_framework/app/models/crowbar_service.rb
@@ -340,14 +340,11 @@ class CrowbarService < ServiceObject
       prop.save
     end
 
-    # Change pacemaker setting to not use pacemaker for stateless services.
-    # Also, turn off possible DRBD enablement.
+    # Turn off possible DRBD enablement.
     pacemaker_proposals = Proposal.all.where(barclamp: "pacemaker")
     pacemaker_proposals.each do |proposal|
       role = proposal.role
-      proposal.raw_data["attributes"]["pacemaker"]["clone_stateless_services"] = false
       proposal.raw_data["attributes"]["pacemaker"]["drbd"]["enabled"] = false
-      role.default_attributes["pacemaker"]["clone_stateless_services"] = false
       role.default_attributes["pacemaker"]["drbd"]["enabled"] = false
       role.save
       proposal.save


### PR DESCRIPTION
Since clone_stateless_services attribute was dropped in
crowbar-ha/1cf82d3ff3142a700ac0e2c55c20944bf364e868 and implicitly
set to false, we don't need some parts of code which were active
when it was set to true.