### PR TITLE
upgrade: Make sure cinder-volume is really stopped (bsc#1156305)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -105,6 +105,15 @@ for i in $(systemctl list-units openstack-* --no-legend | cut -d" " -f1 | grep -
     systemctl disable $i
 done
 
+# It is possible that despite general HA setup, cinder-volume is running on controllers,
+# is not managed by pacemaker while clone_stateless_services is still true.
+# Stop such service now
+if systemctl --quiet is-active openstack-cinder-volume; then
+    log "Stopping cinder-volume service"
+    systemctl stop openstack-cinder-volume
+    systemctl disable openstack-cinder-volume
+fi
+
 <% else %>
 
 # Stop openstack services on this node.


### PR DESCRIPTION
It is possible that despite general HA setup, cinder-volume is
running on controllers, is not managed by pacemaker while
clone_stateless_services is still true.
In such scenario we missed this service when trying to stop all of them.

(cherry picked from commit bbdbf90d209545dc8bf1fff405e9a184f2c1b351)

Port of https://github.com/crowbar/crowbar-core/pull/1957