### PR TITLE
batch: Fix another crowbar batch merge issue (SOC-10505)

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -41,7 +41,6 @@ require "open3"
 require "tempfile"
 
 require "easy_diff"
-require "chef/mixin/deep_merge"
 require "pp"
 
 ALIAS_REGEXP = /(@@[^ @]+@@)/
@@ -343,11 +342,7 @@ def merge_attributes(new_json, barclamp, proposal)
     }
   }
 
-  # easy_merge! seems to have problems with Arrays of Hashes :-/
-  #new_json.easy_merge! to_merge
-
-  #new_json.extend Chef::Mixin::DeepMerge
-  Chef::Mixin::DeepMerge.deep_merge!(to_merge, new_json)
+  new_json.easy_merge!(to_merge)
 end
 
 def commit_proposal(barclamp, name)

--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -331,16 +331,16 @@ def wipe_attribute(new_json, barclamp, attribute)
 end
 
 def merge_attributes(new_json, barclamp, proposal)
-  attrs = proposal["attributes"]
+  attributes = proposal["attributes"]
+  deployment = proposal["deployment"]
 
-  to_merge = {
-    "attributes" => {
-      barclamp => attrs
-    },
-    "deployment" => {
-      barclamp => proposal["deployment"]
-    }
-  }
+  to_merge = {}
+  unless attributes.nil?
+    to_merge.merge!(Hash["attributes", Hash[barclamp, attributes]])
+  end
+  unless deployment.nil?
+    to_merge.merge!(Hash["deployment", Hash[barclamp, deployment]])
+  end
 
   new_json.easy_merge!(to_merge)
 end


### PR DESCRIPTION
While merging we overwrite the template value with nil as the to_merge
is filled with a nil value.