### PR TITLE
Public ips for dns nodes when designate integration is in use (SOC-9635)

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -293,7 +293,8 @@ when "suse"
   end
 end
 
-# We would like to bind service only to ip address from admin network
+# We would like to bind service only to ip address from admin network unless enable_designate is
+# enabled. In which case bind both the admin _and_ public.
 admin_network = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "admin")
 admin_addr = admin_network.address
 
@@ -390,8 +391,18 @@ end
 
 ### FIXME Change to "any" once IPv6 support has been implemented
 admin_addr6 = "none"
+public_addr6 = "none"
 if node[:dns][:enable_designate] && !node[:dns][:master]
   node[:dns][:forwarders].push master_ip
+end
+
+ipaddresses = [admin_addr]
+ip6addresses = [admin_addr6]
+if node[:dns][:enable_designate]
+  public_addr = Chef::Recipe::Barclamp::Inventory.get_network_by_type(node, "public").address
+  public_addr = nil if admin_addr == public_addr
+  ipaddresses << public_addr unless public_addr.nil?
+  ip6addresses << public_addr6 unless public_addr6 == "none"
 end
 
 # Rewrite our default configuration file
@@ -402,8 +413,8 @@ template "/etc/bind/named.conf" do
   group bindgroup
   variables(forwarders: node[:dns][:forwarders],
             allow_transfer: allow_transfer,
-            ipaddress: admin_addr,
-            ip6address: admin_addr6,
+            ipaddresses: ipaddresses,
+            ip6addresses: ip6addresses,
             enable_designate: node[:dns][:enable_designate] && node[:dns][:master]
            )
   notifies :restart, "service[bind9]", :immediately

--- a/chef/cookbooks/bind9/templates/default/named.conf.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.erb
@@ -39,8 +39,8 @@ options {
         };
 <% end -%>
         auth-nxdomain no;    # conform to RFC1035
-        listen-on { <%= @ipaddress %>; };
-        listen-on-v6 { <%= @ip6address %>; };
+        listen-on { <%= @ipaddresses.join("; ") %>; };
+        listen-on-v6 { <%= @ip6addresses.join("; ") %>; };
         minimal-responses yes;
         allow-new-zones yes;
 };

--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -113,6 +113,13 @@ class DnsService < ServiceObject
     return if all_nodes.empty?
 
     tnodes = role.override_attributes["dns"]["elements"]["dns-server"]
+    # If designate is enabled, we need each DNS node to be attached to the public network.
+    net_svc = NetworkService.new @logger
+    tnodes.each do |node|
+      if role.default_attributes[:dns][:enable_designate]
+        net_svc.allocate_ip "default", "public", "host", node
+      end
+    end
     nodes = tnodes.map { |n| Node.find_by_name(n) }
 
     if nodes.length == 1


### PR DESCRIPTION
When crowbar's DNS is set to intergrate with designate we need the DNS
servers to be listening on the public network so tennent users of
designate can access the zones they create via the API.

If designate integration is enabled, this patch allocates a public ip
for each DNS node. Each node's bind9 is also setup to listen on both the
public and admin ips.