### PR TITLE
upgrade: add missing exit to Monasca DB dump (trivial)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-dump-monasca-db.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-dump-monasca-db.sh.erb
@@ -34,6 +34,7 @@ exitok()
 {
 touch $STATEFILE
 log "$BASH_SOURCE is finished."
+exit 0
 }
 
 log "Executing $BASH_SOURCE"


### PR DESCRIPTION
The upgrade script for dumping the Monasca database was
missing the actual `exit` in its exitok() function. This
commit adds it.