### PR TITLE
upgrade: Ignore Cloud repository during repocheck (bsc#1152007)

### DIFF
--- a/crowbar_framework/app/models/api/node.rb
+++ b/crowbar_framework/app/models/api/node.rb
@@ -260,9 +260,10 @@ module Api
                                                                    architecture)
                   ::Openstack::Upgrade.enable_repos_for_feature(feature, Rails.logger)
                 end
-                available, repolist = ::Crowbar::Repository.provided_and_enabled_with_repolist(
-                  feature, platform, architecture
-                )
+                available, repolist =
+                  ::Crowbar::Repository.provided_and_enabled_with_repolist_for_upgrade(
+                    feature, platform, architecture
+                  )
                 ret[addon]["available"] &&= available
                 ret[addon]["errors"].deep_merge!(repolist.deep_stringify_keys)
               end

--- a/crowbar_framework/lib/crowbar/repository.rb
+++ b/crowbar_framework/lib/crowbar/repository.rb
@@ -133,6 +133,12 @@ module Crowbar
         provided_with_enabled(feature, platform, arch, true)
       end
 
+      # For upgrade related checks we need that Cloud repo is not needed
+      # so we explicitly exclude it from the list. See also comment in feature_repository_map
+      def provided_and_enabled_with_repolist_for_upgrade(feature, platform = nil, arch = nil)
+        provided_with_enabled(feature, platform, arch, true, true)
+      end
+
       def provided?(feature, platform = nil, arch = nil)
         provided_with_enabled(feature, platform, arch, false).first
       end
@@ -205,19 +211,20 @@ module Crowbar
                                 platform = nil,
                                 arch = nil,
                                 check_enabled = true,
+                                ignore_cloud = false,
                                 repos = {})
         answer = false
 
         if platform.nil?
           all_platforms.each do |p|
-            if provided_with_enabled(feature, p, arch, check_enabled, repos).first
+            if provided_with_enabled(feature, p, arch, check_enabled, ignore_cloud, repos).first
               answer = true
               break
             end
           end
         elsif arch.nil?
           arches(platform).each do |a|
-            if provided_with_enabled(feature, platform, a, check_enabled, repos).first
+            if provided_with_enabled(feature, platform, a, check_enabled, ignore_cloud, repos).first
               answer = true
               break
             end
@@ -233,6 +240,9 @@ module Crowbar
             found = true
 
             r = new(platform, arch, repo)
+
+            # ignore Cloud repo for upgrade related checks
+            next if ignore_cloud && r.name == "Cloud"
 
             answer &&= r.available?
             unless r.available?

--- a/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
+++ b/crowbar_framework/spec/controllers/api/upgrade_controller_spec.rb
@@ -217,7 +217,7 @@ describe Api::UpgradeController, type: :request do
       )
       ["os", "ceph", "ha", "openstack"].each do |feature|
         allow(::Crowbar::Repository).to(
-          receive(:provided_and_enabled_with_repolist).with(
+          receive(:provided_and_enabled_with_repolist_for_upgrade).with(
             feature, "suse-12.4", "x86_64"
           ).and_return([true, {}])
         )

--- a/crowbar_framework/spec/fixtures/node_repocheck_missing.json
+++ b/crowbar_framework/spec/fixtures/node_repocheck_missing.json
@@ -29,14 +29,12 @@
     "errors": {
       "missing": {
         "x86_64": [
-          "Cloud",
           "SUSE-OpenStack-Cloud-Crowbar-9-Pool",
           "SUSE-OpenStack-Cloud-Crowbar-9-Updates"
         ]
       },
       "inactive": {
         "x86_64": [
-          "Cloud",
           "SUSE-OpenStack-Cloud-Crowbar-9-Pool",
           "SUSE-OpenStack-Cloud-Crowbar-9-Updates"
         ]

--- a/crowbar_framework/spec/models/api/node_spec.rb
+++ b/crowbar_framework/spec/models/api/node_spec.rb
@@ -17,7 +17,7 @@ describe Api::Node do
   end
   let!(:os_repo_missing) do
     allow(::Crowbar::Repository).to(
-      receive(:provided_and_enabled_with_repolist).with(
+      receive(:provided_and_enabled_with_repolist_for_upgrade).with(
         "os", "suse-12.4", "x86_64"
       ).and_return(
         [
@@ -42,7 +42,7 @@ describe Api::Node do
   end
   let!(:openstack_repo_missing) do
     allow(::Crowbar::Repository).to(
-      receive(:provided_and_enabled_with_repolist).with(
+      receive(:provided_and_enabled_with_repolist_for_upgrade).with(
         "openstack", "suse-12.4", "x86_64"
       ).and_return(
         [
@@ -50,14 +50,12 @@ describe Api::Node do
           {
             "missing" => {
               "x86_64" => [
-                "Cloud",
                 "SUSE-OpenStack-Cloud-Crowbar-9-Pool",
                 "SUSE-OpenStack-Cloud-Crowbar-9-Updates"
               ]
             },
             "inactive" => {
               "x86_64" => [
-                "Cloud",
                 "SUSE-OpenStack-Cloud-Crowbar-9-Pool",
                 "SUSE-OpenStack-Cloud-Crowbar-9-Updates"
               ]
@@ -88,7 +86,7 @@ describe Api::Node do
   context "with a successful nodes repocheck" do
     it "finds the os repositories required to upgrade the nodes" do
       allow(::Crowbar::Repository).to(
-        receive(:provided_and_enabled_with_repolist).with(
+        receive(:provided_and_enabled_with_repolist_for_upgrade).with(
           "os", "suse-12.4", "x86_64"
         ).and_return([true, {}])
       )
@@ -107,7 +105,7 @@ describe Api::Node do
       allow_any_instance_of(ProvisionerService).to receive(:enable_repository).and_return(true)
       ["os", "ceph", "ha", "openstack"].each do |feature|
         allow(::Crowbar::Repository).to(
-          receive(:provided_and_enabled_with_repolist).with(
+          receive(:provided_and_enabled_with_repolist_for_upgrade).with(
             feature, "suse-12.4", "x86_64"
           ).and_return([true, {}])
         )
@@ -140,7 +138,7 @@ describe Api::Node do
   context "with an addon installed but not deployed" do
     it "finds any node with the ceph addon deployed" do
       allow(::Crowbar::Repository).to(
-        receive(:provided_and_enabled_with_repolist).with(
+        receive(:provided_and_enabled_with_repolist_for_upgrade).with(
           "ceph", "suse-12.4", "x86_64"
         ).and_return([true, {}])
       )

--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -80,7 +80,7 @@ describe Api::Upgrade do
     )
     ["os", "ceph", "ha", "openstack"].each do |feature|
       allow(::Crowbar::Repository).to(
-        receive(:provided_and_enabled_with_repolist).with(
+        receive(:provided_and_enabled_with_repolist_for_upgrade).with(
           feature, "suse-12.4", "x86_64"
         ).and_return([true, {}])
       )


### PR DESCRIPTION
Cloud repository is only needed for initial deployment and
not during the upgrade.
Exclude this repository explicitely during the check for availability.
It might not be the cleanest solution, but is consistent with
feature_repository_map method in repository library.

(cherry picked from commit 4e9eba8dcdcecf06f7296ed2a66d170a9fdc9c2a)

Port of https://github.com/crowbar/crowbar-core/pull/1945