### PR TITLE
[5.0] provisioner: Fix ssh key validation (SOC-11126)

### DIFF
--- a/chef/cookbooks/barclamp/libraries/barclamp_library.rb
+++ b/chef/cookbooks/barclamp/libraries/barclamp_library.rb
@@ -14,6 +14,7 @@
 #
 
 require_relative "conduit_resolver.rb"
+require_relative "ssh_key_parser.rb"
 
 module BarclampLibrary
   class Barclamp
@@ -473,6 +474,10 @@ module BarclampLibrary
           @cache["groups"][group].fetch(instance, {}).fetch(barclamp, {})
         end
       end
+    end
+
+    class SSHKeyParser
+      include Crowbar::SSHKeyParser
     end
   end
 end

--- a/chef/cookbooks/barclamp/libraries/ssh_key_parser.rb
+++ b/chef/cookbooks/barclamp/libraries/ssh_key_parser.rb
@@ -1,0 +1,1 @@
+../../../../crowbar_framework/lib/crowbar/ssh_key_parser.rb

--- a/chef/cookbooks/provisioner/recipes/keys.rb
+++ b/chef/cookbooks/provisioner/recipes/keys.rb
@@ -37,10 +37,11 @@ root_pub_key = `cat /root/.ssh/id_rsa.pub`.chomp
 access_keys[node.name] = root_pub_key
 
 # Add additional keys
+nullnodecounter = 0
 node["provisioner"]["access_keys"].strip.split("\n").each do |key|
   key.strip!
   unless key.empty?
-    nodename = key.split(" ")[2]
+    nodename = key.split(" ")[2] || "hostless-key-#{nullnodecounter += 1}"
     access_keys[nodename] = key
   end
 end

--- a/chef/cookbooks/provisioner/recipes/keys.rb
+++ b/chef/cookbooks/provisioner/recipes/keys.rb
@@ -38,12 +38,13 @@ access_keys[node.name] = root_pub_key
 
 # Add additional keys
 nullnodecounter = 0
+key_parser = BarclampLibrary::Barclamp::SSHKeyParser.new
 node["provisioner"]["access_keys"].strip.split("\n").each do |key|
   key.strip!
-  unless key.empty?
-    nodename = key.split(" ")[2] || "hostless-key-#{nullnodecounter += 1}"
-    access_keys[nodename] = key
-  end
+  next if key.empty? || key[0] == "#"
+  _, _, _, comment = key_parser.split_key_line(key)
+  nodename = comment || "hostless-key-#{nullnodecounter += 1}"
+  access_keys[nodename] = key
 end
 
 # Find provisioner servers and include them.

--- a/crowbar_framework/lib/crowbar/ssh_key_parser.rb
+++ b/crowbar_framework/lib/crowbar/ssh_key_parser.rb
@@ -1,0 +1,76 @@
+#
+# Copyright 2020, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Crowbar
+  module SSHKeyParser
+    # Splits authorized ssh key line into parts as described in
+    # Returns [options, type, key, comment] (options and comment could be nil)
+    # https://man.openbsd.org/sshd
+    def split_key_line(line)
+      line = line.clone
+      res = []
+      field = ""
+      escape = false # was last char a backslash (so current one is escaped)?
+      quotes = 0 # number of double quotes in current field
+      type_found_at = nil # index of valid key type (if found)
+      until line.empty?
+        char = line.slice!(0)
+        # count quotes for proper space handling
+        quotes += 1 if char == "\"" && !escape
+        # end of field, store and reset
+        if char == " " && quotes.even?
+          type_found_at = res.size if valid_key_types.include? field
+          res.push(field) unless field.empty?
+          field = ""
+          quotes = 0
+          # break parsing if we already have three fields (rest is comment)
+          # OR we found a valid key type and one more field (the key)
+          # this is equivalent to:
+          # ... if res.size == 3 || \
+          #        type_found_at && res.size == type_found_at + 2
+          break if res.size == (type_found_at || 1) + 2
+        else
+          field += char
+        end
+        escape = char == "\\"
+      end
+      # take the rest as-is
+      field += line
+      field.strip!
+      res.push(field) unless field.empty?
+
+      # add missing options field
+      res.unshift(nil) if type_found_at && type_found_at.zero?
+      # add missing comment field
+      res.push(nil) if res.size < 4
+      res
+    end
+
+    ## Return valid key types
+    def valid_key_types
+      [
+        "sk-ecdsa-sha2-nistp256@openssh.com",
+        "ecdsa-sha2-nistp256",
+        "ecdsa-sha2-nistp384",
+        "ecdsa-sha2-nistp521",
+        "sk-ssh-ed25519@openssh.com",
+        "ssh-ed25519",
+        "ssh-dss",
+        "ssh-rsa"
+      ]
+    end
+  end
+end

