### PR TITLE
Revert "Use block-migration when needed" (SOC-10133)

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -128,19 +128,12 @@ template "/usr/sbin/crowbar-delete-unknown-nova-services.sh" do
   only_if { roles.include?("nova-controller") }
 end
 
-nova = search(:node, "run_list_map:nova-controller").first
-
 template "/usr/sbin/crowbar-evacuate-host.sh" do
   source "crowbar-evacuate-host.sh.erb"
   mode "0755"
   owner "root"
   group "root"
   action :create
-  variables(
-    lazy {
-      { needs_block_migrate: !nova[:nova][:use_shared_instance_storage] }
-    }
-  )
   only_if { roles.include? "nova-controller" }
 end
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
@@ -42,12 +42,6 @@ if ! nova --insecure list --all-tenants --host "$host" --fields host,status 2>/d
     exit 0
 fi
 
-<% if @needs_block_migrate %>
-blockmigrate="--block-migrate"
-<% else %>
-blockmigrate=""
-<% end %>
-
 ORIGINAL_INSTANCES=$UPGRADEDIR/original_instances
 
 # List active instances on host before the live-migration starts
@@ -66,7 +60,7 @@ if openstack --insecure compute service list --service nova-compute -f value -c 
     exit 4
 fi
 
-if ! nova --insecure host-evacuate-live "$host" $blockmigrate; then
+if ! nova --insecure host-evacuate-live "$host"; then
     log "Live migration of instances from host $host has failed!"
     echo 2 > $UPGRADEDIR/crowbar-evacuate-host-failed
     exit 2


### PR DESCRIPTION
This reverts commit 5c2fece34bdbd51c1700d883dac955ca7b6ff468.
Specifying block migration explicitly is no longer needed as
of Nova API version 2.25 (Mitaka and newer). From this API
version onward Nova will automatically select the appropriate
migration mode.

(cherry picked from commit f6d4e4d8a0b82b870005434f61ba81e67a4723c3)

This is a backport of https://github.com/crowbar/crowbar-core/pull/1936. It's already tested and works against the Cloud 7 -> Cloud 8 upgrade (see Jira issue for details).