### PR TITLE
[5.0] batch: Use easy_merge for merging (SOC-10505)

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -41,7 +41,6 @@ require "open3"
 require "tempfile"
 
 require "easy_diff"
-require "chef/mixin/deep_merge"
 require "pp"
 
 ALIAS_REGEXP = /(@@[^ @]+@@)/
@@ -345,11 +344,7 @@ def merge_attributes(new_json, barclamp, proposal)
 
   prevent_password_lockout(attrs) if barclamp == 'crowbar'
 
-  # easy_merge! seems to have problems with Arrays of Hashes :-/
-  #new_json.easy_merge! to_merge
-
-  #new_json.extend Chef::Mixin::DeepMerge
-  Chef::Mixin::DeepMerge.deep_merge!(to_merge, new_json)
+  new_json.easy_merge!(to_merge)
 end
 
 def prevent_password_lockout(attrs)


### PR DESCRIPTION
easy_diff got fixed some time ago and can now merge the objects. Let's
switch to this and stop using the chef mixin. Also see
https://www.rubydoc.info/github/opscode/chef/Chef/Mixin/DeepMerge
as the Chef Mixin could cause some issues.

(cherry picked from commit 7720e25118c76e1db99e4f43c53b71c78b672990)