### PR TITLE
batch: Use easy_merge for merging the json (SOC-10505)

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -41,7 +41,6 @@ require "open3"
 require "tempfile"
 
 require "easy_diff"
-require "chef/mixin/deep_merge"
 require "pp"
 
 ALIAS_REGEXP = /(@@[^ @]+@@)/
@@ -343,11 +342,7 @@ def merge_attributes(new_json, barclamp, proposal)
     }
   }
 
-  # easy_merge! seems to have problems with Arrays of Hashes :-/
-  #new_json.easy_merge! to_merge
-
-  #new_json.extend Chef::Mixin::DeepMerge
-  Chef::Mixin::DeepMerge.deep_merge!(to_merge, new_json)
+  new_json.easy_merge!(to_merge)
 end
 
 def commit_proposal(barclamp, name)


### PR DESCRIPTION
easy_diff got fixed some time ago and can now merge the objects. Let's
switch to this and stop using the chef mixin. Also see
https://www.rubydoc.info/github/opscode/chef/Chef%2FMixin%2FDeepMerge:deep_merge!
as the Chef Mixin could cause some issues.