### PR TITLE
Allow designate rndc for all nodes (SOC-10339)

### DIFF
--- a/chef/cookbooks/bind9/recipes/default.rb
+++ b/chef/cookbooks/bind9/recipes/default.rb
@@ -355,7 +355,7 @@ template "/etc/bind/named.conf.crowbar" do
   notifies :reload, "service[bind9]"
 end
 
-if node[:dns][:enable_designate] && node[:dns][:master]
+if node[:dns][:enable_designate]
   template "/etc/named.d/designate-rndc-access.conf" do
     source "designate-rndc-access.conf.erb"
     mode 0o640
@@ -363,7 +363,7 @@ if node[:dns][:enable_designate] && node[:dns][:master]
     group bindgroup
     variables(
       rndc_key: node[:dns][:designate_rndc_key],
-      master_ip: admin_network.address,
+      admin_ip: admin_network.address,
       admin_subnet: IP::IP4.netmask_to_subnet(admin_network.netmask),
       admin_network: admin_network.subnet
     )
@@ -415,7 +415,7 @@ template "/etc/bind/named.conf" do
             allow_transfer: allow_transfer,
             ipaddresses: ipaddresses,
             ip6addresses: ip6addresses,
-            enable_designate: node[:dns][:enable_designate] && node[:dns][:master]
+            enable_designate: node[:dns][:enable_designate]
            )
   notifies :restart, "service[bind9]", :immediately
 end

--- a/chef/cookbooks/bind9/templates/default/designate-rndc-access.conf.erb
+++ b/chef/cookbooks/bind9/templates/default/designate-rndc-access.conf.erb
@@ -7,5 +7,5 @@ controls {
     # listen on the admin interface and
     # allow access via the designate-key
     # from ips of admin_network
-    inet <%= @master_ip -%> allow { <%= @admin_network -%>/<%= @admin_subnet -%>; } keys { designate-key; };
+    inet <%= @admin_ip -%> allow { <%= @admin_network -%>/<%= @admin_subnet -%>; } keys { designate-key; };
 };


### PR DESCRIPTION
With designate enabled, all Bind servers act as slaves for
designate created zones. These zones are created via rndc addzone
from designate server(s).

Adding permissions and key for allowing rndc access.