### PR TITLE
Explicitely remove and later install openstack-dashboard-theme-SUSE

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
@@ -76,6 +76,14 @@ initiate_node_upgrade()
       sed -i s/django.utils.log.NullHandler/logging.NullHandler/g $horizon_custom_config
     fi
 
+    update_dashboard_theme_SUSE=0
+    if rpm -q openstack-dashboard-theme-SUSE; then
+      # Uninstall openstack-dashboard-theme-SUSE so that its postun script is called
+      # and post script of the new package does not complain about non existing files
+      zypper --no-color --non-interactive rm openstack-dashboard-theme-SUSE
+      update_dashboard_theme_SUSE=1
+    fi
+
     # Upgrade the distribution non-interactively
     log "Executing zypper ref"
     zypper --no-color --releasever <%= @target_platform_version %> ref -f
@@ -87,6 +95,11 @@ initiate_node_upgrade()
         log "zypper dist-upgrade has failed with $ret, check zypper logs"
         echo "$ret" > $UPGRADEDIR/crowbar-upgrade-os-failed
         exit $ret
+    fi
+
+    if [ $update_dashboard_theme_SUSE == 1 ]; then
+        # Install the package that could not be updated because it was explicitly removed
+        zypper --no-color --non-interactive install openstack-dashboard-theme-SUSE
     fi
 
     # move the openstack configurations after the upgrade. We want the default


### PR DESCRIPTION
When simply upgrading the package, post script (or rather
/srv/www/openstack-dashboard/manage.py that is executed from post script)
complains that it cannot find old documentation symlinks that were
created for SOC7 version of the package.

This is the problem that we see when we just upgrade the theme package from SP2 to SP3:

```
(694/707) Installing: openstack-dashboard-theme-SUSE-2017.2-5.5.noarch [..................done]
Additional rpm output:
Traceback (most recent call last):
  File "/srv/www/openstack-dashboard/manage.py", line 23, in <module>
    execute_from_command_line(sys.argv)
  File "/usr/lib/python2.7/site-packages/django/core/management/__init__.py", line 364, in execute_from_command_line
    utility.execute()
  File "/usr/lib/python2.7/site-packages/django/core/management/__init__.py", line 356, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/lib/python2.7/site-packages/django/core/management/base.py", line 283, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/usr/lib/python2.7/site-packages/django/core/management/base.py", line 330, in execute
    output = self.handle(*args, **options)
  File "/usr/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 199, in handle
    collected = self.collect()
  File "/usr/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 124, in collect
    handler(path, prefixed_path, storage)
  File "/usr/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 363, in copy_file
    with source_storage.open(path) as source_file:
  File "/usr/lib/python2.7/site-packages/django/core/files/storage.py", line 38, in open
    return self._open(name, mode)
  File "/usr/lib/python2.7/site-packages/django/core/files/storage.py", line 300, in _open
    return File(open(self.path(name), mode))
IOError: [Errno 2] No such file or directory: u'/srv/www/openstack-dashboard/openstack_dashboard/dashboards/help/static/help/suse-openstack-cloud-admin_en.pdf'
```

Here django complains about non-existing links to pdf's - these links were created in SP2 (SOC7) version of the package, but the paths to pdf's have changed in SP3 (SOC8).
So I have no idea how to fix it on the package level, looking at the spec files, I do not think they are doing anything wrong.