### PR TITLE
upgrade: Stop if nova-compute upgrade fails (SOC-10378)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -105,7 +105,7 @@ systemctl restart <%= @metadata_agent %>
 <% end %>
 
 <% if @is_remote_node %>
-log "Leving nova-compute service to be restarted by cluster resources"
+log "Leaving nova-compute service to be restarted by cluster resources"
 <% else %>
 log "Starting nova-compute service"
 systemctl restart openstack-nova-compute.service

--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -90,6 +90,13 @@ log "Upgrading packages needed for nova-compute node"
 
 zypper --non-interactive up openstack-nova-compute
 
+ret=$?
+if [ $ret != 0 ] ; then
+    log "Error occured during nova-compute packages upgrade"
+    echo $ret > $UPGRADEDIR/crowbar-pre-upgrade-failed
+    exit $ret
+fi
+
 log "Restarting services for Rocky"
 
 <% unless @is_remote_node %>


### PR DESCRIPTION
Compute services are upgraded early and problems which were not detected
at that point can pop up again later when it is harder to correct them.
After this change, pre-upgrade script will fail if nova-compute packages
fail to upgrade correctly.
This happened in test scenarios where new packages were coming from
a different (test) vendor and "allow vendor change" was not enabled.
In real life cases such failures could be caused by e.g. repo problems.