### PR TITLE
barclamp_lib: Sync timeout with other barclamps (SOC-10513, SOC-10011)

### DIFF
--- a/bin/barclamp_lib.rb
+++ b/bin/barclamp_lib.rb
@@ -33,7 +33,7 @@ require "getoptlong"
 }
 @data = ""
 @allow_zero_args = false
-@timeout = 500
+@timeout = 3600
 
 #
 # Parsing options can be added by adding to this list before calling opt_parse


### PR DESCRIPTION
All barclamps use a timeout of 3600 seconds just crowbar batch uses 500
second by default which is way to less. Let's sync the timeouts.