### PR TITLE
ovs-pre-up: remove controller for admin bridge (SOC-10073)

### DIFF
--- a/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
+++ b/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
@@ -5,9 +5,16 @@ ovs-vsctl br-exists <%= @bridgename %> || exit 0
   # remove the "secure" fail-mode for bridges that share an interface
   # with the "admin" network, otherwise the admin network will be offline
   # during boot and until the neutron OVS agent wakes up
+  #
+  # also remove the OVS controller set up by the OVS neutron agent for the
+  # bridge, otherwise the default "standalone" fail-mode only has effect
+  # until the OVS agent starts up, instead of remaining in effect until the
+  # OVS agent actually reconfigures the bridge some time after startup
+  # (see SOC-10073 for details)
   if @is_admin_nwk
 -%>
 ovs-vsctl del-fail-mode <%= @bridgename %>
+ovs-vsctl del-controller <%= @bridgename %>
 <%
   end
 -%>


### PR DESCRIPTION
When the `of_interface` neutron configuration value is set to
`native` instead of `ovs_ofctl`, the Neutron OVS agent configures
itself as the controller for all OVS bridges that it manages.
This configuration is persisted, so all bridges will immediately
connect to the configured controller as soon as the Neutron OVS
agent comes up - e.g. after a reboot.

When the admin network is on the same interface as the neutron bridge
for the tenant network (i.e. br-fixed is carrying the admin IP in a
"single" or "team" Crowbar network mode), Crowbar ensures that the
`br-fixed` OVS bridge uses a `standalone` fail-mode on startup, to
allow admin traffic to flow uninterrupted until the neutron OVS agent
starts up and takes control of the bridge. However, with a `native`
`of_interface`, this is no longer sufficient, because the `standalone`
fail-mode has no effect if the bridge is connected to its controller,
so the admin traffic is cut off right around the time that the neutron
OVS agent starts up, but before it had a chance to connect via RPC to
the neutron-server to retrieve the configuration.

This commit proposes removing the configured controller in addition
to setting the `standalone` fail-mode on the `br-fixed` bridge, to
keep the admin network connectivity unaltered until the Neutron OVS
agent actually re-configures the bridge and not a moment before.