### PR TITLE
Update input group to be more specific (SOC-10644)

### DIFF
--- a/crowbar_framework/vendor/assets/stylesheets/_patches.scss
+++ b/crowbar_framework/vendor/assets/stylesheets/_patches.scss
@@ -142,6 +142,8 @@
 
 .input-group > .input-group-btn > .btn {
   padding: 6px 12px;
+  min-height: 34px;
+  line-height: unset;
 }
 
 // scss-lint:disable QualifyingElement


### PR DESCRIPTION
Updates styles applied to input group buttons so that their height computed correctly.

Before:
![Clipboard - September 19, 2019 8_48 AM](https://user-images.githubusercontent.com/4097545/65267030-178e6380-dac9-11e9-80c6-81cfd95b63e0.png)

After:
![Screenshot from 2019-09-19 10-33-56](https://user-images.githubusercontent.com/4097545/65267003-0c3b3800-dac9-11e9-9101-4bb973b137df.png)
