### PR TITLE
[5.0] Call finalize_nodes_upgrade at the very end (bsc#1155942)

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -824,8 +824,8 @@ module Api
           run_online_migrations
           status.save_substep(:run_online_migrations, :finished)
 
-          finalize_nodes_upgrade
           unlock_crowbar_ui_package
+          finalize_nodes_upgrade
           status.end_step
         end
       rescue ::Crowbar::Error::Upgrade::NodeError => e
@@ -1031,7 +1031,13 @@ module Api
           "post-upgrade",
           "chef-upgraded",
           "reload-nova-after-upgrade",
-          "run-nova-online-migrations"
+          "delete-unknown-nova-services",
+          "heat-migrations-after-upgrade",
+          "migrate-keystone-and-start",
+          "nova-migrations-after-upgrade",
+          "set-network-agents-state",
+          "shutdown-keystone",
+          "shutdown-remaining-services"
         ].map { |f| "/usr/sbin/crowbar-#{f}.sh" }.join(" ")
         scripts_to_delete << " /etc/neutron/lbaas-connection.conf"
         node.run_ssh_cmd("rm -f #{scripts_to_delete}")


### PR DESCRIPTION
There should be no other upgrade related call after finalize, because
finalize deletes all the upgrade scripts and failure in the next step
would try to re-run (now non-existing) scripts.

Also, update the list of scripts that should be deleted.

(cherry picked from commit 7defe527e94a82e4aed68988ffb6edc47deb0ff8)

Backport of https://github.com/crowbar/crowbar-core/pull/1952