### PR TITLE
[4.0] network: Allow locking down the network config for nodes (bsc#1120657)

### DIFF
--- a/chef/cookbooks/network/recipes/role_network.rb
+++ b/chef/cookbooks/network/recipes/role_network.rb
@@ -15,6 +15,11 @@
 #
 
 if CrowbarRoleRecipe.node_state_valid_for_role?(node, "network", "network")
-  include_recipe "network::default"
-  include_recipe "network::fast_nics_tune"
+  if node[:network][:config_frozen]
+    Chef::Log.info("Skipping network recipes because the network configuration " \
+                   "is marked frozen for this node.")
+  else
+    include_recipe "network::default"
+    include_recipe "network::fast_nics_tune"
+  end
 end


### PR DESCRIPTION
This change provides the possibilty to lock down the network
configuration of specific nodes. It implemented by simply skipping the
whole network cookbook whe the nodes attribute
'node["network"]["config_frozen"]' is set to 'true'. In that case
anychanges to the network barclamp, or any other change that would cause
the network to be reconfigured (e.g. allocation of IPs, enablement of a
network, addition or removal of network devices, ...) will just have no
effect on that node.

stable/4.0 Backport of: https://github.com/crowbar/crowbar-core/pull/1854