### PR TITLE
network: start OVS before wickedd (SOC-11067)

### DIFF
--- a/chef/cookbooks/network/recipes/default.rb
+++ b/chef/cookbooks/network/recipes/default.rb
@@ -53,6 +53,27 @@ if node[:network][:needs_openvswitch]
     end
     s.run_action :disable
   end
+
+  directory "/etc/systemd/system/openvswitch.service.d" do
+    owner "root"
+    group "root"
+    mode 0o755
+    action :create
+  end
+
+  template "/etc/systemd/system/openvswitch.service.d/99-wickedd.conf" do
+    source "openvswitch.service-wickedd.conf.erb"
+    owner "root"
+    group "root"
+    mode 0o644
+  end
+
+  bash "reload systemd for openvswitch.service extension" do
+    code "systemctl daemon-reload"
+    action :nothing
+    subscribes :run, "template[/etc/systemd/system/openvswitch.service.d/99-wickedd.conf]", :immediate
+  end
+
 end
 
 require "fileutils"

--- a/chef/cookbooks/network/templates/default/openvswitch.service-wickedd.conf.erb
+++ b/chef/cookbooks/network/templates/default/openvswitch.service-wickedd.conf.erb
@@ -1,0 +1,2 @@
+[Unit]
+Before=wickedd.service


### PR DESCRIPTION
According to the official documentation [1], the OVS services need
to start long before the network (wicked) service, to be able to
interact with the service during boot. However, both OVS and wicked
are multi-service applications and the way that OVS and wicked systemd
service files are being set up, using a `Before=network.service` entry
in the OVS systemd unit file is not enough to guarantee that OVS
services are fully started before wicked services start.

The network.service systemd unit is an alias for wicked.service, which
is just a front-end unit for the multiple wickedd-* services that are
part of the wicked application. These wickedd-* services are also configured
to start `Before=wicked.service`, which means that OVS services and
wicked services usually end up being started in parallel. This is
the source of a number of heisenbugs that only manifest during
reboot and intermittently impact the gating and periodic CI jobs.

NOTE: this service startup dependency cannot be modeled as an OVS
patch, because wicked is a SUSE specific product. It also cannot be
modeled as a wicked patch because there is no direct dependency
between wicked and OVS. It needs to be modeled by SOC, because
it is in the context of SOC where both applications need to be
running side by side. I did file an upstream ticket though, just in
case this can be solved in the wicked systemd files: https://github.com/openSUSE/wicked/issues/822

[1] https://en.opensuse.org/Portal:Wicked/OpenvSwitch
