### PR TITLE
dns: add checks to designate migration (SOC-11047)

### DIFF
--- a/chef/data_bags/crowbar/migrate/dns/301_add_rndckey.rb
+++ b/chef/data_bags/crowbar/migrate/dns/301_add_rndckey.rb
@@ -3,8 +3,8 @@ def upgrade(template_attrs, template_deployment, attrs, deployment)
     service = ServiceObject.new "fake-logger"
     @@dns_designate_rndc_key = service.random_password
   end
-  attrs["designate_rndc_key"] = @@dns_designate_rndc_key
-  attrs["enable_designate"] = template_attrs["enable_designate"]
+  attrs["designate_rndc_key"] = @@dns_designate_rndc_key unless attrs.key?("designate_rndc_key")
+  attrs["enable_designate"] = template_attrs["enable_designate"] unless attrs.key?("enable_designate")
   return attrs, deployment
 end
 


### PR DESCRIPTION
This commit modifies the Designate migration to check for the
presence of the attributes it adds. Otherwise it would
overwrite these attributes with the values from the JSON data
bag, thus breaking any existing Designate deployments in the
course of the upgrade.

Please do not merge, yet, we need to test it first.