### PR TITLE
apache2: Restart after enabling SSL flag (SOC-11029)

### DIFF
--- a/chef/cookbooks/apache2/recipes/mod_ssl.rb
+++ b/chef/cookbooks/apache2/recipes/mod_ssl.rb
@@ -32,6 +32,12 @@ end
 if node[:platform_family] == "suse"
   execute "/usr/sbin/a2enflag SSL" do
     command "/usr/sbin/a2enflag SSL"
+    # apache needs to be hard-restarted or -DSSL will not be added to the main process
+    # this would result in some config files with <IfDefine SSL> not being picked up by
+    # following reloads
+    notifies :restart, resources(service: "apache2"), :immediately
+    not_if "grep '^[[:space:]]*APACHE_SERVER_FLAGS=' /etc/sysconfig/apache2 |"\
+           "sed -r 's/[\"=]|$/ /g' | grep -q ' SSL '"
   end
   apache_module "version"
 end


### PR DESCRIPTION
When SSL flag is enabled in apache's sysconfig file it is translated
into a -DSSL command argument that will be used the next time apache
is (re)started. When apache is reloaded, it is just signaled with
SIGUSR1 but not completely restarted.
Without a restart, the main process doesn't get the -DSSL option and
this causes all configs with <IfDefine SSL> to be skipped.
Additional restart in the mod_ssl recipe after enabling SSL flag is
required to handle this properly.