### PR TITLE
allow user to ask for FQDN as public hostname (SOC-9616)

### DIFF
--- a/chef/cookbooks/utils/libraries/helpers.rb
+++ b/chef/cookbooks/utils/libraries/helpers.rb
@@ -33,7 +33,8 @@ module CrowbarHelper
     end
   end
 
-  def self.get_host_for_public_url(node, use_ssl, use_cluster = false)
+  def self.get_host_for_public_url(node, use_ssl, use_cluster = false,
+                                   want_fqdn = false)
     if use_cluster && defined?(CrowbarPacemakerHelper)
       # loose dependency on the pacemaker cookbook
       cluster_vhostname = CrowbarPacemakerHelper.cluster_vhostname(node)
@@ -49,14 +50,15 @@ module CrowbarHelper
     end
 
     # For the public endpoint, we prefer the public name. If not set, then we
-    # use the IP address except for SSL, where we always prefer a hostname
-    # (for certificate validation).
+    # use hostname when approprate (i.e. for SSL certificate validation or
+    # WebSSO identification), otherwise we use the IP address.
     if public_name.nil? || public_name.empty?
-      if use_ssl
-        public_name = public_fqdn
-      else
-        public_name = public_ip
-      end
+      public_name =
+        if use_ssl || want_fqdn
+          public_fqdn
+        else
+          public_ip
+        end
     end
 
     public_name


### PR DESCRIPTION
Currently CrowbarHelper.get_host_for_public_url() indiscriminately
return the IP instead of FQDN in the situation where the
node's public_name is not set and SSL is not being used.
This behavior was introduced in

https://github.com/crowbar/barclamp-glance/commit/22d3c190f1edc6f4d278982eb58076acdde16505

to address certain situations where the crowbar generated hostnames are not
resolveable externally. For SSL, we need the FQDN or hostname for
certificate validation. However, for WebSSO, certain identity providers
(i.e. Google) requires FQDN to match the authorized domain, regardless of
whether SSL is used.

In theory, we could change the behavior of get_host_for_public_url() to
always return the FQDN instead of IP as we *should be* supporting
external name resolution by now, but doing so may risk breaking
backward compatibility. Therefore, this patch introduce an option to allow
users to ask for FQDN regardless whether SSL is used without breaking
backward compatibility.