### PR TITLE
IPV6 - Expose methods in chef NetworkHelper to crowbar_framework (SOC-6397)

### DIFF
--- a/chef/cookbooks/network/libraries/helpers.rb
+++ b/chef/cookbooks/network/libraries/helpers.rb
@@ -7,4 +7,13 @@ module NetworkHelper
       address.to_s
     end
   end
+
+  def self.ipv6(address)
+    require "ipaddr"
+    if IPAddr.new(address).ipv6?
+      true
+    else
+      false
+    end
+  end
 end

--- a/crowbar_framework/config/application.rb
+++ b/crowbar_framework/config/application.rb
@@ -22,6 +22,7 @@ module Crowbar
     # Explicitely eager load /lib/crowbar/lock so we can use SharedNonBlocking
     # with threading without hitting circular dependencies
     config.eager_load_paths += Dir["#{config.root}/lib/crowbar/lock"]
+    config.eager_load_paths += Dir["#{config.root}/../chef/cookbooks/network/libraries"]
 
     config.autoload_paths += %W(
       #{config.root}/lib


### PR DESCRIPTION
Barclamp horizon need to handle ipv6. NetworkHelper in chef/cookbooks/network/libraries/helpers.rb has methods that can be used to deal with ipv6 in barclamp horizon. 
We assume the addresses used in barclamp horizon are ip addresses. 

This commit includes:
1) Because the methods in Chef NetworkHelper are not exposed to crowbar_framework, added the path of chef/cookbooks/network/libraries/helpers.rb in crowbar_framework/config/application.rb so they can be called from crowbar_framework. 
 2) Added boolean ipv6 method to check if the address is in ipv6 form. 
