### PR TITLE
[5.0] upgrade: Add a precheck for XEN compute nodes presence (SOC-10495)

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -290,6 +290,9 @@ module Api
         if ::Node.find("roles:ceilometer-server").any? && ::Node.find("roles:monasca-server").none?
           ret[:legacy_ceilometer] = true
         end
+        # Make sure there are no xen compute nodes
+        xen_nodes = NodeObject.find("roles:nova-compute-xen")
+        ret[:xen_nodes_present] = xen_nodes.map(&:name) if xen_nodes.any?
         ret
       end
 

--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1910,6 +1910,12 @@ module Api
             help: I18n.t("api.upgrade.prechecks.legacy_ceilometer.help")
           }
         end
+        if check[:xen_nodes_present]
+          ret[:xen_nodes_present] = {
+            data: I18n.t("api.upgrade.prechecks.xen_nodes.error"),
+            help: I18n.t("api.upgrade.prechecks.xen_nodes.help")
+          }
+        end
         ret
       end
 

--- a/crowbar_framework/config/locales/crowbar/en.yml
+++ b/crowbar_framework/config/locales/crowbar/en.yml
@@ -850,6 +850,9 @@ en:
         legacy_ceilometer:
           error: 'Ceilometer proposal has been detected but Monasca proposal is missing. Only Ceilosca deployments are supported in SUSE OpenStack Cloud 9.'
           help: 'Deactivate and delete Ceilometer proposal and deploy Ceilosca after upgrade is completed.'
+        xen_nodes:
+          error: 'XEN compute nodes were found: %{nodes}.'
+          help: 'SUSE OpenStack Cloud 9 does not support XEN compute nodes. Stop all workloads running on these nodes and remove nova-compute-xen role from all nodes before proceeding with the upgrade.'
       prepare:
         help:
           default: 'Refer to the error message in the response'

--- a/crowbar_framework/spec/models/api/crowbar_spec.rb
+++ b/crowbar_framework/spec/models/api/crowbar_spec.rb
@@ -393,6 +393,7 @@ describe Api::Crowbar do
       allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:ceilometer-server").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
           ["nova-compute-kvm", "cinder-volume", "swift-storage"]
@@ -407,6 +408,7 @@ describe Api::Crowbar do
       allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:ceilometer-server").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
           ["nova-compute-kvm", "pacemaker-remote"]
@@ -421,6 +423,7 @@ describe Api::Crowbar do
       allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:ceilometer-server").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
           ["nova-compute-kvm", "cinder-controller", "nova-controller"]
@@ -436,6 +439,7 @@ describe Api::Crowbar do
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:ceilometer-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:monasca-server").and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
           ["nova-compute-kvm", "cinder-volume", "swift-storage"]
@@ -452,6 +456,7 @@ describe Api::Crowbar do
       allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:ceilometer-server").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
           ["nova-compute-kvm", "cinder-controller"]
@@ -476,6 +481,7 @@ describe Api::Crowbar do
       allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([drbd_node]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:ceilometer-server").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
           ["nova-compute-kvm", "cinder-volume", "swift-storage"]
@@ -492,6 +498,7 @@ describe Api::Crowbar do
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:ceilometer-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:monasca-server").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
       allow_any_instance_of(NodeObject).to(
         receive(:roles).and_return(
           ["nova-compute-kvm", "cinder-volume", "swift-storage"]
@@ -507,6 +514,7 @@ describe Api::Crowbar do
       allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:ceilometer-server").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
 
       allow(Proposal).to(receive(:where).and_return([]))
       dummy_proposal = true # only any? check is used, no need for real Proposal object
@@ -524,6 +532,7 @@ describe Api::Crowbar do
       allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
       allow(NodeObject).to(receive(:find).with("roles:ceilometer-server").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([]))
 
       allow(Proposal).to(receive(:where).and_return([]))
       dummy_proposal = true # only any? check is used, no need for real Proposal object
@@ -535,6 +544,16 @@ describe Api::Crowbar do
 
       expect(subject.class.deployment_check).to eq(
         trove_proposal: true
+      )
+    end
+    it "fails when xen compute nodes are found" do
+      allow(NodeObject).to(receive(:find).with("roles:database-server").and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-*").and_return([node]))
+      allow(NodeObject).to(receive(:find).with("roles:ceilometer-server").and_return([]))
+      allow(NodeObject).to(receive(:find).with("roles:nova-compute-xen").and_return([node]))
+
+      expect(subject.class.deployment_check).to eq(
+        xen_nodes_present: ["testing.crowbar.com"]
       )
     end
 


### PR DESCRIPTION
XEN compute nodes are no longer supported in SOC9 so they need
to be removed before the upgrade from SOC8 to SOC9 starts.