### PR TITLE
upgrade: Make a check for SLES product version (SOC-3089)

### DIFF
--- a/crowbar_framework/spec/models/api/upgrade_spec.rb
+++ b/crowbar_framework/spec/models/api/upgrade_spec.rb
@@ -166,6 +166,9 @@ describe Api::Upgrade do
       allow(Api::Upgrade).to(
         receive(:check_schema_migrations).and_return(true)
       )
+      allow(Api::Upgrade).to(
+        receive(:check_product_version).and_return(true)
+      )
       allow(Node).to(
         receive(:find).with("state:crowbar_upgrade").and_return(
           [Node.find_by_name("testing.crowbar.com")]


### PR DESCRIPTION
If some packages are incorrectly upgaded during admin server upgrade,
it could blow to our faces later. Better to make some explicit check
if things went well when it's still time and check for the installed
SLES product version.

It is not necessary to check for Cloud product version because another
check for the state of crowbar migrations should cover it.

Do the extra check right at the start of services step. Not during
admin upgrade step, beacuse that one is not repeatable after the reboot.