### PR TITLE
upgrade: Fixes for neutron-evacuate-lbaasv2-agent execution (SOC-11171)

### DIFF
--- a/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
+++ b/chef/cookbooks/crowbar/recipes/prepare-upgrade-scripts.rb
@@ -242,9 +242,6 @@ template "/usr/sbin/crowbar-lbaas-evacuation.sh" do
   owner "root"
   group "root"
   action :create
-  variables(
-    use_ha: use_ha
-  )
   only_if { roles.include? "neutron-network" }
 end
 

--- a/chef/cookbooks/crowbar/templates/default/crowbar-lbaas-evacuation.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-lbaas-evacuation.sh.erb
@@ -34,7 +34,7 @@ if systemctl --quiet is-active  openstack-neutron-lbaasv2-agent.service; then
     /usr/bin/neutron-evacuate-lbaasv2-agent $delete_ns \
         --host $hostname \
         --config-file /etc/neutron/lbaas-connection.conf \
-        --config-file /etc/neutron/neutron.conf
+        --config-dir /etc/neutron/neutron.conf.d
 
     ret=$?
     if [ $ret != 0 ] ; then

--- a/chef/cookbooks/crowbar/templates/default/crowbar-lbaas-evacuation.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-lbaas-evacuation.sh.erb
@@ -31,8 +31,7 @@ rm -f $UPGRADEDIR/crowbar-lbaas-evacuation-failed
 
 if systemctl --quiet is-active  openstack-neutron-lbaasv2-agent.service; then
     log "Evacuating neutron-lbaasv2-agent on $hostname"
-    use_crm=<%= @use_ha ? "--use_crm" : "" %>
-    /usr/bin/neutron-evacuate-lbaasv2-agent $use_crm $delete_ns \
+    /usr/bin/neutron-evacuate-lbaasv2-agent $delete_ns \
         --host $hostname \
         --config-file /etc/neutron/lbaas-connection.conf \
         --config-file /etc/neutron/neutron.conf


### PR DESCRIPTION
use_crm option is there for the cases when lbaas agents are handled
by pacemaker resources. So the script puts the node into the maintenance
mode for the time it is restarting the agent.

However since SOC8 we do not use pacameker for lbaas agents, so there
is no need for maintenance mode and no need to execute the script with
use_crm option.