### PR TITLE
upgrade: Raise the timeout for nodes evacuation (trivial)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-evacuate-host.sh.erb
@@ -60,7 +60,7 @@ fi
 
 while nova --insecure list --all-tenants --host "$host" --fields host,status 2>/dev/null | grep -e ACTIVE -e MIGRATING | grep "$host"; do
     log "There is still some VM running at $host..."
-    sleep 10
+    sleep 30
 done
 
 # check the potential error state of instances that were running before

--- a/configs/upgrade_timeouts.yml
+++ b/configs/upgrade_timeouts.yml
@@ -4,7 +4,7 @@
 :post_upgrade: 600
 :shutdown_services: 600
 :shutdown_remaining_services: 600
-:evacuate_host: 300
+:evacuate_host: 600
 :chef_upgraded: 1200
 :router_migration: 600
 :lbaas_evacuation: 600


### PR DESCRIPTION
Also, no need to ping the migration status every 10 seconds
when the task is gonna take minutes.