### PR TITLE
Revert: Add lb-mgmt-net to network.json (SOC-10904) 

### DIFF
--- a/chef/data_bags/crowbar/template-network.json
+++ b/chef/data_bags/crowbar/template-network.json
@@ -179,7 +179,7 @@
         },
         "nova_fixed": {
           "conduit": "intf1",
-          "vlan": 700,
+          "vlan": 500,
           "use_vlan": true,
           "add_bridge": false,
           "add_ovs_bridge": false,
@@ -205,21 +205,6 @@
           "broadcast": "192.168.126.255",
           "ranges": {
             "host": { "start": "192.168.126.129", "end": "192.168.126.254" }
-          }
-        },
-        "octavia": {
-          "conduit": "intf1",
-          "vlan": 500,
-          "use_vlan": true,
-          "add_bridge": false,
-          "add_ovs_bridge": false,
-          "mtu": 1500,
-          "subnet": "192.168.131.0",
-          "netmask": "255.255.255.0",
-          "router": "192.168.131.1",
-          "broadcast": "192.168.131.255",
-          "ranges": {
-            "host": { "start": "192.168.131.10", "end": "192.168.131.239" }
           }
         },
         "bmc": {

--- a/crowbar_framework/config/locales/network/en.yml
+++ b/crowbar_framework/config/locales/network/en.yml
@@ -51,7 +51,6 @@ en:
       bmc_vlan: 'Mgmt Connect'
       nova_fixed: 'Nova Fixed'
       nova_floating: 'Nova Floating'
-      octavia: 'Octavia Management Network'
       public: 'Public'
       private: 'Private'
       storage: 'Storage'


### PR DESCRIPTION
The octavia network.json network is not mandatory (customers
may choose to deploy their own provider network). If we add
it to network.json, the network will always be detected and
used by Octavia.

Instead, we need to document this as an optional network
that customers may choose to add to their deployment.

Side-note: this is also a way of resolving the circular dependency
between Octavia (the consumer of this octavia network) and Neutron
(the provider that needs to configure the octavia network only if the
Octavia barclamp is deployed).

This reverts PR #1998 