### PR TITLE
[5.0] Disable automatic repo services and installation repo (bsc#1152007)

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -30,23 +30,9 @@ new_repos = Provisioner::Repositories.get_repos(
   target_platform, target_platform_version, arch
 )
 
-# Find out the location of the base system repository
 provisioner_config = Barclamp::Config.load("core", "provisioner")
 
-web_path = "#{provisioner_config['root_url']}/#{node[:platform]}-#{node[:platform_version]}/#{arch}"
-old_install_url = "#{web_path}/install"
-
 web_path = "#{provisioner_config['root_url']}/#{node[:target_platform]}/#{arch}"
-new_install_url = "#{web_path}/install"
-
-# try to create an alias for new base repo from the original base repo
-repo_alias = "SLES12-SP2-12.2-0"
-doc = REXML::Document.new(`zypper --xmlout lr --details`)
-doc.elements.each("stream/repo-list/repo") do |repo|
-  repo_alias = repo.attributes["alias"] if repo.elements["url"].text == old_install_url
-end
-
-new_alias = repo_alias.gsub("SP2", "SP3").gsub(node[:platform_version], target_platform_version)
 
 template "/usr/sbin/crowbar-prepare-repositories.sh" do
   source "crowbar-prepare-repositories.sh.erb"
@@ -55,9 +41,7 @@ template "/usr/sbin/crowbar-prepare-repositories.sh" do
   group "root"
   action :create
   variables(
-    new_repos: new_repos,
-    new_base_repo: new_install_url,
-    new_alias: new_alias
+    new_repos: new_repos
   )
 end
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-prepare-repositories.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-prepare-repositories.sh.erb
@@ -25,6 +25,9 @@ if [[ -f $UPGRADEDIR/crowbar-prepare-repositories-ok ]] ; then
     exit 0
 fi
 
+log "Disabling Repository Index Services (RIS)..."
+zypper services --show-enabled-only | tr -d ' ' | awk -F "|" '{ if ($7=="ris") print $1}' | xargs -i zypper modifyservice --disable {}
+
 
 log "Removing old repositories..."
 rm -f /etc/zypp/repos.d/*.repo

--- a/chef/cookbooks/crowbar/templates/default/crowbar-prepare-repositories.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-prepare-repositories.sh.erb
@@ -40,7 +40,6 @@ zypper --non-interactive addrepo -f <%= attrs[:url] %> <%= name %>
 zypper --non-interactive addrepo <%= attrs[:url] %> <%= name %>
     <% end -%>
 <% end %>
-zypper --non-interactive addrepo <%= @new_base_repo %> <%= @new_alias %>
 
 touch $UPGRADEDIR/crowbar-prepare-repositories-ok
 log "$BASH_SOURCE is finished."


### PR DESCRIPTION
When nodes are installed from SMT, they can have some automatic repo
services configured. These conflict with crowbar repo management and
should be disabled during upgrade (or earlier).

In addition this change disables configuration of install media repo
as it is not needed for upgraded nodes (just for new ones).