### PR TITLE
Ignore latest ruby-related CVEs in the CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
        - bundle exec rake spec brakeman:run
        # ignore rest-client issues, chef 10 requires that
        - bin/bundle exec bundle-audit update
-       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201 CVE-2019-13117 CVE-2019-16770 CVE-2020-7595 CVE-2020-5247 CVE-2020-8130 CVE-2020-10663 CVE-2020-5267
+       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201 CVE-2019-13117 CVE-2019-16770 CVE-2020-7595 CVE-2020-5247 CVE-2020-8130 CVE-2020-10663 CVE-2020-5267 CVE-2020-8164 CVE-2020-8166 CVE-2020-8167 CVE-2020-8151 CVE-2020-8165 CVE-2020-5249 CVE-2020-11077 CVE-2020-11076 CVE-2020-8161
     - name: "Validate Cookbooks (RSpec)"
       gemfile: chef/cookbooks/barclamp/Gemfile
       script:


### PR DESCRIPTION
The bugs will be fixed in related packages, but we do not update
them in CI server.