### PR TITLE
[5.0] upgrade: Make sure cinder-volume is really stopped (bsc#1156305)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -70,6 +70,15 @@ for i in $(systemctl list-units openstack-* --no-legend | cut -d" " -f1 | grep -
 done
 <% end %>
 
+# It is possible that despite general HA setup, cinder-volume is running on controllers,
+# is not managed by pacemaker while clone_stateless_services is still true.
+# Stop such service now
+if systemctl --quiet is-active openstack-cinder-volume; then
+    log "Stopping cinder-volume service"
+    systemctl stop openstack-cinder-volume
+    systemctl disable openstack-cinder-volume
+fi
+
 <% else %>
 
 # Stop openstack services on this node.


### PR DESCRIPTION
It is possible that despite general HA setup, cinder-volume is
running on controllers, is not managed by pacemaker while
clone_stateless_services is still true.
In such scenario we missed this service when trying to stop all of them.