### PR TITLE
Upgrade neutron agent together with nova-compute package (SOC-11031)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-pre-upgrade.sh.erb
@@ -97,7 +97,7 @@ if [ $ret != 0 ] ; then
     exit $ret
 fi
 
-log "Restarting services for Rocky"
+zypper --non-interactive up <%= @neutron_agent %>
 
 <% unless @is_remote_node %>
 systemctl restart <%= @neutron_agent %>


### PR DESCRIPTION
In some cases we start losing network connectivity to VM's when
all nova-compute services are upgraded and live-migration is being
performed. Upgrading neutron agents on the compute nodes seems to help.

Just a note: this is consistent with the code in 4.0 branch, where we also upgraded nova-compute on all nodes during the upgrade...