### PR TITLE
avoid v4.1.5 of gem delayed_job_active_record

### DIFF
--- a/crowbar_framework/Gemfile
+++ b/crowbar_framework/Gemfile
@@ -38,7 +38,7 @@ gem "syslogger", "~> 1.6.0"
 gem "yaml_db", "~> 0.3.0"
 gem "apipie-rails", "~> 0.3.6"
 gem "pg", "~> 0.17.1"
-gem "delayed_job_active_record", "~> 4.1.1"
+gem "delayed_job_active_record", "~> 4.1.1", "!= 4.1.5"
 gem "daemons", "~> 1.2.3"
 gem "rails-observers", "<= 0.1.2"
 


### PR DESCRIPTION
There was a breaking change in version 4.1.5 of the gem
delayed_job_active_record:
https://github.com/collectiveidea/delayed_job_active_record/issues/185

Resulting failure:
```
$ bin/rake db:create db:migrate
[...]
NameError: undefined method `reserve' for class `Class'
/home/travis/build/crowbar/crowbar-core/crowbar_framework/config/initializers/delayed_job_log_silencer.rb:22:in `alias_method'
[...]
```