### PR TITLE
upgrade: Do not stop pacemaker managed apache service (SOC-11298)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
+++ b/chef/cookbooks/crowbar/templates/default/crowbar-delete-pacemaker-resources.sh.erb
@@ -35,7 +35,7 @@ log "Stopping pacemaker resources..."
 # Otherwise we could have services starting up in unwanted locations while deleting constraints.
 
 for type in clone group ms primitive; do
-    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /galera|haproxy|stonith|remote-|vip-/) {print \$2}"); do
+    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /galera|haproxy|stonith|apache|remote-|vip-/) {print \$2}"); do
         log "Stopping resource $resource"
         crm --wait resource stop $resource
     done
@@ -53,7 +53,7 @@ log "Deleting pacemaker resources..."
 crm_cmd=""
 for type in location clone group ms primitive; do
     log "Looking at typ $type of resources..."
-    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /galera|haproxy|stonith|remote-|vip-/) {print \$2}"); do
+    for resource in $(crm configure show | awk "\$1 == \"$type\" && ! (\$2 ~ /galera|haproxy|stonith|apache|remote-|vip-/) {print \$2}"); do
         printf -v crm_cmd "${crm_cmd}delete $resource\n"
     done
 done


### PR DESCRIPTION
apache service should not be stopped by usual upgrade scripts,
because we need it so the keystone API can function as long as possible.

Recently we found a corner case where apache is stopped because
it is handled by Pacemaker (setting that is non-default for a long time)
and most of pacemaker resources are stopped and deleted at certain point.

Solution is to exclude apache resource from this deletion command.