### PR TITLE
Ignore CVE-2019-16770

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
        - bundle exec rake spec brakeman:run
        # ignore rest-client issues, chef 10 requires that
        - bin/bundle exec bundle-audit update
-       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201 CVE-2019-13117
+       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201 CVE-2019-13117 CVE-2019-16770
     - name: "Validate Cookbooks (RSpec)"
       gemfile: chef/cookbooks/barclamp/Gemfile
       script:


### PR DESCRIPTION
The fix for our rubygem-puma package is currently being tested
and should make it into a maintenance update soon. Meanwhile,
we can add this CVE to the ignore list since Travis consumes
puma-2.16.0 from Ruby Gems which will never have the
backported patch we've got in our package.