### PR TITLE
[5.0] ohai: Hardcode ruby version for package installation (SOC-10010)

### DIFF
--- a/chef/cookbooks/ohai/recipes/default.rb
+++ b/chef/cookbooks/ohai/recipes/default.rb
@@ -65,7 +65,7 @@ unless node[:platform_family] == "windows"
     if node["languages"]["ruby"]["version"].to_f == 1.8
       pkg = "rubygem-cstruct"
     else
-      pkg = "ruby#{node["languages"]["ruby"]["version"].to_f}-rubygem-cstruct"
+      pkg = "ruby2.1-rubygem-cstruct"
     end
     package(pkg).run_action(:install)
 


### PR DESCRIPTION
Sometimes there is a race condition and ohai didn't collect the ruby
version. to_f evalutes then the version to 0.0 and zypper fails to
install the rubygem `ruby0.0-rubygem-cstruct' not found in package
names`.

(cherry picked from commit 72a4f6510cc464a3e5309a25823c6a085502f10c)