### PR TITLE
[5.0] batch: Fix another crowbar batch merge issue (SOC-10505)

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -331,18 +331,18 @@ def wipe_attribute(new_json, barclamp, attribute)
 end
 
 def merge_attributes(new_json, barclamp, proposal)
-  attrs = proposal["attributes"]
+  attributes = proposal["attributes"]
+  deployment = proposal["deployment"]
 
-  to_merge = {
-    "attributes" => {
-      barclamp => attrs
-    },
-    "deployment" => {
-      barclamp => proposal["deployment"]
-    }
-  }
+  to_merge = {}
+  unless attributes.nil?
+    to_merge.merge!(Hash["attributes", Hash[barclamp, attributes]])
+  end
+  unless deployment.nil?
+    to_merge.merge!(Hash["deployment", Hash[barclamp, deployment]])
+  end
 
-  prevent_password_lockout(attrs) if barclamp == 'crowbar'
+  prevent_password_lockout(attributes) if barclamp == 'crowbar'
 
   new_json.easy_merge!(to_merge)
 end

--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -41,7 +41,6 @@ require "open3"
 require "tempfile"
 
 require "easy_diff"
-require "chef/mixin/deep_merge"
 require "pp"
 
 ALIAS_REGEXP = /(@@[^ @]+@@)/
@@ -345,11 +344,7 @@ def merge_attributes(new_json, barclamp, proposal)
 
   prevent_password_lockout(attrs) if barclamp == 'crowbar'
 
-  # easy_merge! seems to have problems with Arrays of Hashes :-/
-  #new_json.easy_merge! to_merge
-
-  #new_json.extend Chef::Mixin::DeepMerge
-  Chef::Mixin::DeepMerge.deep_merge!(to_merge, new_json)
+  new_json.easy_merge!(to_merge)
 end
 
 def prevent_password_lockout(attrs)


### PR DESCRIPTION
While merging we overwrite the template value with nil as the to_merge
is filled with a nil value.

(cherry picked from commit 6b51a038b03c7f7979040ea38472f2f81931fb26)