### PR TITLE
ntp: Do not use rate-limiting (bsc#1179161)

### DIFF
--- a/chef/cookbooks/ntp/templates/default/ntp.conf.erb
+++ b/chef/cookbooks/ntp/templates/default/ntp.conf.erb
@@ -43,9 +43,9 @@ restrict -6 default ignore
 restrict <%= @admin_subnet %> mask <%= @admin_netmask %> notrap nomodify nopeer noquery
 
 # Exchange time with external NTP servers, but don't allow configuration
-# and use rate-limiting.
+# Do not use rate-limiting, because that can block crowbar_join. (bsc#1179161)
 <% @ntp_servers.each do |ntp_server| -%>
-restrict <%= ntp_server %> kod limited notrap nomodify nopeer noquery
+restrict <%= ntp_server %> kod notrap nomodify nopeer noquery
 <% end -%>
 
 <% else -%>


### PR DESCRIPTION
because that can block crowbar_join

/usr/sbin/crowbar_join@139(sync_time): /usr/sbin/ntpdate -u 10.162.184.10 10.162
.184.82 10.162.184.83
18 Nov 19:52:20 ntpdate[12664]: 10.162.184.10 rate limit response from server.
18 Nov 19:52:27 ntpdate[12664]: 10.162.184.83 rate limit response from server.
18 Nov 19:52:27 ntpdate[12664]: no server suitable for synchronization found
/usr/sbin/crowbar_join@142(sync_time): tries_left=108
/usr/sbin/crowbar_join@143(sync_time): echo_verbose 'Waiting for NTP server(s)

(cherry picked from commit 27bbc4e216a79b4835bc33879a381f8a51d081cb)
Backport of: https://github.com/crowbar/crowbar-core/pull/2046