### PR TITLE
crowbar: add crowbar-pacemaker dependency (SOC-10986)

### DIFF
--- a/chef/cookbooks/crowbar/metadata.json
+++ b/chef/cookbooks/crowbar/metadata.json
@@ -9,6 +9,7 @@
       "apache2": [],
       "barclamp": [],
       "bluepill": [],
+      "crowbar-pacemaker": [],
       "utils": []
     },
     "groupings": {


### PR DESCRIPTION
Without this dependency, barclamp application will fail with a

  uninitialized constant Chef::Recipe::CrowbarPacemakerHelper

for any node that does not have other barclamps with this
dependency declaration applied. In practice, this problem only
becomes apparent for nodes that have no roles from crowbar-openstack
applied since all Openstack barclamps declare a dependency on
crowbar-pacemaker.