### PR TITLE
[4.0] Ignore CVE-2017-1002201 in CI builds (bsc#1155089)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
        - bundle exec rake spec brakeman:run
        # ignore rest-client issues, chef 10 requires that
        - bin/bundle exec bundle-audit update
-       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477
+       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201
     - name: "Validate Cookbooks (RSpec)"
       gemfile: chef/cookbooks/barclamp/Gemfile
       script:


### PR DESCRIPTION
Relevant package (rubygem-haml) is going to be fixed to address the
security issue and this occurence can be ignored is at is only affecting
internal CI.

(cherry picked from commit 825f6d14c9cc77f1314d376f199a1f754dfbd2c0)

Port of https://github.com/crowbar/crowbar-core/pull/1947