### PR TITLE
[5.0] upgrade: Remove DRBD specific code from the upgrade

### DIFF
--- a/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
+++ b/chef/cookbooks/crowbar/recipes/crowbar-upgrade.rb
@@ -60,11 +60,6 @@ when "crowbar_upgrade"
 
   ha = node["run_list_map"].key? "pacemaker-cluster-member"
 
-  service "drbd" do
-    action :disable
-    only_if { ha && node["drbd"] && node["drbd"]["rsc"] && node["drbd"]["rsc"].any? }
-  end
-
   service "pacemaker" do
     action :disable
     only_if { ha }


### PR DESCRIPTION
DRBD support was dropped in SOC8, so upgrade from this version
does not need to handle it.