### PR TITLE
travis: Whitelist CVE-2015-3448 (SOC-9911)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ matrix:
       script:
       - pip install gitlint
       - wget https://raw.githubusercontent.com/SUSE-Cloud/automation/master/scripts/jenkins/gitlint.ini
-      - gitlint --commits master..HEAD -C gitlint.ini
+      # See: https://github.com/travis-ci/travis-ci/issues/4596 for details on TRAVIS_COMMIT_RANGE
+      - gitlint --commits ${TRAVIS_COMMIT_RANGE/.../..} -C gitlint.ini
     - name: "Validate Framework (RSpec) and Security Audit"
       gemfile: crowbar_framework/Gemfile
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
        - bundle exec rake spec brakeman:run
        # ignore rest-client issues, chef 10 requires that
        - bin/bundle exec bundle-audit update
-       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 OSVDB-117461 CVE-2019-11068
+       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068
     - name: "Validate Cookbooks (RSpec)"
       gemfile: chef/cookbooks/barclamp/Gemfile
       script:


### PR DESCRIPTION
CVE-2015-3448 is not fixed in rest-client for a long time. As we are
using custom version of the gem, fixing it would require considerable
effort. Whitelisting it in travis config should unblock the gating runs.

Additional commit changes gitlint parameters for easier backporting.