### PR TITLE
[5.0] upgrade: Reload repo config in repochecks (SOC-10718)

### DIFF
--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -242,6 +242,9 @@ module Api
           provisioner_service.enable_repository(platform, architecture, "ptf")
         end
 
+        # force-reload the repository configuration to refresh caches
+        ::Crowbar::Repository.load!
+
         {}.tap do |ret|
           ret[addon] = {
             "available" => true,


### PR DESCRIPTION
When /etc/crowbar/repos.yml was modified manually, nodes repochecks
sometimes returned old content which could be confusing.
Forcefully reloading the configs each time the repochecks are run
solves the problem.

(cherry picked from commit 69581b06d051659258aa3856c61d5811190290d5)

port of #1943 