### PR TITLE
upgrade: Run DHCP evacuation (SOC-11046)

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -205,6 +205,14 @@ template "/usr/sbin/crowbar-router-migration.sh" do
   action :create
 end
 
+template "/usr/sbin/crowbar-dhcp-migration.sh" do
+  source "crowbar-dhcp-migration.sh.erb"
+  mode "0755"
+  owner "root"
+  group "root"
+  action :create
+end
+
 template "/usr/sbin/crowbar-set-network-agents-state.sh" do
   source "crowbar-set-network-agents-state.sh.erb"
   mode "0755"

--- a/chef/cookbooks/crowbar/templates/default/crowbar-dhcp-migration.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-dhcp-migration.sh.erb
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# This script migrates all neutron dhcps from the node passed as argument.
+
+LOGFILE=/var/log/crowbar/node-upgrade.log
+UPGRADEDIR=/var/lib/crowbar/upgrade
+mkdir -p "`dirname "$LOGFILE"`"
+exec >>"$LOGFILE" 2>&1
+
+hostname=$1
+
+log()
+{
+    set +x
+    echo "[$(date --iso-8601=ns)] [$$] $@"
+    set -x
+}
+
+log "Executing $BASH_SOURCE"
+
+set -x
+
+mkdir -p $UPGRADEDIR
+rm -f $UPGRADEDIR/crowbar-dhcp-migration-failed
+
+set +x
+source /root/.openrc
+set -x
+
+
+zypper --non-interactive install openstack-neutron-ha-tool
+
+/usr/bin/neutron-ha-tool --dhcp-agent-evacuate $hostname \
+                         --wait-for-dhcp-network \
+                         --exit-on-first-failure \
+                         --insecure
+ret=$?
+if [ $ret != 0 ] ; then
+    echo "Failed to evacuate dhcp agent on host: $hostname"
+    echo $ret > $UPGRADEDIR/crowbar-dhcp-migration-failed
+    exit $ret
+fi
+
+
+touch $UPGRADEDIR/crowbar-dhcp-migration-ok
+log "$BASH_SOURCE is finished."

--- a/configs/upgrade_timeouts.yml
+++ b/configs/upgrade_timeouts.yml
@@ -6,6 +6,7 @@
 :shutdown_remaining_services: 600
 :evacuate_host: 300
 :chef_upgraded: 1200
+:dhcp_migration: 1200
 :router_migration: 600
 :lbaas_evacuation: 600
 :set_network_agents_state: 300

--- a/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
+++ b/crowbar_framework/lib/crowbar/upgrade_timeouts.rb
@@ -30,6 +30,7 @@ module Crowbar
         shutdown_remaining_services: @timeouts_config[:shutdown_remaining_services] || 600,
         evacuate_host: @timeouts_config[:evacuate_host] || 300,
         chef_upgraded: @timeouts_config[:chef_upgraded] || 1200,
+        dhcp_migration: @timeouts_config[:dhcp_migration] || 1200,
         router_migration: @timeouts_config[:router_migration] || 600,
         lbaas_evacuation: @timeouts_config[:lbaas_evacuation] || 600,
         set_network_agents_state: @timeouts_config[:set_network_agents_state] || 300,


### PR DESCRIPTION
DHCP agent handles networks and ports in a way similar to L3 agent's
routers. The assignment of these to the network nodes need to be
properly orchestrated to keep things under control in upgrade scenario
where we need to move network agents out from node before upgrading
to make the process non-disruptive.

pre-req: https://github.com/SUSE-Cloud/cookbook-openstack-network/pull/38