### PR TITLE
provisioner: check for client_user (SOC-11389)

### DIFF
--- a/chef/cookbooks/provisioner/recipes/base.rb
+++ b/chef/cookbooks/provisioner/recipes/base.rb
@@ -357,8 +357,17 @@ package "ruby2.1-rubygem-crowbar-client"
 
 unless is_admin
   # On non-admin nodes, setup /etc/crowbarrc with the restricted client
-  username = crowbar_node["crowbar"]["client_user"]["username"]
-  password = crowbar_node["crowbar"]["client_user"]["password"]
+  # SOC-11389: this check bridges the gap between proposal being saved and
+  # proposal being applied/first chef-client run on admin node having passed.
+  # Until that time, the data won't be available to chef clients running on any
+  # node other than the Crowbar admin node.
+  if crowbar_node["crowbar"]["client_user"].nil?
+    username = "crowbar"
+    password = crowbar_node["crowbar"]["users"][username]["password"]
+  else
+    username = crowbar_node["crowbar"]["client_user"]["username"]
+    password = crowbar_node["crowbar"]["client_user"]["password"]
+  end
 
   template "/etc/crowbarrc" do
     source "crowbarrc.erb"


### PR DESCRIPTION
This commit adds a check for the presence of the client_user
attribute in the Crowbar barclamp's data bag. This attribute
will only become available in chef once chef-client has run on
the Crowbar admin node or the Crowbar data bag has been
applied. Until that has happened, the code using it would
error out on all other nodes.

Note that this pull request is a Cloud 9 specific solution to the same problem and separate from https://github.com/crowbar/crowbar-core/pull/2042 (i.e. https://github.com/crowbar/crowbar-core/pull/2042 is not a backport). Setting the _do not merge yet_ label for now - I still need to test this against a Cloud 9 deployment.