--- a/crowbar_framework/spec/lib/crowbar/ssh_key_parser_spec.rb
+++ b/crowbar_framework/spec/lib/crowbar/ssh_key_parser_spec.rb
@@ -1,0 +1,185 @@
+#
+# Copyright 2020, SUSE
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require "spec_helper"
+
+class DummyKeyParser
+  include Crowbar::SSHKeyParser
+end
+
+describe Crowbar::SSHKeyParser do
+  subject { Crowbar::SSHKeyParser }
+
+  # parser doesn't verify key length or contens so we can test with short one
+  DUMMY_KEY_CONTENTS = "QmV3YXJlIG9mIHRoZSBMZW9wYXJkLgo=".freeze
+
+  context "good key lines" do
+    it "basic" do
+      line = "ssh-rsa %s user@example.net" % DUMMY_KEY_CONTENTS
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq(nil)
+      expect(type).to eq("ssh-rsa")
+      expect(key).to eq(DUMMY_KEY_CONTENTS)
+      expect(comment).to eq("user@example.net")
+    end
+
+    it "with rogue spaces and comment" do
+      line = "  ssh-rsa   %s   user@example.net  " % DUMMY_KEY_CONTENTS
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq(nil)
+      expect(type).to eq("ssh-rsa")
+      expect(key).to eq(DUMMY_KEY_CONTENTS)
+      expect(comment).to eq("user@example.net")
+    end
+
+    it "with rogue spaces and no comment" do
+      line = "  ssh-rsa   %s   " % DUMMY_KEY_CONTENTS
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq(nil)
+      expect(type).to eq("ssh-rsa")
+      expect(key).to eq(DUMMY_KEY_CONTENTS)
+      expect(comment).to eq(nil)
+    end
+
+    it "with basic options" do
+      line = 'from="*.sales.example.net,!pc.sales.example.net" ssh-rsa %s john@example.net' % DUMMY_KEY_CONTENTS
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq('from="*.sales.example.net,!pc.sales.example.net"')
+      expect(type).to eq("ssh-rsa")
+      expect(key).to eq(DUMMY_KEY_CONTENTS)
+      expect(comment).to eq("john@example.net")
+    end
+
+    it "with mixed options with spaces" do
+      line = 'command="dump /home",no-pty,no-port-forwarding ssh-rsa %s example.net' % DUMMY_KEY_CONTENTS
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq('command="dump /home",no-pty,no-port-forwarding')
+      expect(type).to eq("ssh-rsa")
+      expect(key).to eq(DUMMY_KEY_CONTENTS)
+      expect(comment).to eq("example.net")
+    end
+
+    it "with options and no comment" do
+      line = 'permitopen="192.0.2.1:80",permitopen="192.0.2.2:25" ssh-rsa %s' % DUMMY_KEY_CONTENTS
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq('permitopen="192.0.2.1:80",permitopen="192.0.2.2:25"')
+      expect(type).to eq("ssh-rsa")
+      expect(key).to eq(DUMMY_KEY_CONTENTS)
+      expect(comment).to eq(nil)
+    end
+
+    it "with options with spaces and comment" do
+      line = 'tunnel="0",command="sh /etc/netstart tun0" ssh-rsa %s jane@example.net' % DUMMY_KEY_CONTENTS
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq('tunnel="0",command="sh /etc/netstart tun0"')
+      expect(type).to eq("ssh-rsa")
+      expect(key).to eq(DUMMY_KEY_CONTENTS)
+      expect(comment).to eq("jane@example.net")
+    end
+
+    it "with mixed options and comment" do
+      line = 'restrict,pty,command="nethack" ssh-rsa %s user2@example.net' % DUMMY_KEY_CONTENTS
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq('restrict,pty,command="nethack"')
+      expect(type).to eq("ssh-rsa")
+      expect(key).to eq(DUMMY_KEY_CONTENTS)
+      expect(comment).to eq("user2@example.net")
+    end
+
+    it "with non-ssh-rsa type" do
+      line = "no-touch-required sk-ecdsa-sha2-nistp256@openssh.com %s user3@example.net" % DUMMY_KEY_CONTENTS
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq("no-touch-required")
+      expect(type).to eq("sk-ecdsa-sha2-nistp256@openssh.com")
+      expect(key).to eq(DUMMY_KEY_CONTENTS)
+      expect(comment).to eq("user3@example.net")
+    end
+
+    it "with quotes and spaces in options" do
+      line = 'environment="MYVAR=I have a quote\" in my middle" ssh-rsa %s user4@example.net' % DUMMY_KEY_CONTENTS
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq('environment="MYVAR=I have a quote\" in my middle"')
+      expect(type).to eq("ssh-rsa")
+      expect(key).to eq(DUMMY_KEY_CONTENTS)
+      expect(comment).to eq("user4@example.net")
+    end
+
+    it "with spaces in comment" do
+      line = "ssh-rsa %s comment with spaces user@example.net " % DUMMY_KEY_CONTENTS
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq(nil)
+      expect(type).to eq("ssh-rsa")
+      expect(key).to eq(DUMMY_KEY_CONTENTS)
+      expect(comment).to eq("comment with spaces user@example.net")
+    end
+  end
+
+  context "bad key lines" do
+    it "empty" do
+      line = ""
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq(nil)
+      expect(type).to eq(nil)
+      expect(key).to eq(nil)
+      expect(comment).to eq(nil)
+    end
+
+    it "with one field" do
+      line = "invalid"
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq("invalid")
+      expect(type).to eq(nil)
+      expect(key).to eq(nil)
+      expect(comment).to eq(nil)
+    end
+
+    it "with two fields" do
+      line = "invalid two"
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq("invalid")
+      expect(type).to eq("two")
+      expect(key).to eq(nil)
+      expect(comment).to eq(nil)
+    end
+
+    it "with three fields" do
+      line = "invalid line three"
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq("invalid")
+      expect(type).to eq("line")
+      expect(key).to eq("three")
+      expect(comment).to eq(nil)
+    end
+
+    it "with four fields" do
+      line = "invalid line four field"
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq("invalid")
+      expect(type).to eq("line")
+      expect(key).to eq("four")
+      expect(comment).to eq("field")
+    end
+
+    it "with more fields " do
+      line = "invalid line which is not a key at all"
+      (options, type, key, comment) = DummyKeyParser.new.split_key_line(line)
+      expect(options).to eq("invalid")
+      expect(type).to eq("line")
+      expect(key).to eq("which")
+      expect(comment).to eq("is not a key at all")
+    end
+  end
+end


### PR DESCRIPTION
backport of #2024 and #1699 (for clean cherry-pick)