### PR TITLE
upgrade: Remove the assignement of crowbar-upgrade role (SOC-11166)

### DIFF
--- a/crowbar_framework/app/models/api/upgrade.rb
+++ b/crowbar_framework/app/models/api/upgrade.rb
@@ -970,6 +970,7 @@ module Api
 
           unlock_crowbar_ui_package
           finalize_nodes_upgrade
+          cleanup_crowbar_proposal
           status.end_step
         end
       rescue ::Crowbar::Error::Upgrade::NodeError => e
@@ -1229,6 +1230,14 @@ module Api
           finalize_node_upgrade node
           delete_upgrade_scripts node
         end
+      end
+
+      # Remove the assignement of crowbar-upgrade role to the nodes in crowbar barclamp
+      def cleanup_crowbar_proposal
+        proposal = Proposal.find_by(barclamp: "crowbar", name: "default")
+        # remove the nodes from upgrade role
+        proposal["deployment"]["crowbar"]["elements"]["crowbar-upgrade"] = []
+        proposal.save
       end
 
       #


### PR DESCRIPTION
At the end of upgrade, remove elements of crowbar-upgrade from
crowbar barclamp. Otherwise if user makes changes to crowbar proposal
(or even just reapplies it for some reason), nodes would be moved
into crowbar-upgrade state again.