### PR TITLE
[4.0] barclamp_lib: Sync timeout with other barclamps (SOC-10513, SOC-10011)

### DIFF
--- a/bin/barclamp_lib.rb
+++ b/bin/barclamp_lib.rb
@@ -32,7 +32,7 @@ require "getoptlong"
 }
 @data = ""
 @allow_zero_args = false
-@timeout = 500
+@timeout = 3600
 @crowbar_key_file = "/etc/crowbar.install.key"
 
 #


### PR DESCRIPTION
All barclamps use a timeout of 3600 seconds just crowbar batch uses 500
second by default which is way to less. Let's sync the timeouts.

(cherry picked from commit 3bf3efd96044c8967f1f39ba52b089399349b8ee)