### PR TITLE
Add port 443 to listen_ports in apache2 (SOC-9172)

### DIFF
--- a/chef/cookbooks/apache2/recipes/mod_ssl.rb
+++ b/chef/cookbooks/apache2/recipes/mod_ssl.rb
@@ -40,7 +40,8 @@ unless node[:apache][:listen_ports].include?("443")
   # override the resource defined in default.rb; we don't want to create the
   # resource again, otherwise we will write the file twice
   resource = resources(template: "#{node[:apache][:dir]}/ports.conf")
-  resource.variables({apache_listen_ports: [node[:apache][:listen_ports], "443"].flatten})
+  node[:apache][:listen_ports] << "443"
+  resource.variables({ apache_listen_ports: node[:apache][:listen_ports] })
 end
 
 apache_module "ssl" do


### PR DESCRIPTION
This commit stops port clashes between horizon and haproxy on HA
deployments with SSL enabled.

Without this patch, the apache ssl recipe adds port 443 to the apache
listen.conf file without adding the port to the listen_ports array.
In a HA setup with ssl enabled, both HAProxy and Apache will
try to use port 443. To work around this, the horizon ssl recipe currently
checks to see what ports are listed in a listen_ports array, and
if either port 443 or port 80 is in there, it wipes the listen.conf
file. As port 443 is not currently in the listen_ports array, the
horizon recipe leaves the listen.conf file alone in cases where
port 443 is in there.

This commit adds port 443 to the listen_ports array at the point
where it is added as a listen port, so that the horizon recipe can
find it later.

More explanation in:
https://bugzilla.suse.com/show_bug.cgi?id=1141490#c34