### PR TITLE
[4.0] Fix travis for SOC7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
        - bundle exec rake spec brakeman:run
        # ignore rest-client issues, chef 10 requires that
        - bin/bundle exec bundle-audit update
-       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201 CVE-2019-13117 CVE-2019-16770
+       - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201 CVE-2019-13117 CVE-2019-16770 CVE-2020-8164 CVE-2020-8166 CVE-2020-5267 CVE-2020-8167 CVE-2020-8151 CVE-2020-8165 CVE-2020-10663 CVE-2020-7595 CVE-2020-5247 CVE-2020-5249 CVE-2020-11077 CVE-2020-11076 CVE-2020-8161 CVE-2020-8184 CVE-2020-8130 CVE-2020-15169
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,6 @@ matrix:
        # ignore rest-client issues, chef 10 requires that
        - bin/bundle exec bundle-audit update
        - bin/bundle exec bundle-audit check --ignore CVE-2015-1820 CVE-2015-3448 OSVDB-117461 CVE-2019-11068 CVE-2019-5477 CVE-2017-1002201 CVE-2019-13117 CVE-2019-16770
-    - name: "Validate Cookbooks (RSpec)"
-      gemfile: chef/cookbooks/barclamp/Gemfile
-      script:
-       - cd chef/cookbooks/barclamp && bundle exec rake
 
 addons:
   apt:


### PR DESCRIPTION
As suse/12.2 is not available anymore in travis, and chefspec tests have
very limited coverage, it's pretty safe to disable these for SOC7.

