### PR TITLE
upgrade: Upgrade compute services early (SOC-10273)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -90,7 +90,7 @@ log "Upgrading packages needed for nova-compute node"
 
 zypper --non-interactive up openstack-nova-compute
 
-log "Restarting services for Pike"
+log "Restarting services for Rocky"
 
 <% unless @remote_node %>
 systemctl restart <%= @neutron_agent %>

--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -86,6 +86,10 @@ log "No HA setup found..."
 
 <% if @compute_node %>
 
+log "Upgrading packages needed for nova-compute node"
+
+zypper --non-interactive up openstack-nova-compute
+
 log "Restarting services for Pike"
 
 <% unless @remote_node %>

--- a/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# After the upgrade of all services on all nodes is finished, it's
+# After the upgrade of all compute services on all nodes is finished, it's
 # necessary to signal all nova services so that they start using latest RPC API version.
 
 LOGFILE=/var/log/crowbar/node-upgrade.log

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -770,6 +770,8 @@ module Api
           upgrade_controller_clusters
           upgrade_non_compute_nodes
           prepare_all_compute_nodes
+          reload_nova_services
+
           ::Crowbar::UpgradeStatus.new.save_substep(substep, :finished)
         end
       end
@@ -839,10 +841,6 @@ module Api
         status = ::Crowbar::UpgradeStatus.new
         if status.progress[:remaining_nodes].zero?
           status.save_substep(substep, :finished)
-
-          status.save_substep(:reload_nova, :running)
-          reload_nova_services
-          status.save_substep(:reload_nova, :finished)
 
           status.save_substep(:run_online_migrations, :running)
           run_online_migrations


### PR DESCRIPTION
As RPC 4.x support was dropped with https://review.opendev.org/#/c/543580/
Rocky controller can't talk to Pike compute anymore. We need to upgrade
nova compute services before the controllers so that everything is running
on new RPC when we get to live-migrate the VMs during upgrade.