### PR TITLE
upgrade: Re-run upgrade on non-compute nodes (SOC-10072)

### DIFF
--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -551,7 +551,7 @@ describe Api::Upgrade do
       # upgrade_non_compute_nodes:
       allow(Node).to(
         receive(:find).with(
-          "state:crowbar_upgrade AND NOT run_list_map:nova-compute-*"
+          "NOT run_list_map:nova-compute-*"
         ).and_return([ceph, testing])
       )
       allow_any_instance_of(Api::Node).to receive(:save_node_state).with(


### PR DESCRIPTION
Previous search for not-upgraded non-compute nodes was just checking for `crowbar_upgrade` state. In case where crowbar_join wait loop would time out but the script would eventually finish, state would be changed to `ready` but the `node_upgrade_state` would still be `upgrading`. 
Old version was skipping such nodes when retrying the upgrade and they were left in half-upgraded state with no easy way to correct things.
    
The new version of non-compute nodes lookup follows the pattern present in other parts of upgrade code: find some subset of nodes, then exclude those which are upgraded, then sort to move half-upgraded nodes to front and (re)start the upgrade for this list.
