### PR TITLE
[5.0] Revert "batch: Use easy_merge for merging (SOC-10505)"

### DIFF
--- a/bin/crowbar_batch
+++ b/bin/crowbar_batch
@@ -41,6 +41,7 @@ require "open3"
 require "tempfile"
 
 require "easy_diff"
+require "chef/mixin/deep_merge"
 require "pp"
 
 ALIAS_REGEXP = /(@@[^ @]+@@)/
@@ -344,7 +345,11 @@ def merge_attributes(new_json, barclamp, proposal)
 
   prevent_password_lockout(attrs) if barclamp == 'crowbar'
 
-  new_json.easy_merge!(to_merge)
+  # easy_merge! seems to have problems with Arrays of Hashes :-/
+  #new_json.easy_merge! to_merge
+
+  #new_json.extend Chef::Mixin::DeepMerge
+  Chef::Mixin::DeepMerge.deep_merge!(to_merge, new_json)
 end
 
 def prevent_password_lockout(attrs)


### PR DESCRIPTION
This reverts commit ce564c3000e7d58cca236d7c738f258cf6acf2c5.