### PR TITLE
Make sure the crowbar migrations are OK

### DIFF
--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -163,6 +163,9 @@ describe Api::Upgrade do
       allow_any_instance_of(CrowbarService).to receive(
         :prepare_nodes_for_os_upgrade
       ).and_return(true)
+      allow(Api::Upgrade).to(
+        receive(:check_schema_migrations).and_return(true)
+      )
       allow(Node).to(
         receive(:find).with("state:crowbar_upgrade").and_return(
           [Node.find_by_name("testing.crowbar.com")]


### PR DESCRIPTION
Migrations are executed at the end of admin upgrade step and if there was a failure,
there's a big chance services step would fail
(because correct chef templates might not be rendered)

So do the extra check right at the start of services step. Not during
admin upgrade step, beacuse that one is not repeatable after the packages installations.