### PR TITLE
dns: Always set master_ip

### DIFF
--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -123,6 +123,7 @@ class DnsService < ServiceObject
       node.set[:dns] = {} if node[:dns].nil?
       unless node[:dns][:master]
         node.set[:dns][:master] = true
+        node.set[:dns][:master_ip] = node.get_network_by_type("admin")["address"]
         node.save
       end
     elsif nodes.length > 1


### PR DESCRIPTION
Currently, the DNS barclamp will only set master_ip and slave_ips if
there is more than one node. However, this is causing an issue with the
designate barclamp which now relies on it being set all the time, so set
for the single node case too.