### PR TITLE
Add lb-mgmt-net to network.json (SOC-10904)

### DIFF
--- a/chef/data_bags/crowbar/template-network.json
+++ b/chef/data_bags/crowbar/template-network.json
@@ -179,7 +179,7 @@
         },
         "nova_fixed": {
           "conduit": "intf1",
-          "vlan": 500,
+          "vlan": 700,
           "use_vlan": true,
           "add_bridge": false,
           "add_ovs_bridge": false,
@@ -205,6 +205,21 @@
           "broadcast": "192.168.126.255",
           "ranges": {
             "host": { "start": "192.168.126.129", "end": "192.168.126.254" }
+          }
+        },
+        "octavia": {
+          "conduit": "intf1",
+          "vlan": 500,
+          "use_vlan": true,
+          "add_bridge": false,
+          "add_ovs_bridge": false,
+          "mtu": 1500,
+          "subnet": "192.168.131.0",
+          "netmask": "255.255.255.0",
+          "router": "192.168.131.1",
+          "broadcast": "192.168.131.255",
+          "ranges": {
+            "host": { "start": "192.168.131.10", "end": "192.168.131.239" }
           }
         },
         "bmc": {

--- a/crowbar_framework/config/locales/network/en.yml
+++ b/crowbar_framework/config/locales/network/en.yml
@@ -51,6 +51,7 @@ en:
       bmc_vlan: 'Mgmt Connect'
       nova_fixed: 'Nova Fixed'
       nova_floating: 'Nova Floating'
+      octavia: 'Octavia Management Network'
       public: 'Public'
       private: 'Private'
       storage: 'Storage'


### PR DESCRIPTION
This change adds a network to `network.json` for configuring a
provider network for Octavia management network traffic.

Signed-off-by: Nicolas Bock <nicolas.bock@suse.com>