### PR TITLE
Fix deployment queue display (SOC-10741)

### DIFF
--- a/crowbar_framework/app/assets/stylesheets/content/content.scss
+++ b/crowbar_framework/app/assets/stylesheets/content/content.scss
@@ -83,6 +83,10 @@
   }
 }
 
+.no-word-wrap {
+  white-space: nowrap;
+}
+
 h1 {
   font-size: 30px;
   font-weight: normal;

--- a/crowbar_framework/app/views/deploy_queue/_elements.html.haml
+++ b/crowbar_framework/app/views/deploy_queue/_elements.html.haml
@@ -3,7 +3,7 @@
     = role_name
   %div
     - node_names.map { |node_name| [node_name, all_nodes[node_name]] }.each do |node_name, node|
-      %span
+      %span.no-word-wrap
         - if ServiceObject.is_cluster?(node_name) || ServiceObject.is_remotes?(node_name)
           - nodes = ServiceObject.expand_nodes_for_all([node_name]).first.map { |cluster_node| all_nodes[cluster_node] }.compact
           = render :partial => "dashboard/link_cluster", :locals => { :status => ServiceObject.cluster_status(nodes), :name => ServiceObject.cluster_name(node_name) || node_name }


### PR DESCRIPTION
With big list of nodes, the line breaks between status indicators and
names were confusing as sometimes the LED was at the end of row while
the name was already in next one.