### PR TITLE
crowbar: Also add access to /restricted/ in SSL vhost (SOC-11352)

### DIFF
--- a/chef/cookbooks/crowbar/templates/default/apache.conf.erb
+++ b/chef/cookbooks/crowbar/templates/default/apache.conf.erb
@@ -87,6 +87,16 @@
         <%- end %>
         <%- end %>
     </Location>
+
+    <%- unless @realm.nil? %>
+    <Location /restricted/>
+        AuthType Digest
+        AuthName "<%= @realm %>"
+        AuthDigestProvider file
+        AuthUserFile /opt/dell/crowbar_framework/htdigest-clients
+        Require valid-user
+    </Location>
+    <%- end %>
 </VirtualHost>
 
 </IfDefine>


### PR DESCRIPTION
The `/restricted/` path is missing on the SSL vhost configuration.

(cherry picked from commit 5f7b8c4e685a4e3de497714af6d58aca7dc30fba)