### PR TITLE
[5.0] Remove existing upgrade directories from nodes (SOC-10956)

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -92,6 +92,14 @@ when "crowbar_upgrade"
     end
   end
 
+  # Remove existing upgrade directory. If it exists, it would contain
+  # indications of upgrade scripts runs from previous upgrade.
+  # If they'd stay, script wouldn't be executed in current upgrade
+  directory "/var/lib/crowbar/upgrade" do
+    action :delete
+    recursive true
+  end
+
 when "prepare-os-upgrade"
 
   include_recipe "crowbar::prepare-upgrade-scripts"


### PR DESCRIPTION
If such dir exists, it would contain indications of upgrade scripts' runs
from previous upgrade.
If they'd stay, script wouldn't be executed in current upgrade.