### PR TITLE
[4.0] network: Don't set datapath-ids on ovs-bridges anymore (bsc#1152916)

### DIFF
--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -843,22 +843,6 @@ class ::Nic
       ::Kernel.system("ovs-vsctl add-port #{@nic} #{slave}")
     end
 
-    def datapath_id
-      res = ""
-      ::IO.popen("ovs-vsctl get Bridge #{@nic} datapath-id 2> /dev/null") do |f|
-        f.each do |line|
-          # There should only be one line of output, the double quoted
-          # datapath-id
-          res = line.strip.tr('"', '')
-        end
-      end
-      res
-    end
-
-    def datapath_id=(id)
-      ::Kernel.system("ovs-vsctl set Bridge #{@nic} other-config:datapath-id=#{id}")
-    end
-
     def self.create(nic, slaves = [])
       Chef::Log.info("Creating new OVS bridge #{nic}")
       if self.exists?(nic)

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -157,17 +157,6 @@ def kill_nic(nic)
   kill_nic_files(nic)
 end
 
-require "securerandom"
-def get_datapath_id_for_ovsbridge(bridge)
-  node.set["network"]["ovs_datapath_ids"] = {} if node["network"]["ovs_datapath_ids"].nil?
-  unless node["network"]["ovs_datapath_ids"][bridge]
-    datapath_id = SecureRandom.hex(8)
-    node.set["network"]["ovs_datapath_ids"][bridge] = datapath_id
-    Chef::Log.info("Generated datapath_id #{datapath_id} for ovsbridge #{bridge}")
-  end
-  node["network"]["ovs_datapath_ids"][bridge]
-end
-
 sorted_networks = Barclamp::Inventory.list_networks(node).sort do |a, b|
   net_weight(a) <=> net_weight(b)
 end
@@ -418,10 +407,6 @@ sorted_networks.each do |network|
       Chef::Log.info("Creating OVS bridge #{bridge} for network #{network.name}")
       Nic::OvsBridge.create(bridge)
     end
-
-    datapath_id = get_datapath_id_for_ovsbridge(bridge)
-    br.datapath_id = datapath_id unless br.datapath_id == datapath_id
-
     ifs[br.name] ||= Hash.new
     ifs[br.name]["addresses"] ||= Array.new
     ifs[our_iface.name]["slave"] = true
@@ -681,7 +666,6 @@ when "suse"
       end
 
       pre_up_script = "/etc/wicked/scripts/#{nic.name}-pre-up"
-      datapath_id = get_datapath_id_for_ovsbridge nic.name
       is_admin_nwk = if_mapping.key?("admin") && if_mapping["admin"].include?(nic.name)
 
       template pre_up_script do
@@ -691,7 +675,6 @@ when "suse"
         source "ovs-pre-up.sh.erb"
         variables(
           bridgename: nic.name,
-          datapath_id: datapath_id,
           is_admin_nwk: is_admin_nwk
         )
       end

--- a/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
+++ b/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
@@ -1,7 +1,6 @@
 #! /bin/bash
 
 ovs-vsctl br-exists <%= @bridgename %> || exit 0
-ovs-vsctl set Bridge <%= @bridgename %> other-config:datapath-id=<%= @datapath_id %>
 <%
   # remove the "secure" fail-mode for bridges that share an interface
   # with the "admin" network, otherwise the admin network will be offline


### PR DESCRIPTION
Neutron is now taking care of setting a unique datapath-id. So we don't
need this anymore. This was backported to Newton in

  -------------------------------------------------------------------
Tue May 28 19:07:45 UTC 2019 - Swaminathan Vasudevan <svasudevan@suse.com>

- Add 0001-Change-duplicate-OVS-bridge-datapath-ids.patch
  backport based on https://review.opendev.org/#/c/649192/3

https://review.opendev.org/#/c/587244/
(cherry picked from commit 8de91b09c92e52b77306bd7b0970a37eff4af037)