### PR TITLE
upgrade: disable zypper process check temporarily (SOC-11203)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-upgrade-os.sh.erb
@@ -76,12 +76,19 @@ initiate_node_upgrade()
       sed -i s/django.utils.log.NullHandler/logging.NullHandler/g $horizon_custom_config
     fi
 
+    # SOC-11203: record old setting and disable lsof check for running
+    # processes since it may hang indefinitely
+    zypper --non-interactive install crudini
+    zypper_upgrade_conf=/tmp/zypper.conf.upgrade
+    cp /etc/zypp/zypper.conf $zypper_upgrade_conf
+    crudini --set $zypper_upgrade_conf commit psCheckAccessDeleted no
+
     # Upgrade the distribution non-interactively
     log "Executing zypper ref"
-    zypper --no-color --releasever <%= @target_platform_version %> ref -f
+    zypper --config $zypper_upgrade_conf --no-color --releasever <%= @target_platform_version %> ref -f
 
     log "Executing zypper dist-upgrade"
-    zypper --no-color --non-interactive dist-upgrade -l --recommends --replacefiles
+    zypper --config $zypper_upgrade_conf --no-color --non-interactive dist-upgrade -l --recommends --replacefiles
     ret=$?
     if [ $ret != 0 ]; then
         log "zypper dist-upgrade has failed with $ret, check zypper logs"


### PR DESCRIPTION
This commit temporarily sets zypper's psCheckAccessDeleted
(introduced by bsc#945169) setting to 'no' before package
upgrade on nodes. This check launches an lsof command that may
hang indefinitely to check for running processes using files
that were changed by a package upgrade. In our case, this
check is entirely unneccessary since the nodes will be
rebooted after package upgrade anyway. Hence we can safely
turn it off, thus saving the operator the trouble of killing
these lsof processes manually on each node that experiences
the problem.