### PR TITLE
upgrade: remove nova-consoleauth service entries on upgrade (SOC-10164)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-delete-unknown-nova-services.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-delete-unknown-nova-services.sh.erb
@@ -48,7 +48,7 @@ done
 
 # Delete all controller based nova services that are registered to a node
 # that does not have nova-controller crowbar role
-for s in cert conductor consoleauth scheduler; do
+for s in cert conductor scheduler; do
     for host in $(openstack compute service list --service "nova-$s" -f value -c Host | sort | uniq); do
         # @controller_nodes is comma separated string like "node1,node2,node3"
         if [[ ! ",<%=@controller_nodes%>," =~ ",$host," ]]; then
@@ -56,6 +56,13 @@ for s in cert conductor consoleauth scheduler; do
                 openstack compute service delete $service
             done
         fi
+    done
+done
+
+# Delete all nova-consoleauth entries, as in Rocky there is no consoleauth anymore
+for host in $(openstack compute service list --service "nova-consoleauth" -f value -c Host | sort | uniq); do
+    for service in $(openstack compute service list --service "nova-consoleauth" --host "$host" -f value -c ID); do
+        openstack compute service delete $service
     done
 done
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
@@ -28,12 +28,18 @@ if [[ -f $UPGRADEDIR/crowbar-reload-nova-after-upgrade-ok ]] ; then
 fi
 
 <% if @nova_controller %>
-for service in conductor consoleauth scheduler novncproxy serialproxy api; do
+for service in conductor scheduler novncproxy serialproxy api; do
     fullname="openstack-nova-$service"
     if systemctl --quiet is-active $fullname 2>/dev/null ; then
         systemctl kill --signal HUP --kill-who main $fullname
     fi
 done
+# Remove and unmanage openstack-nova-consoleauth
+systemctl disable openstack-nova-consoleauth
+systemctl stop openstack-nova-consoleauth
+systemctl kill openstack-nova-consoleauth
+rpm -e openstack-nova-consoleauth
+
 <% else %>
 systemctl kill --signal HUP --kill-who main openstack-nova-compute
 <% end %>


### PR DESCRIPTION
nova-consoleauth is no longer used in Cloud 9, so we should
be removing the service entries related to it.