### PR TITLE
[5.0] Ignore Cloud repository when checking for required ones

### DIFF
--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -257,9 +257,10 @@ module Api
                                                                    architecture)
                   ::Openstack::Upgrade.enable_repos_for_feature(feature, Rails.logger)
                 end
-                available, repolist = ::Crowbar::Repository.provided_and_enabled_with_repolist(
-                  feature, platform, architecture
-                )
+                available, repolist =
+                  ::Crowbar::Repository.provided_and_enabled_with_repolist_for_upgrade(
+                    feature, platform, architecture
+                  )
                 ret[addon]["available"] &&= available
                 ret[addon]["errors"].deep_merge!(repolist.deep_stringify_keys)
               end

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -209,7 +209,7 @@ describe Api::UpgradeController, type: :request do
       )
       ["os", "ceph", "ha", "openstack"].each do |feature|
         allow(::Crowbar::Repository).to(
-          receive(:provided_and_enabled_with_repolist).with(
+          receive(:provided_and_enabled_with_repolist_for_upgrade).with(
             feature, "suse-12.3", "x86_64"
           ).and_return([true, {}])
         )

--- a/crowbar_framework/spec/fixtures/node_repocheck_missing.json
+++ b/crowbar_framework/spec/fixtures/node_repocheck_missing.json
@@ -29,14 +29,12 @@
     "errors": {
       "missing": {
         "x86_64": [
-          "Cloud",
           "SUSE-OpenStack-Cloud-Crowbar-8-Pool",
           "SUSE-OpenStack-Cloud-Crowbar-8-Updates"
         ]
       },
       "inactive": {
         "x86_64": [
-          "Cloud",
           "SUSE-OpenStack-Cloud-Crowbar-8-Pool",
           "SUSE-OpenStack-Cloud-Crowbar-8-Updates"
         ]

--- a/crowbar_framework/spec/models/api/node_spec.rb
+++ b/crowbar_framework/spec/models/api/node_spec.rb
@@ -17,7 +17,7 @@ describe Api::Node do
   end
   let!(:os_repo_missing) do
     allow(::Crowbar::Repository).to(
-      receive(:provided_and_enabled_with_repolist).with(
+      receive(:provided_and_enabled_with_repolist_for_upgrade).with(
         "os", "suse-12.3", "x86_64"
       ).and_return(
         [
@@ -42,7 +42,7 @@ describe Api::Node do
   end
   let!(:openstack_repo_missing) do
     allow(::Crowbar::Repository).to(
-      receive(:provided_and_enabled_with_repolist).with(
+      receive(:provided_and_enabled_with_repolist_for_upgrade).with(
         "openstack", "suse-12.3", "x86_64"
       ).and_return(
         [
@@ -50,14 +50,12 @@ describe Api::Node do
           {
             "missing" => {
               "x86_64" => [
-                "Cloud",
                 "SUSE-OpenStack-Cloud-Crowbar-8-Pool",
                 "SUSE-OpenStack-Cloud-Crowbar-8-Updates"
               ]
             },
             "inactive" => {
               "x86_64" => [
-                "Cloud",
                 "SUSE-OpenStack-Cloud-Crowbar-8-Pool",
                 "SUSE-OpenStack-Cloud-Crowbar-8-Updates"
               ]
@@ -88,7 +86,7 @@ describe Api::Node do
   context "with a successful nodes repocheck" do
     it "finds the os repositories required to upgrade the nodes" do
       allow(::Crowbar::Repository).to(
-        receive(:provided_and_enabled_with_repolist).with(
+        receive(:provided_and_enabled_with_repolist_for_upgrade).with(
           "os", "suse-12.3", "x86_64"
         ).and_return([true, {}])
       )
@@ -107,7 +105,7 @@ describe Api::Node do
       allow_any_instance_of(ProvisionerService).to receive(:enable_repository).and_return(true)
       ["os", "ceph", "ha", "openstack"].each do |feature|
         allow(::Crowbar::Repository).to(
-          receive(:provided_and_enabled_with_repolist).with(
+          receive(:provided_and_enabled_with_repolist_for_upgrade).with(
             feature, "suse-12.3", "x86_64"
           ).and_return([true, {}])
         )
@@ -140,7 +138,7 @@ describe Api::Node do
   context "with an addon installed but not deployed" do
     it "finds any node with the ceph addon deployed" do
       allow(::Crowbar::Repository).to(
-        receive(:provided_and_enabled_with_repolist).with(
+        receive(:provided_and_enabled_with_repolist_for_upgrade).with(
           "ceph", "suse-12.3", "x86_64"
         ).and_return([true, {}])
       )

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -80,7 +80,7 @@ describe Api::Upgrade do
     )
     ["os", "ceph", "ha", "openstack"].each do |feature|
       allow(::Crowbar::Repository).to(
-        receive(:provided_and_enabled_with_repolist).with(
+        receive(:provided_and_enabled_with_repolist_for_upgrade).with(
           feature, "suse-12.3", "x86_64"
         ).and_return([true, {}])
       )


### PR DESCRIPTION
Cloud repo should not be necessary to have, so if user does not have it, upgrade checks should not complain.
