### PR TITLE
provisioner: allow tftp access from admin network only (bsc#1019111)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/setup_base_images.rb
+++ b/chef/cookbooks/provisioner/recipes/setup_base_images.rb
@@ -299,7 +299,8 @@ if node[:platform_family] == "suse"
       owner "root"
       group "root"
       mode "0644"
-      variables(tftproot: tftproot, admin_ip: admin_ip)
+      variables(tftproot: tftproot, admin_ip: admin_ip,
+                admin_subnet: admin_net.subnet, admin_netmask: admin_net.netmask)
     end
 
     service "tftp.service" do

--- a/chef/cookbooks/provisioner/templates/default/tftp.service.erb
+++ b/chef/cookbooks/provisioner/templates/default/tftp.service.erb
@@ -3,5 +3,7 @@ Description=Tftp Server
 
 [Service]
 Type=simple
+ExecStartPre=/usr/sbin/iptables -A INPUT -d <%= @admin_ip %> ! -s <%= @admin_subnet %>/<%= @admin_netmask %> -p udp -m udp --dport 69 -j DROP
 ExecStart=/usr/sbin/in.tftpd -u tftp -s <%= @tftproot %> -m /etc/tftpd.conf -L -a <%= @admin_ip %> -B 1024 -v
+ExecStopPost=/usr/sbin/iptables -D INPUT -d <%= @admin_ip %> ! -s <%= @admin_subnet %>/<%= @admin_netmask %> -p udp -m udp --dport 69 -j DROP
 Restart=on-failure


### PR DESCRIPTION
The tftp server is for hosts on the admin network only. But it can be
accessed from outside if the admin network is routable. This patch adds
an iptables rule to prevent access from outside the admin network.