### PR TITLE
upgrade: restart nova services after upgrade

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
@@ -31,7 +31,7 @@ fi
 for service in conductor scheduler novncproxy serialproxy api; do
     fullname="openstack-nova-$service"
     if systemctl --quiet is-active $fullname 2>/dev/null ; then
-        systemctl kill --signal HUP --kill-who main $fullname
+        systemctl restart $fullname
     fi
 done
 # Remove and unmanage openstack-nova-consoleauth
@@ -41,7 +41,7 @@ systemctl kill openstack-nova-consoleauth
 rpm -e openstack-nova-consoleauth
 
 <% else %>
-systemctl kill --signal HUP --kill-who main openstack-nova-compute
+systemctl restart openstack-nova-compute
 <% end %>
 
 touch $UPGRADEDIR/crowbar-reload-nova-after-upgrade-ok


### PR DESCRIPTION
After upgrading from Pike to Rocky, nova-compute services
are all failing with this error message:

  Failed to allocate the network(s), not rescheduling.

which is logged as:

  NovaException: In shutdown, no new events can be scheduled

This is actually an oslo.service bug:

  https://bugs.launchpad.net/nova/+bug/1715374

which has not been fixed so far. Restart is the workaround
that was pushed upstream.