### PR TITLE
upgrade: Add more prechecks for 8->9 (SOC-9868)

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -278,6 +278,18 @@ module Api
           end
           ret[:controller_roles] = { node: node.name, roles: wrong_roles } if wrong_roles.any?
         end
+        # Make sure Aodh is not deployed
+        if Proposal.where(barclamp: "aodh").any?
+          ret[:aodh_proposal] = true
+        end
+        # Make sure Trove is not deployed
+        if Proposal.where(barclamp: "trove").any?
+          ret[:trove_proposal] = true
+        end
+        # Make sure Ceilometer is deployed with Monasca or not at all
+        if ::Node.find("roles:ceilometer-server").any? && ::Node.find("roles:monasca-server").none?
+          ret[:legacy_ceilometer] = true
+        end
         ret
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1892,6 +1892,24 @@ module Api
             help: I18n.t("api.upgrade.prechecks.wrong_sql_engine.help")
           }
         end
+        if check[:aodh_proposal]
+          ret[:aodh_proposal] = {
+            data: I18n.t("api.upgrade.prechecks.deprecated_proposal.error", proposal: "Aodh"),
+            help: I18n.t("api.upgrade.prechecks.deprecated_proposal.help", proposal: "Aodh")
+          }
+        end
+        if check[:trove_proposal]
+          ret[:trove_proposal] = {
+            data: I18n.t("api.upgrade.prechecks.deprecated_proposal.error", proposal: "Trove"),
+            help: I18n.t("api.upgrade.prechecks.deprecated_proposal.help", proposal: "Trove")
+          }
+        end
+        if check[:legacy_ceilometer]
+          ret[:legacy_ceilometer] = {
+            data: I18n.t("api.upgrade.prechecks.legacy_ceilometer.error"),
+            help: I18n.t("api.upgrade.prechecks.legacy_ceilometer.help")
+          }
+        end
         ret
       end
 

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -844,6 +844,12 @@ en:
         crowbar_ceph_present:
           error: 'There are nodes with ceph roles present. Remove all ceph roles deployed by crowbar and migrate to external Ceph cluster.'
           help: 'Refer to the SUSE Enterprise Storage documentation for the information about upgrading from Crowbar Deployment.'
+        deprecated_proposal:
+          error: '%{proposal} proposal has been detected. %{proposal} is deprecated and removed in SUSE OpenStack Cloud 9.'
+          help: 'Deactivate and delete %{proposal} proposal.'
+        legacy_ceilometer:
+          error: 'Ceilometer proposal has been detected but Monasca proposal is missing. Only Ceilosca deployments are supported in SUSE OpenStack Cloud 9.'
+          help: 'Deactivate and delete Ceilometer proposal and deploy Ceilosca after upgrade is completed.'
       prepare:
         help:
           default: 'Refer to the error message in the response'


### PR DESCRIPTION
Additional prechecks were added to detect problematic scenarios before
upgrade is started. These cover:
- Aodh deployment
- Trove deployment
- "Legacy" Ceilometer (without Monasca) deployment