### PR TITLE
5.0: Public ips for dns nodes when designate integration is in use (SOC-9635)

### DIFF
--- a/chef/cookbooks/bind9/templates/default/named.conf.erb
+++ b/chef/cookbooks/bind9/templates/default/named.conf.erb
@@ -39,8 +39,8 @@ options {
         };
 <% end -%>
         auth-nxdomain no;    # conform to RFC1035
-        listen-on { <%= @ipaddress %>; };
-        listen-on-v6 { <%= @ip6address %>; };
+        listen-on { <%= @ipaddresses.join("; ") %>; };
+        listen-on-v6 { <%= @ip6addresses.join("; ") %>; };
         minimal-responses yes;
         allow-new-zones yes;
 };

--- a/crowbar_framework/app/models/dns_service.rb
+++ b/crowbar_framework/app/models/dns_service.rb
@@ -113,6 +113,13 @@ class DnsService < ServiceObject
     return if all_nodes.empty?
 
     tnodes = role.override_attributes["dns"]["elements"]["dns-server"]
+    # If designate is enabled, we need each DNS node to be attached to the public network.
+    net_svc = NetworkService.new @logger
+    tnodes.each do |node|
+      if role.default_attributes[:dns][:enable_designate]
+        net_svc.allocate_ip "default", "public", "host", node
+      end
+    end
     nodes = tnodes.map { |n| Node.find_by_name(n) }
 
     if nodes.length == 1


### PR DESCRIPTION
When crowbar's DNS is set to intergrate with designate we need the DNS
servers to be listening on the public network so tennent users of
desigante can access the zones they create via the API.

If designate intergration is enabled, this patch allocates a public ip
for each DNS node. Each node's bind9 is also setup to listen on both the
public and admin ips.

(cherry picked from commit 5e74dc28c98c7b6d2910fd702770ffca2f925ae4)