### PR TITLE
upgrade: Fix systemd unit listing (trivial)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -61,7 +61,7 @@ if [ $ret != 0 ] ; then
 fi
 
 # Make sure services are shut down - they may not have to be managed by pacemaker
-for i in $(systemctl list-units openstack-* --no-legend | cut -d" " -f1) ; do
+for i in $(systemctl list-units 'openstack-*' --no-legend | cut -d" " -f1) ; do
     log "Stopping service $i"
     systemctl stop $i
     systemctl disable $i

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-remaining-services.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-remaining-services.sh.erb
@@ -29,7 +29,7 @@ if [[ -f $UPGRADEDIR/crowbar-shutdown-remaining-services-ok ]] ; then
 fi
 
 # Make sure all services are shut down
-for i in $(systemctl list-units openstack* --no-legend | cut -d" " -f1) ; do
+for i in $(systemctl list-units 'openstack*' --no-legend | cut -d" " -f1) ; do
     log "Stopping service $i"
     systemctl stop $i
     systemctl disable $i

--- a/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-shutdown-services-before-upgrade.sh.erb
@@ -99,7 +99,7 @@ done
 log "Stopping OpenStack services..."
 
 # We do not want to stop neutron services just yet, they are needed in later upgrade stage
-for i in $(systemctl list-units openstack-* --no-legend | cut -d" " -f1 | grep -v neutron) ; do
+for i in $(systemctl list-units 'openstack-*' --no-legend | cut -d" " -f1 | grep -v neutron) ; do
     log "Stopping service $i"
     systemctl stop $i
     systemctl disable $i


### PR DESCRIPTION
If there was some file matching openstack-* pattern in current directory
the patern was expanded on execution and `systemctl list-units openstack-*`
became `systemctl list-units openstack-the-rest-of-file-name` which didn't
give the result which was expected. Quoting the pattern disabled shell
expansion and pass the argument as-is to systemctl.