### PR TITLE
upgrade: dump Monasca, Grafana databases (SOC-9772)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-dump-monasca-db.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-dump-monasca-db.sh.erb
@@ -1,0 +1,56 @@
+#!/bin/bash
+#
+# This script will backup the Monasca and grafana databases
+# from the dedicated MariaDB instance on the monasca-server
+# node (where it resided up to Cloud 8) for later migration to
+# the OpenStack cloud's shared mariadb instance.
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+STATEFILE=${UPGRADEDIR}/crowbar-dump-monasca-db-ok
+DBNAME=<%= @db_name %>
+
+DUMPFILE=${UPGRADEDIR}/monasca-${DBNAME}-database.dump.gz
+
+DB_USER="<%= @db_user %>"
+DB_PASSWORD="<%= @db_password %>"
+DB_HOST="<%= @db_host %>"
+DB_NAME="<%= @db_name %>"
+
+STOP_DB="<%= @stop_db %>"
+
+mkdir -p "$UPGRADEDIR"
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+exitok()
+{
+touch $STATEFILE
+log "$BASH_SOURCE is finished."
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+if [[ -f $STATEFILE ]] ; then
+    exitok
+fi
+
+set -e
+
+# Connect to the monasca-server node from the node where this script is running
+# so we can store the dump right where we will need it later. That may either
+# be the first database node (where the Grafana DB dump will go) or the
+# monasca-server node (where the Metrics DB dump will go).
+
+mysqldump -h ${DB_HOST} -u ${DB_USER} "-p${DB_PASSWORD}" --skip-add-locks "${DB_NAME}" | gzip > $DUMPFILE
+
+exitok

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -47,6 +47,30 @@ for id in `openstack --insecure compute service list --service nova-cert -f valu
 done
 <% end %>
 
+
+
+
+<% if @monasca_server %>
+# Stop and disable Monasca's dedicated MariaDB instance on the monasca-server
+# node: as of Cloud 9 it's no longer needed.
+systemctl stop mariadb
+systemctl disable mariadb
+<% end %>
+
+# This is relevant for Cloud 8 to Cloud 9 upgrade (shouldn't hurt to leave this
+# around for later ones though). We need to shut down grafana-server before
+# the upgrade: otherwise, an upgrade of the grafana-server package (happens
+# early on) will restart it, causing database migrations to run on the freshly
+# created grafana database in the main MariaDB instance. Restoring the Cloud 8
+# Grafana database on top of that will result in an undefined Grafana
+# database state. If grafana-server is not running, it will not run the
+# migrations it performs on startup, leaving us with an empty grafana database
+<% if @horizon_node && @monasca_enabled %>
+log "Stopping grafana-server..."
+systemctl stop grafana-server
+systemctl disable grafana-server
+<% end %>
+
 <% if @use_ha %>
 
 <% if @cluster_founder %>

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -431,7 +431,7 @@ module Api
             false,
             services: {
               data: msg,
-              help: "Check /var/log/crowbar/production.log at admin server."
+              help: "Check /var/log/crowbar/production.log on admin server."
             }
           )
           return
@@ -442,6 +442,7 @@ module Api
         # For all nodes in cluster, set the pre-upgrade attribute
         upgrade_nodes = ::Node.find("state:crowbar_upgrade")
         cinder_node = nil
+        horizon_node = nil
         nova_node = nil
         monasca_node = nil
 
@@ -451,6 +452,11 @@ module Api
               (!node.roles.include?("pacemaker-cluster-member") ||
                   node["pacemaker"]["founder"] == node[:fqdn])
             cinder_node = node
+          end
+          if node.roles.include?("horizon-server") &&
+              (!node.roles.include?("pacemaker-cluster-member") ||
+                  node["pacemaker"]["founder"] == node[:fqdn])
+            horizon_node = node
           end
           if node.roles.include?("nova-controller") &&
               (!node.roles.include?("pacemaker-cluster-member") ||
@@ -473,8 +479,49 @@ module Api
             false,
             services: {
               data: "Problem while removing Java based Monasca persister: " + e.message,
-              help: "Check /var/log/crowbar/production.log at admin server " \
+              help: "Check /var/log/crowbar/production.log on admin server " \
                 "and /var/log/crowbar/node-upgrade.log at #{monasca_node.name}."
+            }
+          )
+          # Stop here and error out
+          return
+        end
+
+        begin
+          unless horizon_node.nil? || monasca_node.nil?
+            horizon_node.wait_for_script_to_finish(
+              "/usr/sbin/crowbar-dump-monasca-db.sh",
+              timeouts[:dump_grafana_db]
+            )
+          end
+        rescue StandardError => e
+          ::Crowbar::UpgradeStatus.new.end_step(
+            false,
+            services: {
+              data: "Problem while dumping Grafana database: " + e.message,
+              help: "Check /var/log/crowbar/production.log on admin server, " \
+                "and /var/log/crowbar/node-upgrade.log on #{horizon_node.name}."
+            }
+          )
+          # Stop here and error out
+          return
+        end
+
+        begin
+          unless monasca_node.nil?
+            monasca_node.wait_for_script_to_finish(
+              "/usr/sbin/crowbar-dump-monasca-db.sh",
+              timeouts[:dump_monasca_db]
+            )
+            Rails.logger.info("Dump and shutdown of Monasca database sucessful.")
+          end
+        rescue StandardError => e
+          ::Crowbar::UpgradeStatus.new.end_step(
+            false,
+            services: {
+              data: "Problem while dumping/shutting down monasca databases: " + e.message,
+              help: "Check /var/log/crowbar/production.log on admin server, " \
+                "and /var/log/crowbar/node-upgrade.log on #{monasca_node.name}."
             }
           )
           # Stop here and error out
@@ -494,7 +541,7 @@ module Api
             false,
             services: {
               data: "Problem while deleting unknown nova services: " + e.message,
-              help: "Check /var/log/crowbar/production.log at admin server " \
+              help: "Check /var/log/crowbar/production.log on admin server " \
                 "and /var/log/crowbar/node-upgrade.log at #{nova_node.name}."
             }
           )
@@ -523,7 +570,7 @@ module Api
             false,
             services: {
               data: "Problem while deleting cinder services: " + e.message,
-              help: "Check /var/log/crowbar/production.log at admin server. " \
+              help: "Check /var/log/crowbar/production.log on admin server. " \
                 "If the action failed at a specific node, " \
                 "check /var/log/crowbar/node-upgrade.log at the node."
             }
@@ -1047,6 +1094,7 @@ module Api
           "upgrade-os",
           "shutdown-services-before-upgrade",
           "delete-cinder-services-before-upgrade",
+          "dump-monasca-db",
           "monasca-cleanups",
           "evacuate-host",
           "pre-upgrade",
@@ -2056,7 +2104,7 @@ module Api
           false,
           prepare: {
             data: message,
-            help: "Check /var/log/crowbar/production.log at admin server."
+            help: "Check /var/log/crowbar/production.log on admin server."
           }
         )
         Rails.logger.error message


### PR DESCRIPTION
Up until SUSE OpenStack Cloud 8, Monasca ran its own MariaDB
instance on the monasca-server node which hosted Monasca's
metrics database and Grafana's configuration database. As of
Cloud 9 we use the OpenStack cloud's main MariaDB instance for
both of these, hence we need to create a dump of the the data
from both in order to later migrate them to the main MariaDB
instance.