### PR TITLE
Allow enabling bpdu-forwarding on OVS bridges (SOC-9172)

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -92,6 +92,7 @@ module BarclampLibrary
         attr_reader :vlan, :use_vlan
         attr_reader :add_bridge, :add_ovs_bridge, :bridge_name
         attr_reader :conduit
+        attr_reader :ovs_forward_bpdu
 
         def initialize(node, net, data)
           @node = node
@@ -109,6 +110,7 @@ module BarclampLibrary
           @add_bridge = data["add_bridge"]
           @add_ovs_bridge = data["add_ovs_bridge"]
           @bridge_name = data["bridge_name"]
+          @ovs_forward_bpdu = data["ovs_forward_bpdu"]
           # let's resolve this only if needed
           @interface = nil
           @interface_list = nil

--- a/chef/cookbooks/barclamp/libraries/nic.rb
+++ b/chef/cookbooks/barclamp/libraries/nic.rb
@@ -843,6 +843,10 @@ class ::Nic
       ::Kernel.system("ovs-vsctl add-port #{@nic} #{slave}")
     end
 
+    def ovs_forward_bpdu(forward)
+      ::Kernel.system("ovs-vsctl set Bridge #{@nic} other_config:forward-bpdu=#{forward}")
+    end
+
     def self.create(nic, slaves = [])
       Chef::Log.info("Creating new OVS bridge #{nic}")
       if self.exists?(nic)

--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -439,6 +439,12 @@ sorted_networks.each do |network|
     our_iface = br
     net_ifs << our_iface.name
   end
+
+  unless network.ovs_forward_bpdu.nil?
+    Chef::Log.info("OVS BPDU forwarding set to #{network.ovs_forward_bpdu}.")
+    ifs[our_iface.name]["ovs_forward_bpdu"] = network.ovs_forward_bpdu
+  end
+
   if network.mtu
     Chef::Log.info("Using mtu #{network.mtu} for #{network.name} network on #{our_iface.name}")
     ifs[our_iface.name]["mtu"] = network.mtu
@@ -666,7 +672,10 @@ when "suse"
       end
 
       pre_up_script = "/etc/wicked/scripts/#{nic.name}-pre-up"
+      ovs_forward_bpdu = ifs[nic.name]["ovs_forward_bpdu"] || false
       is_admin_nwk = if_mapping.key?("admin") && if_mapping["admin"].include?(nic.name)
+
+      nic.ovs_forward_bpdu(ovs_forward_bpdu)
 
       template pre_up_script do
         owner "root"
@@ -675,6 +684,7 @@ when "suse"
         source "ovs-pre-up.sh.erb"
         variables(
           bridgename: nic.name,
+          ovs_forward_bpdu: ovs_forward_bpdu,
           is_admin_nwk: is_admin_nwk
         )
       end

--- a/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
+++ b/chef/cookbooks/network/templates/default/ovs-pre-up.sh.erb
@@ -1,6 +1,7 @@
 #! /bin/bash
 
 ovs-vsctl br-exists <%= @bridgename %> || exit 0
+ovs-vsctl set bridge <%= @bridgename %> other-config:forward-bpdu=<%= @ovs_forward_bpdu %>
 <%
   # remove the "secure" fail-mode for bridges that share an interface
   # with the "admin" network, otherwise the admin network will be offline

--- a/chef/data_bags/crowbar/template-network.schema
+++ b/chef/data_bags/crowbar/template-network.schema
@@ -88,6 +88,7 @@
                     "add_bridge": { "type": "bool", "required": true },
                     "add_ovs_bridge": { "type": "bool", "required": false },
                     "bridge_name": { "type": "str", "required": false },
+                    "ovs_forward_bpdu": { "type": "bool", "required": false },
                     "subnet": { "type": "str", "required": true, "name": "IpAddress" },
                     "netmask": { "type": "str", "required": true, "name": "IpAddress" },
                     "broadcast": { "type": "str", "required": true, "name": "IpAddress" },


### PR DESCRIPTION
This change allows users to enable BPDU forwarding on OVS bridges
that are used for Neutron provider networks (br-fixed, br-floating).
Enabling it will allow the physical network to detect and stop loops
if these bridges are accidentally misconfigured. It is turned off
by default.

More context in:

  https://bugzilla.suse.com/show_bug.cgi?id=1133804

(backported from: 273312c0c8be73d050bec2ed912958c74c7652b7 )