### PR TITLE
upgrade: Allow transition from crowbar_upgrade to reboot (trivial)

### DIFF
--- a/crowbar_framework/lib/crowbar/state.rb
+++ b/crowbar_framework/lib/crowbar/state.rb
@@ -82,8 +82,8 @@ module Crowbar
           "recovering" => ["readying", "reboot", "shutdown", "problem"],
           "problem" => ["readying", "reboot", "shutdown"],
           ## other states that can be set by rails app
-          # upgrade is controlled by rails app
-          "crowbar_upgrade" => [],
+          # upgrade is entered by rails app but left by crowbar_join/reboot
+          "crowbar_upgrade" => ["reboot"],
           "confupdate" => ["hardware-updating"],
           "update" => ["hardware-updating"],
           # noupdate is when we have no up-to-date data from chef; in theory


### PR DESCRIPTION
When restricted API was added, some additional cleanup work was done
around the transition state machine.
One missing transition was from "crowbar_upgrade" to "reboot" which
happens when node is rebooted during upgrade. After that, node will
be in "reboot" state which opens usual transitions to "readying" etc.

**NOTE: backport for SOC7 should be added to the main "restricted API" backport**