### PR TITLE
List XEN nodes when failing precheck (trivial)

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -1918,7 +1918,7 @@ module Api
         end
         if check[:xen_nodes_present]
           ret[:xen_nodes_present] = {
-            data: I18n.t("api.upgrade.prechecks.xen_nodes.error"),
+            data: I18n.t("api.upgrade.prechecks.xen_nodes.error", nodes: check[:xen_nodes_present]),
             help: I18n.t("api.upgrade.prechecks.xen_nodes.help")
           }
         end


### PR DESCRIPTION
The error message output when a cloud fails the upgrade
precheck was missing the :nodes parameter, leading to an
uninformative error message that didn't list the affected
nodes. This commit fixes the problem.

Note: this is only needed for Cloud 8 since the upgrade to Cloud 9 won't allow any Xen based compute nodes through.