### PR TITLE
provisioner: check for client_user (SOC-11389)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -351,7 +351,11 @@ address = crowbar_node["crowbar"]["network"]["admin"]["address"]
 protocol = crowbar_node["crowbar"]["apache"]["ssl"] ? "https" : "http"
 server = "#{protocol}://#{address}"
 is_admin = CrowbarHelper.is_admin?(node)
-if is_admin
+# SOC-11389: or condition bridges the gap between proposal being saved and
+# proposal being applied/first chef-client run on admin node having passed.
+# Until that time, the data won't be available to chef clients running on any
+# node other than the Crowbar admin node.
+if is_admin || crowbar_node["crowbar"]["client_user"].nil?
   username = "crowbar"
   password = crowbar_node["crowbar"]["users"][username]["password"]
 else


### PR DESCRIPTION
This commit adds a check for the presence of the client_user
attribute in the Crowbar barclamp's data bag. This attribute
will only become available in chef once chef-client has run on
the Crowbar admin node or the Crowbar data bag has been
applied. Until that has happened, the code using it would
error out on all other nodes.

Note that this is _not_ a backport from Cloud 9 since the code for writing crowbarrc has changed considerable between Cloud 8 and Cloud 9. I'll create a separate pull request for Cloud 9 once I've come up with and tested a patch that fits the Cloud 9 code base.