### PR TITLE
[5.0] Ignore latest CVEs in the CI, update default OS version used by CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
        - bundle exec rake spec brakeman:run
        # ignore rest-client issues, chef 10 requires that
        - bin/bundle exec bundle-audit update
-       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201 CVE-2019-13117 CVE-2019-16770 CVE-2020-7595 CVE-2020-5247 CVE-2020-8130
+       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201 CVE-2019-13117 CVE-2019-16770 CVE-2020-7595 CVE-2020-5247 CVE-2020-8130 CVE-2020-10663
     - name: "Validate Cookbooks (RSpec)"
       gemfile: chef/cookbooks/barclamp/Gemfile
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
        - bundle exec rake spec brakeman:run
        # ignore rest-client issues, chef 10 requires that
        - bin/bundle exec bundle-audit update
-       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201 CVE-2019-13117 CVE-2019-16770 CVE-2020-7595 CVE-2020-5247 CVE-2020-8130 CVE-2020-10663
+       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201 CVE-2019-13117 CVE-2019-16770 CVE-2020-7595 CVE-2020-5247 CVE-2020-8130 CVE-2020-10663 CVE-2020-5267
     - name: "Validate Cookbooks (RSpec)"
       gemfile: chef/cookbooks/barclamp/Gemfile
       script:

--- a/chef/cookbooks/barclamp/spec/spec_helper.rb
+++ b/chef/cookbooks/barclamp/spec/spec_helper.rb
@@ -32,7 +32,7 @@ RSpec.configure do |config|
   config.platform = "suse"
 
   # Specify the operating version to mock Ohai data from (default: nil)
-  config.version = "12.2"
+  config.version = "12.3"
 
   # Disable deprecated "should" syntax
   # https://github.com/rspec/rspec-expectations/blob/master/Should.md


### PR DESCRIPTION
Backport of https://github.com/crowbar/crowbar-core/pull/2019