### PR TITLE
[4.0] Allow pacemaker remotes for upgrade (SOC-10133)

### DIFF
--- a/crowbar_framework/app/models/api/crowbar.rb
+++ b/crowbar_framework/app/models/api/crowbar.rb
@@ -100,7 +100,8 @@ module Api
         # Not using Node.all here as we only need node names
         nodes = ChefObject.fetch_nodes_from_cdb.first.map(&:name)
         clusters = ServiceObject.available_clusters.keys
-        valid_elements = nodes + clusters
+        remotes = ServiceObject.available_remotes.keys
+        valid_elements = nodes + clusters + remotes
         bad_proposals = proposals.reject { |p| (p.elements.values.flatten - valid_elements).empty? }
         bad_elements = (proposals.map { |p| p.elements.values }.flatten - valid_elements).uniq
         ret[:unrecognized_elements] = {


### PR DESCRIPTION
This commit allows clouds with Pacemaker remote nodes to be
upgraded. To this end it changes the upgrade precheck to
include remote nodes in the list of valid elements.

Please do not merge this, yet. We can only merge it once all other changes required for SOC-10133 have landed and we have verified the upgrade works.