### PR TITLE
Add CVE-2019-5477 the to travis ignore list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
        - bundle exec rake spec brakeman:run
        # ignore rest-client issues, chef 10 requires that
        - bin/bundle exec bundle-audit update
-       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068
+       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477
     - name: "Validate Cookbooks (RSpec)"
       gemfile: chef/cookbooks/barclamp/Gemfile
       script:


### PR DESCRIPTION
A bunch of PRs in the crowbar-core are blocked due to a travis CI check:

  bundle-audit check --ignore ...

This is due to a security embargo that was lifted and blocked by a
version of nokogiri:

  Name: nokogiri
  Version: 1.9.1
  Advisory: CVE-2019-5477
  Criticality: Unknown
  URL: https://github.com/sparklemotion/nokogiri/issues/1915
  Title: Nokogiri Command Injection Vulnerability via Nokogiri::CSS::Tokenizer#load_file
  Solution: upgrade to >= 1.10.4

I asked about it in the rocketchat #cloud channel, and apparently Rick
has looked into it and it seems we are unaffected by it as we don't use
the version when building the RPM.

I've also done a quick look through IBS and I can't see nokogiri as a
build requirement for crowbar, crowbar-core or crowbar-openstack. Well
it isn't even mentioned in any of the spec files.

So raising this PR to add it to the ignore so we can unblock the
crowbar-core PRs.

Adding the SOC-9635, as its the patch of mine that is blocked on it, and
so it passes travis CI.