### PR TITLE
[5.0] upgrade: Make the time before next upgrade configurable

### DIFF
--- a/configs/upgrade_timeouts.yml
+++ b/configs/upgrade_timeouts.yml
@@ -15,3 +15,4 @@
 :wait_until_compute_started: 60
 :reload_nova_services: 120
 :online_migrations: 1800
+:delay_before_next_upgrade: 86400

--- a/crowbar_framework/lib/crowbar/upgrade_status.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_status.rb
@@ -30,6 +30,7 @@ module Crowbar
     # We're keeping the information in the file so is accessible by
     # external applications and different crowbar versions.
     def initialize(logger = Rails.logger, yaml_file = nil)
+      @timeouts = ::Crowbar::UpgradeTimeouts.new
       yaml_file = current_status_file if yaml_file.nil? || yaml_file.empty?
 
       @running_file_location =
@@ -427,7 +428,7 @@ module Crowbar
         finish_time = File.mtime(finished_file).to_i
       end
       # here "recently" means within last 24hrs
-      (Time.now.to_i - finish_time) < 24 * 60 * 60
+      (Time.now.to_i - finish_time) < @timeouts.values[:delay_before_next_upgrade]
     end
 
     def current_status_file

--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -38,7 +38,8 @@ module Crowbar
         delete_nova_services: @timeouts_config[:delete_nova_services] || 300,
         wait_until_compute_started: @timeouts_config[:wait_until_compute_started] || 60,
         reload_nova_services: @timeouts_config[:reload_nova_services] || 120,
-        online_migrations: @timeouts_config[:online_migrations] || 1800
+        online_migrations: @timeouts_config[:online_migrations] || 1800,
+        delay_before_next_upgrade: @timeouts_config[:delay_before_next_upgrade] || 86400 #= 24*60*60
       }
     end
   end


### PR DESCRIPTION
crowbar upgrade tool returns the information about the finished
upgrade for some time even after everything has been done.
For the cases where user would like to continue with the upgrade
to the next product version ASAP, we can make the required time
configurable.