### PR TITLE
upgrade: cold start nova before live migration (SOC-10761)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -92,19 +92,19 @@ zypper --non-interactive up openstack-nova-compute
 
 log "Restarting services for Rocky"
 
-<% unless @remote_node %>
+<% unless @is_remote_node %>
 systemctl restart <%= @neutron_agent %>
 <% end %>
 
-<% if @l3_agent && !@remote_node %>
+<% if @l3_agent && !@is_remote_node %>
 systemctl restart <%= @l3_agent %>
 <% end %>
 
-<% if @metadata_agent && !@remote_node%>
+<% if @metadata_agent && !@is_remote_node%>
 systemctl restart <%= @metadata_agent %>
 <% end %>
 
-<% if @remote_node %>
+<% if @is_remote_node %>
 log "Leving nova-compute service to be restarted by cluster resources"
 <% else %>
 log "Starting nova-compute service"

--- a/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-reload-nova-after-upgrade.sh.erb
@@ -27,21 +27,43 @@ if [[ -f $UPGRADEDIR/crowbar-reload-nova-after-upgrade-ok ]] ; then
     exit 0
 fi
 
+# Check the python-nova package to make sure it is at the latest version with
+# no more recent versions in any zypper repositories (this package can be used
+# as a proxy for making sure all Nova service packages are up to date since
+# they are version locked to python-nova):
+
+if zypper lu -a | grep -w python-nova; then
+  echo "There are available update candidates for python-nova. This means that "
+  echo "the nova service packages on this node are not at the latest possible "
+  echo "version. Please update them and restart the upgrade."
+
+  exit 1
+fi
+
 <% if @nova_controller %>
 for service in conductor scheduler novncproxy serialproxy api; do
     fullname="openstack-nova-$service"
-    if systemctl --quiet is-active $fullname 2>/dev/null ; then
-        systemctl restart $fullname
+    if systemctl cat $fullname &>/dev/null; then
+      systemctl start $fullname
     fi
 done
-# Remove and unmanage openstack-nova-consoleauth
-systemctl disable openstack-nova-consoleauth
-systemctl stop openstack-nova-consoleauth
-systemctl kill openstack-nova-consoleauth
-rpm -e openstack-nova-consoleauth
+
+# Apache was also stopped by crowbar-stop-nova-services.sh
+systemctl start apache2
+
+  <% if @remotes_present and @is_cluster_founder %>
+# Start nova-compute on remote nodes:
+for remote in $(crm resource list | awk '$1 ~ /^remote-/  {print $1}'); do
+  crm resource start $remote
+done
+  <% end %>
 
 <% else %>
-systemctl restart openstack-nova-compute
+  # Only start on non-remote compute nodes - service on remote nodes will be started by
+  # the controller side code above.
+  <% unless @is_remote_node %>
+systemctl start openstack-nova-compute
+  <% end %>
 <% end %>
 
 touch $UPGRADEDIR/crowbar-reload-nova-after-upgrade-ok

--- a/chef/cookbooks/crowbar/templates/default/crowbar-stop-nova-services.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-stop-nova-services.sh.erb
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# After the upgrade of all compute services on all nodes is finished, it's
+# necessary to stop all nova services so that they start using the latest RPC
+# API version. All services must be stopped without exception: if any service
+# still uses the old RPC API version, it may cause other services to pick that
+# RPC API version as well.
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+SCRIPTNAME=stop-nova-services
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+if [[ -f $UPGRADEDIR/crowbar-${SCRIPTNAME}-ok ]] ; then
+    log "Stop nova script was already successfully executed"
+    exit 0
+fi
+
+<% if @nova_controller %>
+for service in conductor scheduler novncproxy serialproxy api; do
+    fullname="openstack-nova-$service"
+    if systemctl --quiet is-active $fullname 2>/dev/null ; then
+        systemctl stop $fullname
+    fi
+done
+
+# This is needed to prevent the Nova Placement API from causing RPC version
+# trouble.
+if systemctl --quiet is-active apache2 2>/dev/null ; then
+    systemctl stop apache2
+fi
+
+  <% if @remotes_present and @is_cluster_founder %>
+# Stop nova-compute on remote nodes:
+for remote in $(crm resource list | awk '$1 ~ /^remote-/  {print $1}'); do
+  crm resource stop $remote
+done
+  <% end %>
+
+# Remove and unmanage openstack-nova-consoleauth
+systemctl disable openstack-nova-consoleauth
+systemctl stop openstack-nova-consoleauth
+systemctl kill openstack-nova-consoleauth
+rpm -e openstack-nova-consoleauth
+
+<% else %>
+  <% unless @is_remote_node %>
+# Only stop on non-remote compute nodes - service on remote nodes will be stopped by
+# the controller side code above.
+systemctl stop openstack-nova-compute
+  <% end %>
+<% end %>
+
+# This check can run on both remote and non-remote nodes: the `crm resource
+# stop` for the remote resources will have been run before this script runs on
+# the compute node it was intended for. This check needs to fail on the compute
+# node itself if it is going to fail. That way it will pinpoint the problematic
+# node.
+
+for wait in 10 20 40 0; do
+  if ps -U nova u | grep -e apache -e python; then
+    echo "Warning: there are still Nova processes running. These processes must be stopped before continuing the upgrade."
+    if [ $wait -eq 0 ]; then
+      echo "Error: Waited for 70s and Nova processes are still active."
+      echo "Please stop these processes manually and restart the upgrade's nodes step."
+      exit 1
+    fi
+    echo "Sleeping for $wait seconds until rechecking."
+    sleep $wait
+  else
+    break
+  fi
+done
+
+touch $UPGRADEDIR/crowbar-${SCRIPTNAME}-ok
+log "$BASH_SOURCE is finished."

--- a/configs/upgrade_timeouts.yml
+++ b/configs/upgrade_timeouts.yml
@@ -15,3 +15,4 @@
 :wait_until_compute_started: 60
 :reload_nova_services: 120
 :online_migrations: 1800
+:stop_nova_services: 120

--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -38,6 +38,7 @@ module Crowbar
         delete_nova_services: @timeouts_config[:delete_nova_services] || 300,
         wait_until_compute_started: @timeouts_config[:wait_until_compute_started] || 60,
         reload_nova_services: @timeouts_config[:reload_nova_services] || 120,
+        stop_nova_services: @timeouts_config[:stop_nova_services] || 120,
         online_migrations: @timeouts_config[:online_migrations] || 1800
       }
     end


### PR DESCRIPTION
In order to prevent any and all RPC API incompatibilities
through lingering nova-compute processes, this commit stops
all Nova services (both on controllers and compute nodes)
after the early nova-compute update performed at the end of
the controller upgrade. Subsequently, these services are
restarted in a staggered manner to keep them from DDoSing
RabbitMQ on larger clouds. This ensures all Nova services use
the new Nova RPC API (5.0), thus allowing the live migrations
that are part of non-disruptively upgrading the compute nodes,
to take place.